### PR TITLE
point feature to new update site

### DIFF
--- a/net.sf.eclipsecs-feature/feature.xml
+++ b/net.sf.eclipsecs-feature/feature.xml
@@ -18,7 +18,7 @@
    </license>
 
    <url>
-      <update label="%updateSiteName" url="http://eclipse-cs.sf.net/update"/>
+      <update label="%updateSiteName" url="https://checkstyle.github.io/eclipse-cs/update/"/>
    </url>
 
    <requires>


### PR DESCRIPTION
That way with the next update installation (from SF) all plugins learn
the new update site automatically and check for further updates from
github.