### PR TITLE
#32: new checkstyle marker property page

### DIFF
--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/Module.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/Module.java
@@ -30,7 +30,7 @@ import net.sf.eclipsecs.core.config.meta.MetadataFactory;
 import net.sf.eclipsecs.core.config.meta.RuleMetadata;
 
 /**
- * Object representing a module from a checkstyle configuration. Can be augumented with meta data.
+ * Object representing a module from a checkstyle configuration. Can be augmented with meta data.
  * 
  * @author Lars Ködderitzsch
  */

--- a/net.sf.eclipsecs.ui/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.ui/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-Version: 8.7.0.qualifier
 Bundle-Vendor: http://eclipse-cs.sf.net/
 Bundle-Activator: net.sf.eclipsecs.ui.CheckstyleUIPlugin
 Bundle-ActivationPolicy: lazy
-Require-Bundle: net.sf.eclipsecs.core
+Require-Bundle: net.sf.eclipsecs.core,
+ org.eclipse.core.expressions
 Bundle-ClassPath: .,
  lib/jfreechart-1.0.14.jar,
  lib/jfreechart-1.0.14-swt.jar,
@@ -53,6 +54,7 @@ Import-Package: org.eclipse.core.commands,
  org.eclipse.ui.dialogs,
  org.eclipse.ui.ide,
  org.eclipse.ui.internal,
+ org.eclipse.ui.internal.ide,
  org.eclipse.ui.model,
  org.eclipse.ui.part,
  org.eclipse.ui.plugin,

--- a/net.sf.eclipsecs.ui/plugin.xml
+++ b/net.sf.eclipsecs.ui/plugin.xml
@@ -107,6 +107,21 @@
                 name="open"
                 value="true"/>
         </page>
+        <page
+              adaptable="true"
+              class="net.sf.eclipsecs.ui.properties.marker.MarkerPropertyPage"
+              id="net.sf.eclipsecs.properties.MarkerPropertyPage"
+              name="%CheckstylePropertiesPage.name"
+              nameFilter="*"
+              objectClass="org.eclipse.core.resources.IMarker">
+           <enabledWhen>
+              <adapt
+                    type="org.eclipse.core.resources.IMarker">
+                 <test
+                       property="net.sf.eclipsecs.isCheckstyleMarker">
+                 </test>
+              </adapt></enabledWhen>
+        </page>
     </extension>
 
     <!--
@@ -458,5 +473,15 @@
                     tooltip="%PurgeCaches.tooltip" mode="FORCE_TEXT">
                 </action>
           </actionSet>
+    </extension>
+    <extension
+          point="org.eclipse.core.expressions.propertyTesters">
+       <propertyTester
+             class="net.sf.eclipsecs.ui.properties.marker.CheckstyleMarkerPropertyTester"
+             id="net.sf.eclipsecs.MarkerPropertyTester"
+             namespace="net.sf.eclipsecs"
+             properties="isCheckstyleMarker"
+             type="org.eclipse.core.resources.IMarker">
+       </propertyTester>
     </extension>
 </plugin>

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/Messages.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/Messages.java
@@ -487,5 +487,12 @@ public final class Messages extends NLS {
 
   public static String CheckstylePreferenceTransfer_name;
 
+  public static String MarkerPropertyPage_Issue;
+  
+  public static String MarkerPropertyPage_Module;
+
+  public static String MarkerPropertyPage_Group;
+
+  public static String MarkerPropertyPage_Description;
   // CHECKSTYLE:ON
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
@@ -635,13 +635,8 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
         }
       }
 
-      StringBuffer buf = new StringBuffer();
-      buf.append("<html><body style=\"margin: 3px; font-size: 11px; ");
-      buf.append("font-family: verdana, 'trebuchet MS', helvetica, sans-serif;\">");
-      buf.append(description != null ? description
-              : Messages.CheckConfigurationConfigureDialog_txtNoDescription);
-      buf.append("</body></html>");
-      mBrowserDescription.setText(buf.toString());
+      String buf = getDescriptionHtml(description);
+      mBrowserDescription.setText(buf);
     }
 
     /**
@@ -1118,4 +1113,20 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
       return hasAtLeastOneMatchingChild;
     }
   }
+  
+  /**
+   * Convert a module description to HTML for use with a browser component.
+   * @param description module description
+   * @return HTML converted description
+   */
+  public static String getDescriptionHtml(String description) {
+    StringBuffer buf = new StringBuffer();
+    buf.append("<html><body style=\"margin: 3px; font-size: 11px; ");
+    buf.append("font-family: verdana, 'trebuchet MS', helvetica, sans-serif;\">");
+    buf.append(description != null ? description
+            : Messages.CheckConfigurationConfigureDialog_txtNoDescription);
+    buf.append("</body></html>");
+    return buf.toString();
+  }
+  
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/messages.properties
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/messages.properties
@@ -255,7 +255,7 @@ FileSetEditDialog_msgBuildTestResults = Building test results...
 
 FileSetEditDialog_msgNoFilesetName = The name of the file set must be provided
 
