### PR TITLE
fix multiple extension declaration issues

### DIFF
--- a/net.sf.eclipsecs.core/plugin.xml
+++ b/net.sf.eclipsecs.core/plugin.xml
@@ -7,7 +7,7 @@
         schema="schema/checkstyleAddonProvider.exsd"/>
 
     <!-- defines the extension point to contribute custom configuration type. -->
-    <extension-point id="configurationtypes" name="Configuration types" schema="schema/configtypes.exsd"/>
+    <extension-point id="configurationtypes" name="Checkstyle configuration types" schema="schema/configtypes.exsd"/>
 
     <!-- defines the extension point to contribute default checkstyle configurations to the checkstyle plugin -->
     <extension-point id="configurations" name="Checkstyle configurations" schema="schema/configurations.exsd"/>
@@ -16,7 +16,7 @@
     <extension-point id="filters" name="Checkstyle filters" schema="schema/filters.exsd"/>
 
     <!-- defines the extension point to contribute custom configuration save filters -->
-    <extension-point id="saveFilters" name="Configuration save filters" schema="schema/saveFilters.exsd"/>
+    <extension-point id="saveFilters" name="Checkstyle configuration save filters" schema="schema/saveFilters.exsd"/>
 
     <extension id="CheckstyleBuilder" name="%CheckstyleBuilder.name" point="org.eclipse.core.resources.builders">
         <builder>

--- a/net.sf.eclipsecs.core/schema/checkstyleAddonProvider.exsd
+++ b/net.sf.eclipsecs.core/schema/checkstyleAddonProvider.exsd
@@ -1,58 +1,26 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Schema file written by PDE -->
-<schema targetNamespace="net.sf.eclipsecs.core">
+<schema targetNamespace="net.sf.eclipsecs.core" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
-      <appInfo>
-         <meta.schema plugin="net.sf.eclipsecs.core" id="checkstyleAddonProvider" name="checkstyleAddonProvider"/>
-      </appInfo>
+      <appinfo>
+         <meta.schema plugin="net.sf.eclipsecs.core" id="checkstyleAddonProvider" name="Checkstyle Addon provider"/>
+      </appinfo>
       <documentation>
          Use this extension point to declare a plugin providing Checkstyle addon modules (e.g. custom checks) and optionally appropriate metadata for the eclipse-cs plugin.
       </documentation>
    </annotation>
 
    <annotation>
-      <appInfo>
+      <appinfo>
          <meta.section type="since"/>
-      </appInfo>
+      </appinfo>
       <documentation>
          5.6.0
       </documentation>
    </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="examples"/>
