### PR TITLE
Optimize target platform resolution

### DIFF
--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="Eclipse Checkstyle" sequenceNumber="1515838239">
+<target name="Eclipse Checkstyle" sequenceNumber="1523084336">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.sdk.ide" version="0.0.0"/>
       <unit id="org.eclipse.emf.feature.group" version="0.0.0"/>
-      <repository location="http://download.eclipse.org/releases/juno/"/>
+      <repository location="http://download.eclipse.org/releases/juno/201303010900/"/>
     </location>
   </locations>
 </target>

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
@@ -1,7 +1,9 @@
+// install http://mbarbero.github.io/fr.obeo.releng.targetplatform/p2/ to use this target definition
 target "Eclipse Checkstyle"
 with source configurePhase
 
-location "http://download.eclipse.org/releases/juno/" {
+// use the latest version of Juno only, to avoid downloading all children of the Juno composite update site
+location "http://download.eclipse.org/releases/juno/201303010900/" {
 	org.eclipse.jdt.feature.group lazy
 	org.eclipse.sdk.ide lazy
 


### PR DESCRIPTION
The Juno update site is a composite update site. By referencing only the
latest version of Juno we avoid reading all the other child update sites
during the Maven build process and save some seconds of build time. The
overall build result is the same, nevertheless.