-FileSetEditDialog_noCheckConfigSelected = An Check Configuration must be selected
+FileSetEditDialog_noCheckConfigSelected = A Check Configuration must be selected
 
 FileSetEditDialog_titleCreate = Create a new file set.
 FixCheckstyleMarkersJob_title=Fix Checkstyle markers
@@ -316,7 +316,7 @@ ResolvablePropertiesDialog_colName = Name
 
 ResolvablePropertiesDialog_colValue = Value
 
-ResolvablePropertiesDialog_msgAdditionalProperties = Use this dialog to input values for properties occuring in the Checkstyle configuration file, which are not resolved by any of the other ways to resolve such properties.\nSee the plugin documentation for more info about resolving configuration file properties.
+ResolvablePropertiesDialog_msgAdditionalProperties = Use this dialog to input values for properties occurring in the Checkstyle configuration file, which are not resolved by any of the other ways to resolve such properties.\nSee the plugin documentation for more info about resolving configuration file properties.
 
 ResolvablePropertiesDialog_msgFoundProperties = The following unresolved properties were found:\n{0}\nAdd them to the additional configuration properties?
 
@@ -434,5 +434,8 @@ msgErrorFailedExportConfig = Failed to export CheckConfigurations to external fi
 
 CheckstylePreferenceTransfer_name = Checkstyle settings
 
