### PR TITLE
#66: no https for checkstyle.org

### DIFF
--- a/net.sf.eclipsecs-feature/feature.xml
+++ b/net.sf.eclipsecs-feature/feature.xml
@@ -18,7 +18,7 @@
    </license>
 
    <url>
-      <update label="%updateSiteName" url="https://checkstyle.github.io/eclipse-cs/update/"/>
+      <update label="%updateSiteName" url="http://checkstyle.github.io/eclipse-cs/update/"/>
    </url>
 
    <requires>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/install.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/install.html
@@ -44,7 +44,7 @@
         <div class="panel-body">
             <ol>
                 <li>Within Eclipse go to: <em>Help -> Install New Software...</em></li>
-                <li>Enter the following update site url: <code>https://checkstyle.github.io/eclipse-cs/update</code></li>
+                <li>Enter the following update site url: <code>http://checkstyle.github.io/eclipse-cs/update</code></li>
                 <li>Select the Eclipse Checkstyle Plugin feature to install</li>
                 <li>Conclude the installation as described above</li>
             </ol>

--- a/net.sf.eclipsecs.doc/src/main/resources/robots.txt
+++ b/net.sf.eclipsecs.doc/src/main/resources/robots.txt
@@ -1,1 +1,1 @@
-Sitemap: https://checkstyle.github.io/eclipse-cs/sitemap.xml
+Sitemap: http://checkstyle.github.io/eclipse-cs/sitemap.xml

--- a/net.sf.eclipsecs.doc/src/main/resources/sitemap.xml
+++ b/net.sf.eclipsecs.doc/src/main/resources/sitemap.xml
@@ -3,77 +3,77 @@
   xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
             http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
   <url>
-    <loc>https://checkstyle.github.io/eclipse-cs/</loc>
+    <loc>http://checkstyle.github.io/eclipse-cs/</loc>
     <lastmod>${timestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>https://checkstyle.github.io/eclipse-cs/#!/releasenotes</loc>
+    <loc>http://checkstyle.github.io/eclipse-cs/#!/releasenotes</loc>
     <lastmod>${timestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>https://checkstyle.github.io/eclipse-cs/#!/install</loc>
+    <loc>http://checkstyle.github.io/eclipse-cs/#!/install</loc>
     <lastmod>${timestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>https://checkstyle.github.io/eclipse-cs/#!/project-setup</loc>
+    <loc>http://checkstyle.github.io/eclipse-cs/#!/project-setup</loc>
     <lastmod>${timestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>https://checkstyle.github.io/eclipse-cs/#!/custom-config</loc>
+    <loc>http://checkstyle.github.io/eclipse-cs/#!/custom-config</loc>
     <lastmod>${timestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>https://checkstyle.github.io/eclipse-cs/#!/filters</loc>
+    <loc>http://checkstyle.github.io/eclipse-cs/#!/filters</loc>
     <lastmod>${timestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>https://checkstyle.github.io/eclipse-cs/#!/configtypes</loc>
+    <loc>http://checkstyle.github.io/eclipse-cs/#!/configtypes</loc>
     <lastmod>${timestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>https://checkstyle.github.io/eclipse-cs/#!/properties</loc>
+    <loc>http://checkstyle.github.io/eclipse-cs/#!/properties</loc>
     <lastmod>${timestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>https://checkstyle.github.io/eclipse-cs/#!/filesets</loc>
+    <loc>http://checkstyle.github.io/eclipse-cs/#!/filesets</loc>
     <lastmod>${timestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>https://checkstyle.github.io/eclipse-cs/#!/preferences</loc>
+    <loc>http://checkstyle.github.io/eclipse-cs/#!/preferences</loc>
     <lastmod>${timestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>https://checkstyle.github.io/eclipse-cs/#!/extensions</loc>
+    <loc>http://checkstyle.github.io/eclipse-cs/#!/extensions</loc>
     <lastmod>${timestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>https://checkstyle.github.io/eclipse-cs/#!/custom-checks</loc>
+    <loc>http://checkstyle.github.io/eclipse-cs/#!/custom-checks</loc>
     <lastmod>${timestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>https://checkstyle.github.io/eclipse-cs/#!/builtin-config</loc>
+    <loc>http://checkstyle.github.io/eclipse-cs/#!/builtin-config</loc>
     <lastmod>${timestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>https://checkstyle.github.io/eclipse-cs/#!/custom-filters</loc>
+    <loc>http://checkstyle.github.io/eclipse-cs/#!/custom-filters</loc>
     <lastmod>${timestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
-    <loc>https://checkstyle.github.io/eclipse-cs/#!/faq</loc>
+    <loc>http://checkstyle.github.io/eclipse-cs/#!/faq</loc>
     <lastmod>${timestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>


### PR DESCRIPTION
Search/replace all https://checkstyle urls by their http counterpart.