### PR TITLE
fix Maven warnings

### DIFF
--- a/net.sf.eclipsecs.checkstyle/pom.xml
+++ b/net.sf.eclipsecs.checkstyle/pom.xml
@@ -47,7 +47,6 @@
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-source-plugin</artifactId>
-                <version>${tycho-version}</version>
                 <configuration>
                     <additionalFileSets>
                         <fileSet>

--- a/net.sf.eclipsecs.core/pom.xml
+++ b/net.sf.eclipsecs.core/pom.xml
@@ -14,7 +14,6 @@
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-source-plugin</artifactId>
-                <version>${tycho-version}</version>
             </plugin>
         </plugins>
     </build>

--- a/net.sf.eclipsecs.ui/pom.xml
+++ b/net.sf.eclipsecs.ui/pom.xml
@@ -14,7 +14,6 @@
             <plugin>
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-source-plugin</artifactId>
-                <version>${tycho-version}</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
                 <plugin>
                     <groupId>org.eclipse.tycho</groupId>
                     <artifactId>tycho-source-plugin</artifactId>
-                    <version>${tycho.version}</version>
+                    <version>${tycho-version}</version>
                     <configuration>
                         <strictSrcIncludes>false</strictSrcIncludes>
                     </configuration>


### PR DESCRIPTION
The tycho-source-plugin version was overridden in the children of the
aggregator instead of inheriting the version. This was necessary because
the parent version definition had a typo (tycho.version instead of
tycho-version). After fixing the typo, the overrides are not necessary
anymore.