-      </appInfo>
-      <documentation>
-         [Enter extension point usage example here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="apiInfo"/>
-      </appInfo>
-      <documentation>
-         [Enter API information here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="implementation"/>
-      </appInfo>
-      <documentation>
-         [Enter information about supplied implementation of this extension point.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="copyright"/>
-      </appInfo>
-      <documentation>
-         
-      </documentation>
-   </annotation>
 
 </schema>

--- a/net.sf.eclipsecs.core/schema/configtypes.exsd
+++ b/net.sf.eclipsecs.core/schema/configtypes.exsd
@@ -1,16 +1,21 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Schema file written by PDE -->
-<schema targetNamespace="net.sf.eclipsecs.core">
+<schema targetNamespace="net.sf.eclipsecs.core" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
-      <appInfo>
-         <meta.schema plugin="net.sf.eclipsecs.core" id="configurationtypes" name="configurationtypes"/>
-      </appInfo>
+      <appinfo>
+         <meta.schema plugin="net.sf.eclipsecs.core" id="configurationtypes" name="Checkstyle configuration types"/>
+      </appinfo>
       <documentation>
-         This extension point can be used to provide custom confifuration types.
+         This extension point can be used to provide custom configuration types.
       </documentation>
    </annotation>
 
    <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
       <complexType>
          <sequence>
             <element ref="configuration-type" minOccurs="1" maxOccurs="unbounded"/>
@@ -18,7 +23,7 @@
          <attribute name="point" type="string" use="required">
             <annotation>
                <documentation>
-                  The extension point id this contribution shall apply to
+                  The extension point id this contribution shall apply to.
                </documentation>
             </annotation>
          </attribute>
@@ -51,18 +56,18 @@ The id is used to identify the specific filter set.
             <annotation>
                <documentation>
                   The fully qualified class name of the configuration type implementation.
-The class must implement &lt;link&gt;net.sf.eclipsecs.core.config.configtypes.IConfigurationType&lt;/link&gt;.
+The class must implement &lt;code&gt;net.sf.eclipsecs.core.config.configtypes.IConfigurationType&lt;/code&gt;.
                </documentation>
             </annotation>
          </attribute>
          <attribute name="name" type="string" use="required">
             <annotation>
                <documentation>
-                  The human readable name of this name of this configuration type.
+                  The human readable name of this configuration type.
                </documentation>
-               <appInfo>
+               <appinfo>
                   <meta.attribute translatable="true"/>
-               </appInfo>
+               </appinfo>
             </annotation>
          </attribute>
          <attribute name="internal-name" type="string" use="required">
@@ -104,48 +109,16 @@ The class must implement &lt;link&gt;net.sf.eclipsecs.core.config.configtypes.IC
    </element>
 
    <annotation>
-      <appInfo>
+      <appinfo>
          <meta.section type="since"/>
-      </appInfo>
+      </appinfo>
       <documentation>
          4.0.0
       </documentation>
    </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="examples"/>
-      </appInfo>
-      <documentation>
-         [Enter extension point usage example here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="apiInfo"/>
-      </appInfo>
-      <documentation>
-         [Enter API information here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="implementation"/>
-      </appInfo>
-      <documentation>
-         [Enter information about supplied implementation of this extension point.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="copyright"/>
-      </appInfo>
-      <documentation>
-         
-      </documentation>
-   </annotation>
 
 </schema>

--- a/net.sf.eclipsecs.core/schema/configurations.exsd
+++ b/net.sf.eclipsecs.core/schema/configurations.exsd
@@ -2,9 +2,9 @@
 <!-- Schema file written by PDE -->
 <schema targetNamespace="net.sf.eclipsecs.core" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
-      <appInfo>
-         <meta.schema plugin="net.sf.eclipsecs.core" id="filters" name="filters"/>
-      </appInfo>
+      <appinfo>
+         <meta.schema plugin="net.sf.eclipsecs.core" id="configurations" name="Checkstyle configurations"/>
+      </appinfo>
       <documentation>
          This extension point can be used to provide specific filter sets.
       </documentation>
@@ -12,9 +12,9 @@
 
    <element name="extension">
       <annotation>
-         <appInfo>
+         <appinfo>
             <meta.element />
-         </appInfo>
+         </appinfo>
       </annotation>
       <complexType>
          <sequence>
@@ -23,7 +23,7 @@
          <attribute name="point" type="string" use="required">
             <annotation>
                <documentation>
-                  The extension point id this contribution shall apply to
+                  The extension point id this contribution shall apply to.
                </documentation>
             </annotation>
          </attribute>
@@ -67,9 +67,9 @@ The id is used to identify the specific filter set.
                <documentation>
                   A description of the check configuration.
                </documentation>
-               <appInfo>
+               <appinfo>
                   <meta.attribute translatable="true"/>
-               </appInfo>
+               </appinfo>
             </annotation>
          </attribute>
          <attribute name="location" type="string" use="required">
@@ -93,7 +93,7 @@ The all-time default configuration &quot;Sun Checks&quot; is defined with defaul
    <element name="property">
       <annotation>
          <documentation>
-            Defines a resolvable property for the builtin-configuration. This is useful for having mutliple builtin configurations share a common checkstyle configuration file - with the exception of them having a few parametrizable differences (e.g. max line length 80 vs. 100).
+            Defines a resolvable property for the builtin-configuration. This is useful for having multiple builtin configurations share a common checkstyle configuration file - with the exception of them having a few parametrizable differences (e.g. max line length 80 vs. 100).
          </documentation>
       </annotation>
       <complexType>
@@ -115,40 +115,16 @@ The all-time default configuration &quot;Sun Checks&quot; is defined with defaul
    </element>
 
    <annotation>
-      <appInfo>
+      <appinfo>
          <meta.section type="since"/>
-      </appInfo>
+      </appinfo>
       <documentation>
          4.0.0
       </documentation>
    </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="examples"/>
-      </appInfo>
-      <documentation>
-         [Enter extension point usage example here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="apiInfo"/>
-      </appInfo>
-      <documentation>
-         [Enter API information here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="implementation"/>
-      </appInfo>
-      <documentation>
-         [Enter information about supplied implementation of this extension point.]
-      </documentation>
-   </annotation>
 
 
 </schema>

--- a/net.sf.eclipsecs.core/schema/filters.exsd
+++ b/net.sf.eclipsecs.core/schema/filters.exsd
@@ -1,16 +1,21 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Schema file written by PDE -->
-<schema targetNamespace="net.sf.eclipsecs.core">
+<schema targetNamespace="net.sf.eclipsecs.core" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
-      <appInfo>
-         <meta.schema plugin="net.sf.eclipsecs.core" id="filters" name="filters"/>
-      </appInfo>
+      <appinfo>
+         <meta.schema plugin="net.sf.eclipsecs.core" id="filters" name="Checkstyle filters"/>
+      </appinfo>
       <documentation>
          This extension point can be used to provide specific filter sets.
       </documentation>
    </annotation>
 
    <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
       <complexType>
          <sequence>
             <element ref="filter" minOccurs="1" maxOccurs="unbounded"/>
@@ -54,7 +59,7 @@ The id is used to identify the specific filter set.
             <annotation>
                <documentation>
                   The fully qualified class name of the filter implementation.
-The filter class must implement &lt;link&gt;net.sf.eclipsecs.core.filters.IFilter&lt;/link&gt;.
+The filter class must implement &lt;code&gt;net.sf.eclipsecs.core.filters.IFilter&lt;/code&gt;.
                </documentation>
             </annotation>
          </attribute>
@@ -116,48 +121,16 @@ The filter class must implement &lt;link&gt;net.sf.eclipsecs.core.filters.IFilte
    </element>
 
    <annotation>
-      <appInfo>
+      <appinfo>
          <meta.section type="since"/>
-      </appInfo>
+      </appinfo>
       <documentation>
          4.0.0
       </documentation>
    </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="examples"/>
-      </appInfo>
-      <documentation>
-         [Enter extension point usage example here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="apiInfo"/>
-      </appInfo>
-      <documentation>
-         [Enter API information here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="implementation"/>
-      </appInfo>
-      <documentation>
-         [Enter information about supplied implementation of this extension point.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="copyright"/>
-      </appInfo>
-      <documentation>
-         
-      </documentation>
-   </annotation>
 
 </schema>

--- a/net.sf.eclipsecs.core/schema/saveFilters.exsd
+++ b/net.sf.eclipsecs.core/schema/saveFilters.exsd
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Schema file written by PDE -->
-<schema targetNamespace="net.sf.eclipsecs.core">
+<schema targetNamespace="net.sf.eclipsecs.core" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
-      <appInfo>
-         <meta.schema plugin="net.sf.eclipsecs.core" id="filters" name="filters"/>
-      </appInfo>
+      <appinfo>
+         <meta.schema plugin="net.sf.eclipsecs.core" id="saveFilters" name="Checkstyle configuration save filters"/>
+      </appinfo>
       <documentation>
          This extension point can be used to provide a filter that is invoked when a checkstyle configuration is saved by the configuration editor.
 A save filter can modify the order of modules, add modules required in a certain context or remove modules that are unneccessary.
@@ -12,6 +12,11 @@ A save filter can modify the order of modules, add modules required in a certain
    </annotation>
 
    <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
       <complexType>
          <sequence>
             <element ref="saveFilter" minOccurs="1" maxOccurs="unbounded"/>
@@ -51,7 +56,7 @@ A save filter can modify the order of modules, add modules required in a certain
             <annotation>
                <documentation>
                   The fully qualified class name of the save filter implementation.
-The filter class must implement &lt;link&gt;net.sf.eclipsecs.core.config.savefilter.ISaveFilter&lt;/link&gt;.
+The filter class must implement &lt;code&gt;net.sf.eclipsecs.core.config.savefilter.ISaveFilter&lt;/code&gt;.
                </documentation>
             </annotation>
          </attribute>
@@ -59,48 +64,16 @@ The filter class must implement &lt;link&gt;net.sf.eclipsecs.core.config.savefil
    </element>
 
    <annotation>
-      <appInfo>
+      <appinfo>
          <meta.section type="since"/>
-      </appInfo>
+      </appinfo>
       <documentation>
          4.0.0
       </documentation>
    </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="examples"/>
-      </appInfo>
-      <documentation>
-         [Enter extension point usage example here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="apiInfo"/>
-      </appInfo>
-      <documentation>
-         [Enter API information here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="implementation"/>
-      </appInfo>
-      <documentation>
-         [Enter information about supplied implementation of this extension point.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="copyright"/>
-      </appInfo>
-      <documentation>
-         
-      </documentation>
-   </annotation>
 
 </schema>

--- a/net.sf.eclipsecs.ui/plugin.xml
+++ b/net.sf.eclipsecs.ui/plugin.xml
@@ -17,7 +17,7 @@
     <!-- defines the extension point to contribute the ui part of check configuration types -->
     <extension-point
         id="configtypesui"
-        name="Configuration type editors"
+        name="Checkstyle configuration type editors"
         schema="schema/configtypesui.exsd"/>
 
     <!-- Filter editors for filters allowing user input -->

--- a/net.sf.eclipsecs.ui/schema/checkstyleQuickfixProvider.exsd
+++ b/net.sf.eclipsecs.ui/schema/checkstyleQuickfixProvider.exsd
@@ -1,58 +1,26 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Schema file written by PDE -->
-<schema targetNamespace="net.sf.eclipsecs.ui">
+<schema targetNamespace="net.sf.eclipsecs.ui" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
-      <appInfo>
-         <meta.schema plugin="net.sf.eclipsecs.ui" id="checkstyleQuickfixProvider" name="checkstyleQuickfixProvider"/>
-      </appInfo>
+      <appinfo>
+         <meta.schema plugin="net.sf.eclipsecs.ui" id="checkstyleQuickfixProvider" name="Checkstyle Quickfix provider"/>
+      </appinfo>
       <documentation>
          Use this extension point to declare a plugin providing custom quickfixes for Checkstyle problems.
       </documentation>
    </annotation>
 
    <annotation>
-      <appInfo>
+      <appinfo>
          <meta.section type="since"/>
-      </appInfo>
+      </appinfo>
       <documentation>
          5.6.0
       </documentation>
    </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="examples"/>
-      </appInfo>
-      <documentation>
-         [Enter extension point usage example here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="apiInfo"/>
-      </appInfo>
-      <documentation>
-         [Enter API information here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="implementation"/>
-      </appInfo>
-      <documentation>
-         [Enter information about supplied implementation of this extension point.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="copyright"/>
-      </appInfo>
-      <documentation>
-         
-      </documentation>
-   </annotation>
 
 </schema>

--- a/net.sf.eclipsecs.ui/schema/configtypesui.exsd
+++ b/net.sf.eclipsecs.ui/schema/configtypesui.exsd
@@ -1,16 +1,21 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Schema file written by PDE -->
-<schema targetNamespace="net.sf.eclipsecs.ui">
+<schema targetNamespace="net.sf.eclipsecs.ui" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
-      <appInfo>
-         <meta.schema plugin="net.sf.eclipsecs.ui" id="configtypesui" name="configtypesui"/>
-      </appInfo>
+      <appinfo>
+         <meta.schema plugin="net.sf.eclipsecs.ui" id="configtypesui" name="Checkstyle configuration type editors"/>
+      </appinfo>
       <documentation>
          This extension point can be used to provide custom configuration type ui.
       </documentation>
    </annotation>
 
    <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
       <complexType>
          <sequence>
             <element ref="configtypeui" minOccurs="1" maxOccurs="unbounded"/>
@@ -50,7 +55,7 @@
             <annotation>
                <documentation>
                   The fully qualified class name of the configuration type editor implementation.
-The class must implement &lt;link&gt;net.sf.eclipsecs.ui.config.configtypes.ICheckConfigurationEditor&lt;/link&gt;.
+The class must implement &lt;code&gt;net.sf.eclipsecs.ui.config.configtypes.ICheckConfigurationEditor&lt;/code&gt;.
                </documentation>
             </annotation>
          </attribute>
@@ -72,48 +77,16 @@ The class must implement &lt;link&gt;net.sf.eclipsecs.ui.config.configtypes.IChe
    </element>
 
    <annotation>
-      <appInfo>
+      <appinfo>
          <meta.section type="since"/>
-      </appInfo>
+      </appinfo>
       <documentation>
          4.0.0
       </documentation>
    </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="examples"/>
-      </appInfo>
-      <documentation>
-         [Enter extension point usage example here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="apiInfo"/>
-      </appInfo>
-      <documentation>
-         [Enter API information here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="implementation"/>
-      </appInfo>
-      <documentation>
-         [Enter information about supplied implementation of this extension point.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="copyright"/>
-      </appInfo>
-      <documentation>
-         
-      </documentation>
-   </annotation>
 
 </schema>

--- a/net.sf.eclipsecs.ui/schema/filtereditors.exsd
+++ b/net.sf.eclipsecs.ui/schema/filtereditors.exsd
@@ -1,16 +1,21 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Schema file written by PDE -->
-<schema targetNamespace="net.sf.eclipsecs.ui">
+<schema targetNamespace="net.sf.eclipsecs.ui" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
-      <appInfo>
-         <meta.schema plugin="net.sf.eclipsecs.ui" id="filtereditors" name="filtereditors"/>
-      </appInfo>
+      <appinfo>
+         <meta.schema plugin="net.sf.eclipsecs.ui" id="filtereditors" name="Checkstyle filter editors"/>
+      </appinfo>
       <documentation>
-         This extension point can be used to provide specific filter sets.
+         This extension point can be used to provide filter editors.
       </documentation>
    </annotation>
 
    <element name="extension">
+      <annotation>
+         <appinfo>
+            <meta.element />
+         </appinfo>
+      </annotation>
       <complexType>
          <sequence>
             <element ref="filtereditor" minOccurs="1" maxOccurs="unbounded"/>
@@ -60,7 +65,7 @@ The id is used to identify the specific filter set.
             <annotation>
                <documentation>
                   The fully qualified class name of the filter implementation.
-The filter class must implement &lt;link&gt;net.sf.eclipsecs.ui.properties.filter.IFilterEditor&lt;/link&gt;.
+The filter class must implement &lt;code&gt;net.sf.eclipsecs.ui.properties.filter.IFilterEditor&lt;/code&gt;.
                </documentation>
             </annotation>
          </attribute>
@@ -68,48 +73,16 @@ The filter class must implement &lt;link&gt;net.sf.eclipsecs.ui.properties.filte
    </element>
 
    <annotation>
-      <appInfo>
+      <appinfo>
          <meta.section type="since"/>
-      </appInfo>
+      </appinfo>
       <documentation>
          4.0.0
       </documentation>
    </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="examples"/>
-      </appInfo>
-      <documentation>
-         [Enter extension point usage example here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="apiInfo"/>
-      </appInfo>
-      <documentation>
-         [Enter API information here.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="implementation"/>
-      </appInfo>
-      <documentation>
-         [Enter information about supplied implementation of this extension point.]
-      </documentation>
-   </annotation>
 
-   <annotation>
-      <appInfo>
-         <meta.section type="copyright"/>
-      </appInfo>
-      <documentation>
-         
-      </documentation>
-   </annotation>
 
 </schema>


### PR DESCRIPTION
* remove empty [...] sections, they are otherwise part of the generated
documentation
* replace link tags by code tags, since link tags lead to validation
errors and are not rendered
* use descriptive names for the extension points instead of repeating
their IDs
* fix the wrong occurrences of "filters" as extension point schema IDs.
* typos

None of these changes influences the extension point registry. All
relevant IDs are still the same as before, so extenders continue to work
without modification.