### PR TITLE
Add extension point implementation examples

### DIFF
--- a/net.sf.eclipsecs.core/schema/configurations.exsd
+++ b/net.sf.eclipsecs.core/schema/configurations.exsd
@@ -123,6 +123,27 @@ The all-time default configuration &quot;Sun Checks&quot; is defined with defaul
       </documentation>
    </annotation>
 
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         The following is an example of using the &lt;samp&gt;configurations&lt;/samp&gt; extension point.
+
+&lt;pre&gt;
+&lt;extension
+    id=&quot;checkstyle.CheckConfiguration&quot;
+    point=&quot;net.sf.eclipsecs.core.configurations&quot;&gt;
+    &lt;check-configuration
+        name=&quot;Sample Builtin Checks&quot;
+        location=&quot;sample_checks.xml&quot;
+        description=&quot;Sample Built-in configuration&quot;&gt;
+        &lt;property name=&quot;maxLineLength&quot; value=&quot;50&quot;/&gt;
+     &lt;/check-configuration&gt;
+&lt;/extension&gt;
+&lt;/pre&gt;
+      </documentation>
+   </annotation>
 
 
 

--- a/net.sf.eclipsecs.core/schema/filters.exsd
+++ b/net.sf.eclipsecs.core/schema/filters.exsd
@@ -129,6 +129,26 @@ The filter class must implement &lt;code&gt;net.sf.eclipsecs.core.filters.IFilte
       </documentation>
    </annotation>
 
+   <annotation>
+      <appinfo>
+         <meta.section type="examples"/>
+      </appinfo>
+      <documentation>
+         The following is an example of using the &lt;samp&gt;filters&lt;/samp&gt; extension point.
+
+&lt;pre&gt;
+&lt;extension
+    id=&quot;checkstyle.CheckstyleFilters&quot;
+    point=&quot;net.sf.eclipsecs.core.filters&quot;&gt;
+    &lt;filter
+        name=&quot;Sample Filter&quot;
+        internal-name=&quot;SampleFilter&quot;
+        description=&quot;Sample Filter&quot;
+        class=&quot;net.sf.eclipsecs.sample.filter.SampleFilter&quot;/&gt;
+&lt;/extension&gt;
+&lt;/pre&gt;
+      </documentation>
+   </annotation>
 
 
 


### PR DESCRIPTION
This copies the existing example extensions from the documentation into
the extension point declaration itself. This way the examples are
available directly when creating the extension in PDE.