### PR TITLE
releng: have AutoDeriv config for docs folder

### DIFF
--- a/net.sf.eclipsecs.doc/.derived
+++ b/net.sf.eclipsecs.doc/.derived
@@ -1,0 +1,3 @@
+# this is a configuration file for http://nodj.github.io/AutoDeriv/
+# set the 'docs' folder as derived
+docs


### PR DESCRIPTION
When using the AutoDeriv plugin, this automatically set the "docs"
folder as derived, thereby excluding it from file search etc.
Unfortunately the "derived" flag is not part of the workspace itself
(therefore it cannot be versioned).

Developers not using the AutoDeriv plugin are not affected at all by
this change.