### PR TITLE
fix or silence generics warnings

### DIFF
--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
@@ -555,8 +555,9 @@ public final class MetadataFactory {
               property.getPropertyEnumeration().addAll(provider.getOptions());
             } else if (Enum.class.isAssignableFrom(providerClass)) {
 
+              @SuppressWarnings("rawtypes")
               EnumSet<?> values = EnumSet.allOf((Class<Enum>) providerClass);
-              for (Enum e : values) {
+              for (Enum<?> e : values) {
                 property.getPropertyEnumeration().add(e.name().toLowerCase());
               }
             }

--- a/net.sf.eclipsecs.sample/src/net/sf/eclipsecs/sample/checks/MethodLimitQuickfix.java
+++ b/net.sf.eclipsecs.sample/src/net/sf/eclipsecs/sample/checks/MethodLimitQuickfix.java
@@ -20,6 +20,7 @@ public class MethodLimitQuickfix extends AbstractASTResolution {
 
     return new ASTVisitor() {
 
+      @SuppressWarnings("unchecked")
       public boolean visit(MethodDeclaration node) {
 
         Javadoc doc = node.getJavadoc();

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
@@ -675,7 +675,7 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
         boolean openOnAdd = CheckstyleUIPluginPrefs
                 .getBoolean(CheckstyleUIPluginPrefs.PREF_OPEN_MODULE_EDITOR);
 
-        Iterator it = ((IStructuredSelection) selection).iterator();
+        Iterator<?> it = ((IStructuredSelection) selection).iterator();
         while (it.hasNext()) {
           Object selectedElement = it.next();
           if (selectedElement instanceof RuleGroupMetadata) {
@@ -736,6 +736,7 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
                 Messages.CheckConfigurationConfigureDialog_titleRemoveModules,
                 Messages.CheckConfigurationConfigureDialog_msgRemoveModules)) {
 
+          @SuppressWarnings("unchecked")
           Iterator<Module> it = ((IStructuredSelection) selection).iterator();
           while (it.hasNext()) {
             Module m = it.next();
@@ -806,7 +807,7 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
     public Object[] getElements(Object inputElement) {
       Object[] ruleGroups = null;
       if (inputElement instanceof List) {
-        ruleGroups = ((List) inputElement).toArray();
+        ruleGroups = ((List<?>) inputElement).toArray();
       }
       return ruleGroups;
     }
@@ -993,7 +994,7 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
      * {@inheritDoc}
      */
     @Override
-    public Comparable getComparableValue(Object element, int col) {
+    public Comparable<?> getComparableValue(Object element, int col) {
       if (element instanceof Module && col == 0) {
         return Severity.ignore.equals(((Module) element).getSeverity()) ? new Integer(0)
                 : new Integer(1);

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/FixCheckstyleMarkersAction.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/FixCheckstyleMarkersAction.java
@@ -77,6 +77,7 @@ public class FixCheckstyleMarkersAction implements IObjectActionDelegate {
 
     Object element = selection.getFirstElement();
 
+    @SuppressWarnings("cast")
     IFile file = (IFile) ((IAdaptable) element).getAdapter(IFile.class);
     if (file != null) {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/blocks/AvoidNestedBlocksQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/blocks/AvoidNestedBlocksQuickfix.java
@@ -49,6 +49,7 @@ public class AvoidNestedBlocksQuickfix extends AbstractASTResolution {
 
     return new ASTVisitor() {
 
+      @SuppressWarnings("unchecked")
       @Override
       public boolean visit(Block node) {
 
@@ -56,7 +57,7 @@ public class AvoidNestedBlocksQuickfix extends AbstractASTResolution {
 
           if (node.getParent() instanceof Block) {
 
-            List statements = ((Block) node.getParent()).statements();
+            List<?> statements = ((Block) node.getParent()).statements();
             int index = statements.indexOf(node);
 
             statements.remove(node);
@@ -64,7 +65,7 @@ public class AvoidNestedBlocksQuickfix extends AbstractASTResolution {
 
           } else if (node.getParent() instanceof SwitchStatement) {
 
-            List statements = ((SwitchStatement) node.getParent()).statements();
+            List<?> statements = ((SwitchStatement) node.getParent()).statements();
             int index = statements.indexOf(node);
 
             statements.remove(node);

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/blocks/NeedBracesQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/blocks/NeedBracesQuickfix.java
@@ -133,6 +133,7 @@ public class NeedBracesQuickfix extends AbstractASTResolution {
         }
       }
 
+      @SuppressWarnings("unchecked")
       private Block createBracifiedCopy(AST ast, Statement body) {
         Block block = ast.newBlock();
         block.statements().add(ASTNode.copySubtree(block.getAST(), body));

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/DefaultComesLastQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/DefaultComesLastQuickfix.java
@@ -51,6 +51,7 @@ public class DefaultComesLastQuickfix extends AbstractASTResolution {
 
     return new ASTVisitor() {
 
+      @SuppressWarnings("unchecked")
       @Override
       public boolean visit(SwitchCase node) {
 
@@ -59,7 +60,7 @@ public class DefaultComesLastQuickfix extends AbstractASTResolution {
           if (node.isDefault() && !isLastSwitchCase(node)) {
             SwitchStatement switchStatement = (SwitchStatement) node.getParent();
 
-            List defaultCaseStatements = new ArrayList();
+            List<ASTNode> defaultCaseStatements = new ArrayList<>();
             defaultCaseStatements.add(node);
 
             // collect all statements belonging to the default case

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/FinalLocalVariableQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/FinalLocalVariableQuickfix.java
@@ -49,6 +49,7 @@ public class FinalLocalVariableQuickfix extends AbstractASTResolution {
           final int markerStartOffset) {
     return new ASTVisitor() {
 
+      @SuppressWarnings("unchecked")
       @Override
       public boolean visit(SingleVariableDeclaration node) {
         if (containsPosition(node, markerStartOffset) && !Modifier.isFinal(node.getModifiers())) {
@@ -60,6 +61,7 @@ public class FinalLocalVariableQuickfix extends AbstractASTResolution {
         return true;
       }
 
+      @SuppressWarnings("unchecked")
       @Override
       public boolean visit(VariableDeclarationStatement node) {
         if (containsPosition(node, markerStartOffset) && !Modifier.isFinal(node.getModifiers())) {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/MissingSwitchDefaultQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/MissingSwitchDefaultQuickfix.java
@@ -47,6 +47,7 @@ public class MissingSwitchDefaultQuickfix extends AbstractASTResolution {
 
     return new ASTVisitor() {
 
+      @SuppressWarnings("unchecked")
       @Override
       public boolean visit(SwitchStatement node) {
         if (containsPosition(lineInfo, node.getStartPosition())) {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityQuickfix.java
@@ -56,6 +56,7 @@ public class StringLiteralEqualityQuickfix extends AbstractASTResolution {
 
     return new ASTVisitor() {
 
+      @SuppressWarnings("unchecked")
       @Override
       public boolean visit(InfixExpression node) {
 
@@ -117,7 +118,7 @@ public class StringLiteralEqualityQuickfix extends AbstractASTResolution {
                     + property.substring(1);
             String setterMethodName = "set" + capitalizedProperty;
 
-            Class testClass = node.getClass();
+            Class<?> testClass = node.getClass();
 
             while (testClass != null) {
 
@@ -134,7 +135,8 @@ public class StringLiteralEqualityQuickfix extends AbstractASTResolution {
           } else if (node.getLocationInParent().isChildListProperty()) {
             Method listMethod = node.getParent().getClass()
                     .getMethod(node.getLocationInParent().getId(), (Class<?>[]) null);
-            List list = (List) listMethod.invoke(node.getParent(), (Object[]) null);
+            @SuppressWarnings("unchecked")
+            List<ASTNode> list = (List<ASTNode>) listMethod.invoke(node.getParent(), (Object[]) null);
             list.set(list.indexOf(node), replacementNode);
           }
         } catch (InvocationTargetException e) {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/design/DesignForExtensionQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/design/DesignForExtensionQuickfix.java
@@ -27,6 +27,7 @@ import net.sf.eclipsecs.ui.quickfixes.AbstractASTResolution;
 import net.sf.eclipsecs.ui.quickfixes.Messages;
 import net.sf.eclipsecs.ui.quickfixes.modifier.ModifierOrderQuickfix;
 
+import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.Modifier;
@@ -53,6 +54,7 @@ public class DesignForExtensionQuickfix extends AbstractASTResolution {
           final int markerStartOffset) {
     return new ASTVisitor() {
 
+      @SuppressWarnings("unchecked")
       @Override
       public boolean visit(MethodDeclaration node) {
         // recalculate start position because optional javadoc is mixed
@@ -68,7 +70,7 @@ public class DesignForExtensionQuickfix extends AbstractASTResolution {
             node.modifiers().add(finalModifier);
 
             // reorder modifiers into their correct order
-            List reorderedModifiers = ModifierOrderQuickfix.reOrderModifiers(node.modifiers());
+            List<ASTNode> reorderedModifiers = ModifierOrderQuickfix.reOrderModifiers(node.modifiers());
             node.modifiers().clear();
             node.modifiers().addAll(reorderedModifiers);
           }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/design/FinalClassQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/design/FinalClassQuickfix.java
@@ -53,6 +53,7 @@ public class FinalClassQuickfix extends AbstractASTResolution {
           final int markerStartOffset) {
     return new ASTVisitor() {
 
+      @SuppressWarnings("unchecked")
       @Override
       public boolean visit(TypeDeclaration node) {
         // recalculate start position because optional javadoc is mixed
@@ -68,7 +69,7 @@ public class FinalClassQuickfix extends AbstractASTResolution {
             node.modifiers().add(finalModifier);
 
             // reorder modifiers into their correct order
-            List reorderedModifiers = ModifierOrderQuickfix.reOrderModifiers(node.modifiers());
+            List<?> reorderedModifiers = ModifierOrderQuickfix.reOrderModifiers(node.modifiers());
             node.modifiers().clear();
             node.modifiers().addAll(reorderedModifiers);
           }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/ArrayTypeStyleQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/ArrayTypeStyleQuickfix.java
@@ -64,7 +64,7 @@ public class ArrayTypeStyleQuickfix extends AbstractASTResolution {
 
             int dimensions = 0;
 
-            List fragments = node.fragments();
+            List<?> fragments = node.fragments();
             for (int i = 0, size = fragments.size(); i < size; i++) {
               VariableDeclaration decl = (VariableDeclaration) fragments.get(i);
               if (decl.getExtraDimensions() > dimensions) {
@@ -82,7 +82,7 @@ public class ArrayTypeStyleQuickfix extends AbstractASTResolution {
 
             int dimensions = ((ArrayType) node.getType()).getDimensions();
 
-            List fragments = node.fragments();
+            List<?> fragments = node.fragments();
             for (int i = 0, size = fragments.size(); i < size; i++) {
               VariableDeclaration decl = (VariableDeclaration) fragments.get(i);
               decl.setExtraDimensions(dimensions);
@@ -127,7 +127,7 @@ public class ArrayTypeStyleQuickfix extends AbstractASTResolution {
 
             int dimensions = 0;
 
-            List fragments = node.fragments();
+            List<?> fragments = node.fragments();
             for (int i = 0, size = fragments.size(); i < size; i++) {
               VariableDeclaration decl = (VariableDeclaration) fragments.get(i);
               if (decl.getExtraDimensions() > dimensions) {
@@ -144,7 +144,7 @@ public class ArrayTypeStyleQuickfix extends AbstractASTResolution {
 
             int dimensions = ((ArrayType) node.getType()).getDimensions();
 
-            List fragments = node.fragments();
+            List<?> fragments = node.fragments();
             for (int i = 0, size = fragments.size(); i < size; i++) {
               VariableDeclaration decl = (VariableDeclaration) fragments.get(i);
               decl.setExtraDimensions(dimensions);
@@ -166,9 +166,9 @@ public class ArrayTypeStyleQuickfix extends AbstractASTResolution {
         return decl.getExtraDimensions() > 0;
       }
 
-      private boolean isCStyle(List fragments) {
+      private boolean isCStyle(List<?> fragments) {
 
-        Iterator it = fragments.iterator();
+        Iterator<?> it = fragments.iterator();
         while (it.hasNext()) {
           VariableDeclaration decl = (VariableDeclaration) it.next();
           if (isCStyle(decl)) {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/FinalParametersQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/FinalParametersQuickfix.java
@@ -48,6 +48,7 @@ public class FinalParametersQuickfix extends AbstractASTResolution {
           final int markerStartOffset) {
     return new ASTVisitor() {
 
+      @SuppressWarnings("unchecked")
       @Override
       public boolean visit(SingleVariableDeclaration node) {
         if (containsPosition(node, markerStartOffset) && !Modifier.isFinal(node.getModifiers())) {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/modifier/ModifierOrderQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/modifier/ModifierOrderQuickfix.java
@@ -55,7 +55,7 @@ public class ModifierOrderQuickfix extends AbstractASTResolution {
    * List containing modifier keywords in the order proposed by Java Language specification,
    * sections 8.1.1, 8.3.1 and 8.4.3.
    */
-  private static final List MODIFIER_ORDER = Arrays
+  private static final List<Object> MODIFIER_ORDER = Arrays
           .asList(new Object[] { ModifierKeyword.PUBLIC_KEYWORD, ModifierKeyword.PROTECTED_KEYWORD,
               ModifierKeyword.PRIVATE_KEYWORD, ModifierKeyword.ABSTRACT_KEYWORD,
               ModifierKeyword.STATIC_KEYWORD, ModifierKeyword.FINAL_KEYWORD,
@@ -133,8 +133,8 @@ public class ModifierOrderQuickfix extends AbstractASTResolution {
         return visitBodyDecl(node);
       }
 
+      @SuppressWarnings("unchecked")
       private boolean visitBodyDecl(BodyDeclaration node) {
-        @SuppressWarnings("unchecked")
         List<Modifier> modifiers = (List<Modifier>) node.modifiers().stream()
                 .filter(Modifier.class::isInstance).map(Modifier.class::cast)
                 .collect(Collectors.toList());
@@ -146,7 +146,7 @@ public class ModifierOrderQuickfix extends AbstractASTResolution {
         int maxPos = modifiers.stream().mapToInt(Modifier::getStartPosition).max().getAsInt();
         
         if (minPos <= markerStartOffset && markerStartOffset <= maxPos) {
-          List<ASTNode> reorderedModifiers = reOrderModifiers(node.modifiers());
+          List<?> reorderedModifiers = reOrderModifiers(node.modifiers());
           node.modifiers().clear();
           node.modifiers().addAll(reorderedModifiers);
         }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/modifier/RedundantModifierQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/modifier/RedundantModifierQuickfix.java
@@ -60,6 +60,7 @@ public class RedundantModifierQuickfix extends AbstractASTResolution {
 
     return new ASTVisitor() {
 
+      @SuppressWarnings("unchecked")
       @Override
       public boolean visit(MethodDeclaration node) {
 
@@ -83,6 +84,7 @@ public class RedundantModifierQuickfix extends AbstractASTResolution {
         return true;
       }
 
+      @SuppressWarnings("unchecked")
       @Override
       public boolean visit(FieldDeclaration node) {
         // recalculate start position because optional javadoc is mixed
@@ -112,6 +114,7 @@ public class RedundantModifierQuickfix extends AbstractASTResolution {
         return true;
       }
 
+      @SuppressWarnings("unchecked")
       @Override
       public boolean visit(AnnotationTypeMemberDeclaration node) {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/data/MarkerStat.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/data/MarkerStat.java
@@ -31,7 +31,7 @@ import org.eclipse.ui.texteditor.MarkerUtilities;
  * 
  * @author Fabrice BELLINGARD
  */
-public class MarkerStat implements Comparable {
+public class MarkerStat implements Comparable<MarkerStat> {
 
   /**
    * Identifiant du marqueur : dans notre cas, il s'agit du message du marqueur
@@ -42,7 +42,7 @@ public class MarkerStat implements Comparable {
   /**
    * List of the markers of this categories.
    */
-  private Collection mMarkers;
+  private Collection<IMarker> mMarkers;
 
   /**
    * The maximum severity for this marker group.
@@ -59,7 +59,7 @@ public class MarkerStat implements Comparable {
   public MarkerStat(String identifiant) {
     super();
     this.mIdentifiant = identifiant;
-    mMarkers = new ArrayList();
+    mMarkers = new ArrayList<>();
   }
 
   /**
@@ -83,12 +83,8 @@ public class MarkerStat implements Comparable {
    * @see java.lang.Comparable#compareTo(java.lang.Object)
    */
   @Override
-  public int compareTo(Object o) {
-    if (o instanceof MarkerStat) {
-      MarkerStat stat = (MarkerStat) o;
-      return mIdentifiant.compareTo(stat.getIdentifiant());
-    }
-    return 0;
+  public int compareTo(MarkerStat stat) {
+    return mIdentifiant.compareTo(stat.getIdentifiant());
   }
 
   /**
@@ -96,7 +92,7 @@ public class MarkerStat implements Comparable {
    * 
    * @return a collection of IMarker
    */
-  public Collection getMarkers() {
+  public Collection<IMarker> getMarkers() {
     return mMarkers;
   }
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/data/Stats.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/data/Stats.java
@@ -31,7 +31,7 @@ import java.util.Collection;
 public class Stats {
 
   /** Liste des différentes erreurs. */
-  private Collection mMarkerStats;
+  private Collection<MarkerStat> mMarkerStats;
 
   /**
    * Nombre de marqueurs scannés.
@@ -51,7 +51,7 @@ public class Stats {
    * @param markerCountWhole
    *          the number of all checkstyle markers in the workspace
    */
-  public Stats(Collection markerStats, int markerCount, int markerCountWhole) {
+  public Stats(Collection<MarkerStat> markerStats, int markerCount, int markerCountWhole) {
     super();
     this.mMarkerStats = markerStats;
     this.mMarkerCount = markerCount;
@@ -63,7 +63,7 @@ public class Stats {
    * 
    * @return Returns the markerStats.
    */
-  public Collection getMarkerStats() {
+  public Collection<MarkerStat> getMarkerStats() {
     return mMarkerStats;
   }
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/AbstractStatsView.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/AbstractStatsView.java
@@ -36,6 +36,7 @@ import net.sf.eclipsecs.ui.stats.views.internal.CheckstyleMarkerFilterDialog;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarkerDelta;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
@@ -219,6 +220,7 @@ public abstract class AbstractStatsView extends ViewPart {
    */
   protected final void refresh() {
 
+    @SuppressWarnings("cast")
     final IWorkbenchSiteProgressService service = (IWorkbenchSiteProgressService) getSite()
             .getAdapter(IWorkbenchSiteProgressService.class);
 
@@ -296,7 +298,7 @@ public abstract class AbstractStatsView extends ViewPart {
    */
   private void focusSelectionChanged(IWorkbenchPart part, ISelection selection) {
 
-    List resources = new ArrayList();
+    List<IResource> resources = new ArrayList<IResource>();
     if (part instanceof IEditorPart) {
       IEditorPart editor = (IEditorPart) part;
       IFile file = getFile(editor.getEditorInput());
@@ -305,7 +307,7 @@ public abstract class AbstractStatsView extends ViewPart {
       }
     } else {
       if (selection instanceof IStructuredSelection) {
-        for (Iterator iterator = ((IStructuredSelection) selection).iterator(); iterator
+        for (Iterator<?> iterator = ((IStructuredSelection) selection).iterator(); iterator
                 .hasNext();) {
           Object object = iterator.next();
           if (object instanceof IWorkingSet) {
@@ -334,7 +336,8 @@ public abstract class AbstractStatsView extends ViewPart {
     }
   }
 
-  private void considerAdaptable(IAdaptable adaptable, Collection resources) {
+  @SuppressWarnings("cast")
+  private void considerAdaptable(IAdaptable adaptable, Collection<IResource> resources) {
 
     IResource resource = (IResource) adaptable.getAdapter(IResource.class);
 
@@ -403,8 +406,8 @@ public abstract class AbstractStatsView extends ViewPart {
       return false;
     }
     if (onResource == CheckstyleMarkerFilter.ON_ANY_RESOURCE_OF_SAME_PROJECT) {
-      Collection oldProjects = CheckstyleMarkerFilter.getProjectsAsCollection(oldResources);
-      Collection newProjects = CheckstyleMarkerFilter.getProjectsAsCollection(newResources);
+      Collection<IProject> oldProjects = CheckstyleMarkerFilter.getProjectsAsCollection(oldResources);
+      Collection<IProject> newProjects = CheckstyleMarkerFilter.getProjectsAsCollection(newResources);
 
       if (oldProjects.size() == newProjects.size()) {
         return !newProjects.containsAll(oldProjects);

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/GraphPieDataset.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/GraphPieDataset.java
@@ -72,8 +72,8 @@ public class GraphPieDataset extends AbstractDataset implements PieDataset {
    */
   public void setStats(Stats stats) {
 
-    Collection markerStatCollection = stats != null ? stats.getMarkerStats()
-            : Collections.EMPTY_LIST;
+    Collection<MarkerStat> markerStatCollection = stats != null ? stats.getMarkerStats()
+            : Collections.emptyList();
     mData = new DefaultKeyedValues();
 
     // markers que l'on comptera dans une catégorie "Autres" car ils
@@ -81,8 +81,8 @@ public class GraphPieDataset extends AbstractDataset implements PieDataset {
     int leftCount = 0;
     float mCount = new Float(stats.getMarkerCount()).floatValue();
     // et on remplit
-    for (Iterator iter = markerStatCollection.iterator(); iter.hasNext();) {
-      MarkerStat markerStat = (MarkerStat) iter.next();
+    for (Iterator<MarkerStat> iter = markerStatCollection.iterator(); iter.hasNext();) {
+      MarkerStat markerStat = iter.next();
 
       // on calcule le %
       float percentage = CENT * markerStat.getCount() / mCount;
@@ -150,8 +150,9 @@ public class GraphPieDataset extends AbstractDataset implements PieDataset {
    *
    * @return the categories in the dataset.
    */
+  @SuppressWarnings("unchecked")
   @Override
-  public List getKeys() {
+  public List<?> getKeys() {
     return Collections.unmodifiableList(this.mData.getKeys());
   }
 
@@ -164,9 +165,9 @@ public class GraphPieDataset extends AbstractDataset implements PieDataset {
    * @return the category.
    */
   @Override
-  public Comparable getKey(final int item) {
+  public Comparable<?> getKey(final int item) {
 
-    Comparable result = null;
+    Comparable<?> result = null;
     if (getItemCount() > item) {
       result = this.mData.getKey(item);
     }
@@ -182,6 +183,7 @@ public class GraphPieDataset extends AbstractDataset implements PieDataset {
    *
    * @return the key index.
    */
+  @SuppressWarnings("rawtypes")
   @Override
   public int getIndex(final Comparable key) {
 
@@ -216,6 +218,7 @@ public class GraphPieDataset extends AbstractDataset implements PieDataset {
    *
    * @return the value (possibly <code>null</code>).
    */
+  @SuppressWarnings("rawtypes")
   @Override
   public Number getValue(final Comparable key) {
 
@@ -237,7 +240,7 @@ public class GraphPieDataset extends AbstractDataset implements PieDataset {
    * @param value
    *          the value.
    */
-  public void setValue(final Comparable key, final Number value) {
+  public void setValue(final Comparable<?> key, final Number value) {
 
     this.mData.setValue(key, value);
     fireDatasetChanged();
@@ -252,7 +255,7 @@ public class GraphPieDataset extends AbstractDataset implements PieDataset {
    * @param value
    *          the value.
    */
-  public void setValue(final Comparable key, final double value) {
+  public void setValue(final Comparable<?> key, final double value) {
     setValue(key, new Double(value));
   }
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/GraphStatsView.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/GraphStatsView.java
@@ -322,7 +322,7 @@ public class GraphStatsView extends AbstractStatsView {
     hookDoubleClickAction(mShowErrorAction, detailViewer);
 
     // and to the context menu too
-    ArrayList actionList = new ArrayList(1);
+    ArrayList<Object> actionList = new ArrayList<>(3);
     actionList.add(mDrillBackAction);
     actionList.add(mShowErrorAction);
     actionList.add(new Separator());
@@ -484,13 +484,13 @@ public class GraphStatsView extends AbstractStatsView {
    * @param actions
    *          a collection of IAction objets
    */
-  private void hookContextMenu(final Collection actions, StructuredViewer viewer) {
+  private void hookContextMenu(final Collection<Object> actions, StructuredViewer viewer) {
     MenuManager menuMgr = new MenuManager();
     menuMgr.setRemoveAllWhenShown(true);
     menuMgr.addMenuListener(new IMenuListener() {
       @Override
       public void menuAboutToShow(IMenuManager manager) {
-        for (Iterator iter = actions.iterator(); iter.hasNext();) {
+        for (Iterator<Object> iter = actions.iterator(); iter.hasNext();) {
           Object item = iter.next();
           if (item instanceof IContributionItem) {
             manager.add((IContributionItem) item);
@@ -612,10 +612,10 @@ public class GraphStatsView extends AbstractStatsView {
       if (mCurrentDetails == null) {
         // find the marker statistics for the current category
         Stats currentStats = (Stats) inputElement;
-        Collection markerStats = currentStats.getMarkerStats();
-        Iterator it = markerStats.iterator();
+        Collection<MarkerStat> markerStats = currentStats.getMarkerStats();
+        Iterator<MarkerStat> it = markerStats.iterator();
         while (it.hasNext()) {
-          MarkerStat markerStat = (MarkerStat) it.next();
+          MarkerStat markerStat = it.next();
           if (markerStat.getIdentifiant().equals(mCurrentDetailCategory)) {
             mCurrentDetails = markerStat.getMarkers().toArray();
             break;
@@ -714,9 +714,9 @@ public class GraphStatsView extends AbstractStatsView {
     }
 
     @Override
-    public Comparable getComparableValue(Object element, int colIndex) {
+    public Comparable<?> getComparableValue(Object element, int colIndex) {
       IMarker marker = (IMarker) element;
-      Comparable comparable = null;
+      Comparable<?> comparable = null;
 
       switch (colIndex) {
         case 0:

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/MarkerStatsView.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/MarkerStatsView.java
@@ -236,7 +236,7 @@ public class MarkerStatsView extends AbstractStatsView {
     hookDoubleClickAction(mDrillDownAction, masterViewer);
 
     // and to the context menu too
-    ArrayList actionList = new ArrayList(1);
+    ArrayList<Object> actionList = new ArrayList<>(3);
     actionList.add(mDrillDownAction);
     actionList.add(new Separator());
     actionList.add(mChartAction);
@@ -304,7 +304,7 @@ public class MarkerStatsView extends AbstractStatsView {
     hookDoubleClickAction(mShowErrorAction, detailViewer);
 
     // and to the context menu too
-    ArrayList actionList = new ArrayList(1);
+    ArrayList<Object> actionList = new ArrayList<>(1);
     actionList.add(mDrillBackAction);
     actionList.add(mShowErrorAction);
     actionList.add(new Separator());
@@ -496,13 +496,13 @@ public class MarkerStatsView extends AbstractStatsView {
    * @param actions
    *          a collection of IAction objets
    */
-  private void hookContextMenu(final Collection actions, StructuredViewer viewer) {
+  private void hookContextMenu(final Collection<Object> actions, StructuredViewer viewer) {
     MenuManager menuMgr = new MenuManager();
     menuMgr.setRemoveAllWhenShown(true);
     menuMgr.addMenuListener(new IMenuListener() {
       @Override
       public void menuAboutToShow(IMenuManager manager) {
-        for (Iterator iter = actions.iterator(); iter.hasNext();) {
+        for (Iterator<Object> iter = actions.iterator(); iter.hasNext();) {
           Object item = iter.next();
           if (item instanceof IContributionItem) {
             manager.add((IContributionItem) item);
@@ -577,10 +577,10 @@ public class MarkerStatsView extends AbstractStatsView {
       if (mCurrentDetails == null) {
         // find the marker statistics for the current category
         Stats currentStats = (Stats) inputElement;
-        Collection markerStats = currentStats.getMarkerStats();
-        Iterator it = markerStats.iterator();
+        Collection<MarkerStat> markerStats = currentStats.getMarkerStats();
+        Iterator<MarkerStat> it = markerStats.iterator();
         while (it.hasNext()) {
-          MarkerStat markerStat = (MarkerStat) it.next();
+          MarkerStat markerStat = it.next();
           if (markerStat.getIdentifiant().equals(mCurrentDetailCategory)) {
             mCurrentDetails = markerStat.getMarkers().toArray();
             break;
@@ -653,9 +653,9 @@ public class MarkerStatsView extends AbstractStatsView {
     }
 
     @Override
-    public Comparable getComparableValue(Object element, int colIndex) {
+    public Comparable<?> getComparableValue(Object element, int colIndex) {
       MarkerStat stat = (MarkerStat) element;
-      Comparable comparable = null;
+      Comparable<?> comparable = null;
 
       switch (colIndex) {
         case 0:
@@ -752,9 +752,9 @@ public class MarkerStatsView extends AbstractStatsView {
     }
 
     @Override
-    public Comparable getComparableValue(Object element, int colIndex) {
+    public Comparable<?> getComparableValue(Object element, int colIndex) {
       IMarker marker = (IMarker) element;
-      Comparable comparable = null;
+      Comparable<?> comparable = null;
 
       switch (colIndex) {
         case 0:

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilter.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilter.java
@@ -117,7 +117,7 @@ public class CheckstyleMarkerFilter implements Cloneable {
   private boolean mFilterByRegex;
 
   /** List of regular expressions used to filter messages. */
-  private List mFilterRegex;
+  private List<String> mFilterRegex;
 
   //
   // methods
@@ -134,7 +134,7 @@ public class CheckstyleMarkerFilter implements Cloneable {
    */
   public IMarker[] findMarkers(IProgressMonitor mon) throws CoreException {
 
-    List unfiltered = Collections.EMPTY_LIST;
+    List<IMarker> unfiltered = Collections.emptyList();
 
     if (!isEnabled()) {
       unfiltered = findCheckstyleMarkers(
@@ -174,10 +174,10 @@ public class CheckstyleMarkerFilter implements Cloneable {
     }
 
     if (unfiltered == null) {
-      unfiltered = Collections.EMPTY_LIST;
+      unfiltered = Collections.emptyList();
     }
 
-    return (IMarker[]) unfiltered.toArray(new IMarker[unfiltered.size()]);
+    return unfiltered.toArray(new IMarker[unfiltered.size()]);
   }
 
   /**
@@ -220,7 +220,7 @@ public class CheckstyleMarkerFilter implements Cloneable {
   /**
    * Returns the selected resource.
    *
-   * @return the selected resource(s) withing the workbench.
+   * @return the selected resource(s) within the workbench.
    */
   public IResource[] getFocusResource() {
     return mFocusResources;
@@ -230,7 +230,7 @@ public class CheckstyleMarkerFilter implements Cloneable {
    * Sets the focused resources.
    *
    * @param resources
-   *          the focuse resources
+   *          the focused resources
    */
   public void setFocusResource(IResource[] resources) {
     mFocusResources = resources;
@@ -338,7 +338,7 @@ public class CheckstyleMarkerFilter implements Cloneable {
    *
    * @return the regular expressions
    */
-  public List getFilterRegex() {
+  public List<String> getFilterRegex() {
     return mFilterRegex;
   }
 
@@ -348,12 +348,12 @@ public class CheckstyleMarkerFilter implements Cloneable {
    * @param filterRegex
    *          the list of regular expression to filter by
    */
-  public void setFilterRegex(List filterRegex) {
+  public void setFilterRegex(List<String> filterRegex) {
     mFilterRegex = filterRegex;
   }
 
   /**
-   * Restors the state of the filter from the given dialog settings.
+   * Restores the state of the filter from the given dialog settings.
    *
    * @param dialogSettings
    *          the dialog settings
@@ -438,7 +438,7 @@ public class CheckstyleMarkerFilter implements Cloneable {
 
       if (mFilterRegex != null) {
         settings.put(TAG_REGULAR_EXPRESSIONS,
-                (String[]) mFilterRegex.toArray(new String[mFilterRegex.size()]));
+                mFilterRegex.toArray(new String[mFilterRegex.size()]));
       }
     }
   }
@@ -453,7 +453,7 @@ public class CheckstyleMarkerFilter implements Cloneable {
     mSelectBySeverity = DEFAULT_SELECT_BY_SEVERITY;
     mSeverity = DEFAULT_SEVERITY;
     mFilterByRegex = false;
-    mFilterRegex = new ArrayList();
+    mFilterRegex = new ArrayList<>();
   }
 
   /**
@@ -467,17 +467,17 @@ public class CheckstyleMarkerFilter implements Cloneable {
    *          the progress monitor
    * @throws CoreException
    */
-  private List findCheckstyleMarkers(IResource[] resources, int depth, IProgressMonitor mon)
+  private List<IMarker> findCheckstyleMarkers(IResource[] resources, int depth, IProgressMonitor mon)
           throws CoreException {
     if (resources == null) {
-      return Collections.EMPTY_LIST;
+      return Collections.emptyList();
     }
 
-    List resultList = new ArrayList(resources.length * 2);
+    List<IMarker> resultList = new ArrayList<IMarker>(resources.length * 2);
 
     for (int i = 0, size = resources.length; i < size; i++) {
       if (resources[i].isAccessible()) {
-        Collection markers = Arrays
+        Collection<IMarker> markers = Arrays
                 .asList(resources[i].findMarkers(CheckstyleMarker.MARKER_ID, true, depth));
 
         resultList.addAll(markers);
@@ -488,7 +488,7 @@ public class CheckstyleMarkerFilter implements Cloneable {
       // further filter the markers by severity
       int size = resultList.size();
       for (int i = size - 1; i >= 0; i--) {
-        IMarker marker = (IMarker) resultList.get(i);
+        IMarker marker = resultList.get(i);
         if (!selectBySeverity(marker)) {
           resultList.remove(i);
         }
@@ -499,7 +499,7 @@ public class CheckstyleMarkerFilter implements Cloneable {
       // further filter the markers by regular expressions
       int size = resultList.size();
       for (int i = size - 1; i >= 0; i--) {
-        IMarker marker = (IMarker) resultList.get(i);
+        IMarker marker = resultList.get(i);
         if (!selectByRegex(marker)) {
           resultList.remove(i);
         }
@@ -545,7 +545,7 @@ public class CheckstyleMarkerFilter implements Cloneable {
       int size = mFilterRegex != null ? mFilterRegex.size() : 0;
       for (int i = 0; i < size; i++) {
 
-        String regex = (String) mFilterRegex.get(i);
+        String regex = mFilterRegex.get(i);
 
         String message = item.getAttribute(IMarker.MESSAGE, null);
 
@@ -566,8 +566,8 @@ public class CheckstyleMarkerFilter implements Cloneable {
    * @return the array of projects for the given resources
    */
   private static IProject[] getProjects(IResource[] resources) {
-    Collection projects = getProjectsAsCollection(resources);
-    return (IProject[]) projects.toArray(new IProject[projects.size()]);
+    Collection<IProject> projects = getProjectsAsCollection(resources);
+    return projects.toArray(new IProject[projects.size()]);
   }
 
   /**
@@ -577,8 +577,8 @@ public class CheckstyleMarkerFilter implements Cloneable {
    *          the resources
    * @return the collection of projects for the given resources
    */
-  public static Collection getProjectsAsCollection(IResource[] resources) {
-    HashSet projects = new HashSet();
+  public static Collection<IProject> getProjectsAsCollection(IResource[] resources) {
+    HashSet<IProject> projects = new HashSet<IProject>();
 
     for (int idx = 0, size = resources != null ? resources.length : 0; idx < size; idx++) {
       projects.add(resources[idx].getProject());
@@ -599,9 +599,10 @@ public class CheckstyleMarkerFilter implements Cloneable {
     }
 
     IAdaptable[] elements = workingSet.getElements();
-    List result = new ArrayList(elements.length);
+    List<IResource> result = new ArrayList<IResource>(elements.length);
 
     for (int idx = 0; idx < elements.length; idx++) {
+      @SuppressWarnings("cast")
       IResource next = (IResource) elements[idx].getAdapter(IResource.class);
 
       if (next != null) {
@@ -609,7 +610,7 @@ public class CheckstyleMarkerFilter implements Cloneable {
       }
     }
 
-    return (IResource[]) result.toArray(new IResource[result.size()]);
+    return result.toArray(new IResource[result.size()]);
   }
 
   /**

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilterDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilterDialog.java
@@ -120,7 +120,7 @@ public class CheckstyleMarkerFilterDialog extends TitleAreaDialog {
   private PageController mController = new PageController();
 
   /** The regular expressions to filter by. */
-  private List mRegularExpressions;
+  private List<String> mRegularExpressions;
 
   //
   // constructors
@@ -446,7 +446,7 @@ public class CheckstyleMarkerFilterDialog extends TitleAreaDialog {
           initWorkingSetLabel();
         }
       } else if (mBtnEditRegex == e.widget) {
-        List regex = new ArrayList(mRegularExpressions);
+        List<String> regex = new ArrayList<>(mRegularExpressions);
         RegexDialog dialog = new RegexDialog(getShell(), regex);
         if (Window.OK == dialog.open()) {
           mRegularExpressions = regex;
@@ -505,7 +505,7 @@ public class CheckstyleMarkerFilterDialog extends TitleAreaDialog {
 
     private Text mRegexText;
 
-    private List mFileTypesList;
+    private List<String> mFileTypesList;
 
     /**
      * Creates a file matching pattern editor dialog.
@@ -515,7 +515,7 @@ public class CheckstyleMarkerFilterDialog extends TitleAreaDialog {
      * @param pattern
      *          the pattern
      */
-    public RegexDialog(Shell parentShell, List fileTypes) {
+    public RegexDialog(Shell parentShell, List<String> fileTypes) {
       super(parentShell);
       mFileTypesList = fileTypes;
     }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/regex/RegExContentAssistProcessor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/regex/RegExContentAssistProcessor.java
@@ -50,12 +50,12 @@ public final class RegExContentAssistProcessor
     /**
      * The high-priority proposals.
      */
-    private final ArrayList fPriorityProposals;
+    private final ArrayList<CompletionProposal> fPriorityProposals;
 
     /**
      * The low-priority proposals.
      */
-    private final ArrayList fProposals;
+    private final ArrayList<CompletionProposal> fProposals;
 
     /**
      * <code>true</code> iff <code>fExpression</code> ends with an open escape.
@@ -74,8 +74,8 @@ public final class RegExContentAssistProcessor
             int documentOffset) {
       fExpression = contentAssistSubjectControl.getDocument().get();
       fDocumentOffset = documentOffset;
-      fPriorityProposals = new ArrayList();
-      fProposals = new ArrayList();
+      fPriorityProposals = new ArrayList<>();
+      fProposals = new ArrayList<>();
 
       boolean isEscape = false;
       esc: for (int i = documentOffset - 1; i >= 0; i--) {
@@ -296,7 +296,7 @@ public final class RegExContentAssistProcessor
       }
 
       fPriorityProposals.addAll(fProposals);
-      return (ICompletionProposal[]) fPriorityProposals
+      return fPriorityProposals
               .toArray(new ICompletionProposal[fProposals.size()]);
     }
 
@@ -316,7 +316,7 @@ public final class RegExContentAssistProcessor
         addProposal("\n", RegExMessages.displayString_nl, RegExMessages.additionalInfo_nl); //$NON-NLS-1$
         addProposal("\r", RegExMessages.displayString_cr, RegExMessages.additionalInfo_cr); //$NON-NLS-1$
       }
-      return (ICompletionProposal[]) fProposals.toArray(new ICompletionProposal[fProposals.size()]);
+      return fProposals.toArray(new ICompletionProposal[fProposals.size()]);
     }
 
     /**

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/table/EnhancedCheckBoxTableViewer.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/table/EnhancedCheckBoxTableViewer.java
@@ -47,6 +47,7 @@ public class EnhancedCheckBoxTableViewer extends EnhancedTableViewer implements 
   /**
    * List of check state listeners (element type: <code>ICheckStateListener</code>).
    */
+  @SuppressWarnings("rawtypes")
   private final ListenerList checkStateListeners = new ListenerList();
 
   /**
@@ -141,6 +142,7 @@ public class EnhancedCheckBoxTableViewer extends EnhancedTableViewer implements 
   /*
    * (non-Javadoc) Method declared on ICheckable.
    */
+  @SuppressWarnings("unchecked")
   @Override
   public void addCheckStateListener(ICheckStateListener listener) {
     checkStateListeners.add(listener);
@@ -216,7 +218,7 @@ public class EnhancedCheckBoxTableViewer extends EnhancedTableViewer implements 
    */
   public Object[] getCheckedElements() {
     TableItem[] children = getTable().getItems();
-    ArrayList v = new ArrayList(children.length);
+    ArrayList<Object> v = new ArrayList<>(children.length);
     for (int i = 0; i < children.length; i++) {
       TableItem item = children[i];
       if (item.getChecked()) {
@@ -253,7 +255,7 @@ public class EnhancedCheckBoxTableViewer extends EnhancedTableViewer implements 
    */
   public Object[] getGrayedElements() {
     TableItem[] children = getTable().getItems();
-    List v = new ArrayList(children.length);
+    List<Object> v = new ArrayList<>(children.length);
     for (int i = 0; i < children.length; i++) {
       TableItem item = children[i];
       if (item.getGrayed()) {
@@ -485,7 +487,7 @@ public class EnhancedCheckBoxTableViewer extends EnhancedTableViewer implements 
       }
     }
 
-    private static final class EmptyEnumerator implements Enumeration {
+    private static final class EmptyEnumerator implements Enumeration<Object> {
       @Override
       public boolean hasMoreElements() {
         return false;
@@ -497,7 +499,7 @@ public class EnhancedCheckBoxTableViewer extends EnhancedTableViewer implements 
       }
     }
 
-    private class HashEnumerator implements Enumeration {
+    private class HashEnumerator implements Enumeration<Object> {
       boolean key;
 
       int start;
@@ -652,7 +654,7 @@ public class EnhancedCheckBoxTableViewer extends EnhancedTableViewer implements 
      *
      * @return an Enumeration of the values of this Hashtable
      */
-    public Enumeration elements() {
+    public Enumeration<?> elements() {
       if (elementCount == 0) {
         return emptyEnumerator;
       }
@@ -716,7 +718,7 @@ public class EnhancedCheckBoxTableViewer extends EnhancedTableViewer implements 
      *
      * @return an Enumeration of the keys of this Hashtable
      */
-    public Enumeration keys() {
+    public Enumeration<Object> keys() {
       if (elementCount == 0) {
         return emptyEnumerator;
       }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/table/EnhancedTableViewer.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/table/EnhancedTableViewer.java
@@ -359,6 +359,7 @@ public class EnhancedTableViewer extends TableViewer {
     /**
      * {@inheritDoc}
      */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public int compare(Viewer viewer, Object e1, Object e2) {
       Comparable c1 = mComparableProvider.getComparableValue(e1, mSortedColumnIndex);

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/table/ITableComparableProvider.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/table/ITableComparableProvider.java
@@ -39,5 +39,5 @@ public interface ITableComparableProvider {
    *          the table column index
    * @return the comparable value for this columns
    */
-  Comparable getComparableValue(Object element, int col);
+  Comparable<?> getComparableValue(Object element, int col);
 }


### PR DESCRIPTION
First I fixed all warnings that could be fixed by adding generic type
arguments. Only afterward I silenced the remaining warnings (basically
in all the AST visit() methods which operate with the non-generic JDT
API). Additionally, all adapter related assignments have been silenced, since we still compile against the non-generic adapter implementation.