### PR TITLE
configure m2e on the new target project

### DIFF
--- a/net.sf.eclipsecs.target/.project
+++ b/net.sf.eclipsecs.target/.project
@@ -5,7 +5,13 @@
 	<projects>
 	</projects>
 	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
 </projectDescription>

--- a/net.sf.eclipsecs.target/.settings/org.eclipse.core.resources.prefs
+++ b/net.sf.eclipsecs.target/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/net.sf.eclipsecs.target/.settings/org.eclipse.m2e.core.prefs
+++ b/net.sf.eclipsecs.target/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1


### PR DESCRIPTION
When I created the target project, I forgot to configure it for the
Maven Eclipse integration m2e (like all the other projects).