### PR TITLE
remove outdated natures

### DIFF
--- a/net.sf.eclipsecs.branding/.project
+++ b/net.sf.eclipsecs.branding/.project
@@ -28,7 +28,6 @@
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
-		<nature>org.maven.ide.eclipse.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>

--- a/net.sf.eclipsecs.checkstyle/.project
+++ b/net.sf.eclipsecs.checkstyle/.project
@@ -28,7 +28,6 @@
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
-		<nature>org.maven.ide.eclipse.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>

--- a/net.sf.eclipsecs.core/.project
+++ b/net.sf.eclipsecs.core/.project
@@ -33,7 +33,6 @@
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
-		<nature>org.maven.ide.eclipse.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>

--- a/net.sf.eclipsecs.sample/.project
+++ b/net.sf.eclipsecs.sample/.project
@@ -33,7 +33,6 @@
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
-		<nature>org.maven.ide.eclipse.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>

--- a/net.sf.eclipsecs.ui/.project
+++ b/net.sf.eclipsecs.ui/.project
@@ -33,7 +33,6 @@
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
-		<nature>org.maven.ide.eclipse.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>


### PR DESCRIPTION
When m2eclipse was rebranded as m2e, a new nature (namely the m2e nature
directly above the deleted lines) was created. This one can be deleted
to avoid a warning in Photon.