### PR TITLE
remove empty lines in example code

### DIFF
--- a/net.sf.eclipsecs.doc/src/main/resources/partials/builtin-config.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/builtin-config.html
@@ -14,8 +14,7 @@
     <p>
         <b>Example:</b>
     </p>
-    <pre><code>
-&lt;extension
+    <pre><code>&lt;extension
     id="checkstyle.CheckConfiguration"
     point="net.sf.eclipsecs.core.configurations"&gt;
     &lt;check-configuration
@@ -24,13 +23,11 @@
         description="Sample Built-in configuration"&gt;
         &lt;property name="maxLineLength" value="50"/&gt;
      &lt;/check-configuration&gt;
-&lt;/extension&gt;
-        </code></pre>
+&lt;/extension&gt;</code></pre>
     <p>
         <b>Example 2 - custom built-in config to become the default configuration (highest default-weight wins):</b>
     </p>
-    <pre><code>
-&lt;extension
+    <pre><code>&lt;extension
     id="checkstyle.CheckConfiguration"
     point="net.sf.eclipsecs.core.configurations"&gt;
     &lt;check-configuration
@@ -40,6 +37,5 @@
         default-weight="10"&gt;
         &lt;property name="maxLineLength" value="50"/&gt;
      &lt;/check-configuration&gt;
-&lt;/extension&gt;
-        </code></pre>
+&lt;/extension&gt;</code></pre>
 </div>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/custom-checks.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/custom-checks.html
@@ -52,8 +52,7 @@
                 good idea to include this document type declaration to your metadata file: </p>
             <pre><code>&lt;!DOCTYPE checkstyle-metadata
     PUBLIC &quot;-//eclipse-cs//DTD Check Metadata 1.1//EN&quot;
-    &quot;http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd&quot;&gt;
-                </code></pre>
+    &quot;http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd&quot;&gt;</code></pre>
             <p>This way you can validate your metadata file against the dtd using your preferred XML editor.</p>
             <p> The dtd file itself contains an abundance of documentation on the tags and their attributes, further
                 further practical reference you may want to peek into the <code>net.sf.eclipsecs.checkstyle</code>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/custom-filters.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/custom-filters.html
@@ -15,8 +15,7 @@
     </p>
     <p>Example:</p>
     <p>Using the <code>net.sf.eclipsecs.core.filters</code> extension point in your <code>plugin.xml</code></p>
-    <pre><code>
-&lt;extension
+    <pre><code>&lt;extension
     id="checkstyle.CheckstyleFilters"
     point="net.sf.eclipsecs.core.filters"&gt;
     &lt;filter
@@ -24,8 +23,7 @@
         internal-name="SampleFilter"
         description="Sample Filter"
         class="net.sf.eclipsecs.sample.filter.SampleFilter"/&gt;
-&lt;/extension&gt;
-        </code></pre>
+&lt;/extension&gt;</code></pre>
     <p>The filter implementation class must implement the
             <code>net.sf.eclipsecs.core.projectconfig.filters.IFilter</code> interface.<br/> To make life a bit easier
         for you there is the <code>net.sf.eclipsecs.core.projectconfig.filters.AbstractFilter</code> class which

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/extensions.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/extensions.html
@@ -18,7 +18,7 @@
         not as complicated as it sounds.</p>
     <p> The easiest way is to check out the sample eclipse-cs extension plugin from the Git repository, this sample
         plugin provides an example for each documented extension hook.</p>
-    <p>The repository location is: <code>git://git.code.sf.net/p/eclipse-cs/git</code><br/>The project to check out is:
+    <p>The repository location is: <code>https://github.com/checkstyle/eclipse-cs.git</code><br/>The project to check out is:
             <code>net.sf.eclipsecs.sample</code></p>
     <p>After you got the project in your workspace you can just disconnect it from the Git and rename the project and
         the plugins symbolic bundle name in <code>META-INF/MANIFEST.MF</code> to your liking.</p>


### PR DESCRIPTION
If a line break is inside a pre block, it will be rendered as is,
therefore leading to empty lines at the begin or end of some of the
example code blocks in the documentation.

At the same time, this also updates an outdated git URI in the documentation