### PR TITLE
automatic module name for java 9 compatibility

### DIFF
--- a/net.sf.eclipsecs.branding/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.branding/META-INF/MANIFEST.MF
@@ -5,3 +5,4 @@ Bundle-SymbolicName: net.sf.eclipsecs.branding
 Bundle-Version: 8.8.0.qualifier
 Bundle-Vendor: http://eclipse-cs.sf.net/
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: net.sf.eclipsecs.branding

--- a/net.sf.eclipsecs.checkstyle/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.checkstyle/META-INF/MANIFEST.MF
@@ -47,3 +47,4 @@ Export-Package: .,
  org.apache.commons.beanutils;version="8.8.0"
 Bundle-ClassPath: .,
  checkstyle-8.8-all.jar
+Automatic-Module-Name: net.sf.eclipsecs.checkstyle

--- a/net.sf.eclipsecs.core/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.core/META-INF/MANIFEST.MF
@@ -40,4 +40,5 @@ Import-Package: org.eclipse.core.filebuffers,
  org.eclipse.team.core.synchronize;resolution:=optional,
  org.osgi.framework,
  org.osgi.service.prefs
+Automatic-Module-Name: net.sf.eclipsecs.core
 

--- a/net.sf.eclipsecs.doc/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.doc/META-INF/MANIFEST.MF
@@ -5,3 +5,4 @@ Bundle-SymbolicName: net.sf.eclipsecs.doc;singleton:=true
 Bundle-Version: 8.8.0.qualifier
 Bundle-Vendor: http://eclipse-cs.sf.net/
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Automatic-Module-Name: net.sf.eclipsecs.doc

--- a/net.sf.eclipsecs.sample/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.sample/META-INF/MANIFEST.MF
@@ -15,4 +15,5 @@ Import-Package: org.eclipse.core.resources,
  org.eclipse.jface.text,
  org.eclipse.swt.graphics,
  org.eclipse.ui
+Automatic-Module-Name: net.sf.eclipsecs.sample
 

--- a/net.sf.eclipsecs.ui/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.ui/META-INF/MANIFEST.MF
@@ -64,4 +64,5 @@ Import-Package: org.eclipse.core.commands,
  org.eclipse.ui.views.markers,
  org.osgi.framework,
  org.osgi.service.prefs
+Automatic-Module-Name: net.sf.eclipsecs.ui
 


### PR DESCRIPTION
https://dzone.com/articles/automatic-module-name-calling-all-java-library-maintainers

This is basically getting added to each and every Eclipse plugin during the last weeks and months.