### PR TITLE
Fix the Maven build

### DIFF
--- a/net.sf.eclipsecs.checkstyle/pom.xml
+++ b/net.sf.eclipsecs.checkstyle/pom.xml
@@ -21,7 +21,7 @@
                                 <delete dir="${project.build.directory}/checkstyle-src-unpack" />
                                 <delete dir="${project.build.directory}/checkstyle-src" />
                                 <first id="cssrc">
-                                    <fileset dir="." includes="checkstyle-*-src.zip" />
+                                    <fileset dir="." includes="checkstyle-checkstyle-*.zip" />
                                 </first>
                                 <unzip src="${toString:cssrc}" dest="${project.build.directory}/checkstyle-src-unpack">
                                     <patternset>


### PR DESCRIPTION
The new checkstyle source naming scheme was not used in the Maven build.