### PR TITLE
advertise additional checks

### DIFF
--- a/net.sf.eclipsecs-updatesite/category.xml
+++ b/net.sf.eclipsecs-updatesite/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <description name="Eclipse Checkstyle Plugin" url="http://eclipse-cs.sourceforge.net/update">
+   <description name="Eclipse Checkstyle Plugin" url="https://checkstyle.github.io/eclipse-cs/update/">
       Eclipse Checkstyle Plugin Update Site
    </description>
    <feature url="features/net.sf.eclipsecs_8.7.0.qualifier.jar" id="net.sf.eclipsecs" version="8.7.0.qualifier">
@@ -18,4 +18,5 @@
             projects that want to enforce a coding standard.
       </description>
    </category-def>
+   <repository-reference location="https://sevntu-checkstyle.github.com/sevntu.checkstyle/update-site/" enabled="false" />
 </site>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/index.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/index.html
@@ -211,7 +211,7 @@
                     installed from the following
                     update site:
                 </p>
-                <code>http://sevntu-checkstyle.github.com/sevntu.checkstyle/update-site/</code>
+                <code>https://sevntu-checkstyle.github.com/sevntu.checkstyle/update-site/</code>
             </div>
         </div>
         <div class="row">


### PR DESCRIPTION
Have a reference to the update site of the additional checks in our
update site. That way it is automatically added to the list of known
update sites in the local P2 update manager. However, it is initially
disabled, and must be enabled manually by the user (so no additional
checks get installed by this change).

Also change the update site URL inside the update site description
(there is actually no field in the form based category editor showing
this property).