-
+MarkerPropertyPage_Issue=Issue:
+MarkerPropertyPage_Module=Module:
+MarkerPropertyPage_Group=Group:
+MarkerPropertyPage_Description=Description:
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/CheckstylePropertyPage.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/CheckstylePropertyPage.java
@@ -220,7 +220,7 @@ public class CheckstylePropertyPage extends PropertyPage {
       container.setLayout(new FormLayout());
       container.setLayoutData(new GridData(GridData.FILL_BOTH));
 
-      // create the checkbox to enable/diable the simple configuration
+      // create the checkbox to enable/disable the simple configuration
       this.mChkSimpleConfig = new Button(container, SWT.CHECK);
       this.mChkSimpleConfig.setText(Messages.CheckstylePropertyPage_btnUseSimpleConfig);
       this.mChkSimpleConfig.addSelectionListener(this.mPageController);
@@ -232,7 +232,7 @@ public class CheckstylePropertyPage extends PropertyPage {
       fd.right = new FormAttachment(100, -3);
       this.mChkSimpleConfig.setLayoutData(fd);
 
-      // create the checkbox to enabel/disable checkstyle
+      // create the checkbox to enable/disable checkstyle
       this.mChkEnable = new Button(container, SWT.CHECK);
       this.mChkEnable.setText(Messages.CheckstylePropertyPage_btnActivateCheckstyle);
       this.mChkEnable.addSelectionListener(this.mPageController);
@@ -244,7 +244,7 @@ public class CheckstylePropertyPage extends PropertyPage {
       fd.right = new FormAttachment(this.mChkSimpleConfig, 3, SWT.LEFT);
       this.mChkEnable.setLayoutData(fd);
 
-      // create the checkbox for formatter synching
+      // create the checkbox for formatter syncing
       this.mChkSyncFormatter = new Button(container, SWT.CHECK);
       this.mChkSyncFormatter.setText(Messages.CheckstylePropertyPage_btnSyncFormatter);
       this.mChkSyncFormatter.addSelectionListener(this.mPageController);

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/marker/CheckstyleMarkerPropertyTester.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/marker/CheckstyleMarkerPropertyTester.java
@@ -1,0 +1,30 @@
+package net.sf.eclipsecs.ui.properties.marker;
+
+import org.eclipse.core.expressions.PropertyTester;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.runtime.CoreException;
+
+import net.sf.eclipsecs.core.builder.CheckstyleMarker;
+import net.sf.eclipsecs.core.util.CheckstyleLog;
+
+/**
+ * Test whether a given {@link IMarker} shows a Checkstyle issue.
+ */
+public class CheckstyleMarkerPropertyTester extends PropertyTester {
+
+  @Override
+  public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
+    if (!(receiver instanceof IMarker)) {
+      return false;
+    }
+    IMarker marker = (IMarker) receiver;
+    try {
+      return CheckstyleMarker.MARKER_ID.equals(marker.getType());
+    } catch (CoreException e) {
+      CheckstyleLog.log(e);
+    }
+    
+    return false;
+  }
+
+}

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/marker/MarkerPropertyPage.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/marker/MarkerPropertyPage.java
@@ -1,0 +1,121 @@
+package net.sf.eclipsecs.ui.properties.marker;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.browser.Browser;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.ui.dialogs.PropertyPage;
+import org.eclipse.ui.internal.ide.IDEInternalWorkbenchImages;
+
+import net.sf.eclipsecs.core.builder.CheckstyleMarker;
+import net.sf.eclipsecs.core.config.meta.MetadataFactory;
+import net.sf.eclipsecs.core.config.meta.RuleMetadata;
+import net.sf.eclipsecs.core.util.CheckstyleLog;
+import net.sf.eclipsecs.ui.CheckstyleUIPluginImages;
+import net.sf.eclipsecs.ui.Messages;
+import net.sf.eclipsecs.ui.config.CheckConfigurationConfigureDialog;
+
+/**
+ * Property page for checkstyle markers.
+ */
+public class MarkerPropertyPage extends PropertyPage {
+  
+  private IMarker getIssue() {
+    return (IMarker) getElement();
+  }
+
+  @Override
+  protected Control createContents(Composite parent) {
+    noDefaultAndApplyButton();
+    
+    final Composite composite = new Composite(parent, SWT.NULL);
+
+    composite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+    final GridLayout layout = new GridLayout();
+    layout.numColumns = 3;
+    layout.marginHeight = 0;
+    layout.marginWidth = 0;
+    composite.setLayout(layout);
+    
+    try {
+      new Label(composite, SWT.NONE).setImage(
+              getSeverityImage(getIssue().getAttribute(IMarker.SEVERITY, -1)));
+      new Label(composite, SWT.NONE).setText(Messages.MarkerPropertyPage_Issue);
+      String message = (String) getIssue().getAttribute(IMarker.MESSAGE);
+      Label labelMessage = new Label(composite, SWT.NONE);
+      labelMessage.setText(message);
+
+      new Label(composite, SWT.NONE).setImage(
+              CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.MODULEGROUP_ICON));
+      new Label(composite, SWT.NONE).setText(Messages.MarkerPropertyPage_Group);
+
+      String moduleName = (String) getIssue().getAttribute(CheckstyleMarker.MODULE_NAME);
+      RuleMetadata metaData = MetadataFactory.getRuleMetadata(moduleName);
+      new Label(composite, SWT.NONE).setText(metaData.getGroup().getGroupName());
+
+      new Label(composite, SWT.NONE).setImage(
+              CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.MODULE_ICON));
+      new Label(composite, SWT.NONE).setText(Messages.MarkerPropertyPage_Module);
+      new Label(composite, SWT.NONE).setText(metaData.getRuleName());
+
+      Label descriptionLabel = new Label(composite, SWT.NONE);
+      descriptionLabel.setText(Messages.MarkerPropertyPage_Description);
+      GridData gridData = new GridData();
+      gridData.horizontalSpan = 3;
+      gridData.verticalIndent = 20;
+      descriptionLabel.setLayoutData(gridData);
+      
+      gridData = new GridData(GridData.FILL_BOTH);
+      gridData.heightHint = 100;
+      gridData.horizontalSpan = 3;
+      Browser browserDescription = new Browser(composite, SWT.BORDER);
+      browserDescription.setLayoutData(gridData);
+      browserDescription.setText(
+              CheckConfigurationConfigureDialog.getDescriptionHtml(metaData.getDescription()));
+    } catch (CoreException e) {
+      CheckstyleLog.log(e);
+    }
+    return composite;
+  }
+
+  /**
+   * Get the image for the severity if it can be identified.
+   *
+   * @param severity issue severity
+   * @return Image or <code>null</code>
+   */
+  public static Image getSeverityImage(int severity) {
+
+    if (severity == IMarker.SEVERITY_ERROR) {
+      return getIdeImage(IDEInternalWorkbenchImages.IMG_OBJS_ERROR_PATH);
+    }
+    if (severity == IMarker.SEVERITY_WARNING) {
+      return getIdeImage(IDEInternalWorkbenchImages.IMG_OBJS_WARNING_PATH);
+    }
+    if (severity == IMarker.SEVERITY_INFO) {
+      return getIdeImage(IDEInternalWorkbenchImages.IMG_OBJS_INFO_PATH);
+    }
+
+    return null;
+  }
+
+  /**
+   * Get the IDE image at path.
+   *
+   * @param constantName image descriptor name
+   * @return Image
+   */
+  private static Image getIdeImage(String constantName) {
+    return JFaceResources.getResources().createImageWithDefault(
+        IDEInternalWorkbenchImages.getImageDescriptor(constantName));
+  }
+
+
+}


### PR DESCRIPTION
This adds a new property page for checkstyle issues, which show the
check and module of the issue.

This is incomplete, since the retrieved module and key need to be
localized.