### PR TITLE
#70: upgrade to checkstyle core 8.10

### DIFF
--- a/docs/partials/builtin-config.html
+++ b/docs/partials/builtin-config.html
@@ -14,8 +14,7 @@
     <p>
         <b>Example:</b>
     </p>
-    <pre><code>
-&lt;extension
+    <pre><code>&lt;extension
     id="checkstyle.CheckConfiguration"
     point="net.sf.eclipsecs.core.configurations"&gt;
     &lt;check-configuration
@@ -24,13 +23,11 @@
         description="Sample Built-in configuration"&gt;
         &lt;property name="maxLineLength" value="50"/&gt;
      &lt;/check-configuration&gt;
-&lt;/extension&gt;
-        </code></pre>
+&lt;/extension&gt;</code></pre>
     <p>
         <b>Example 2 - custom built-in config to become the default configuration (highest default-weight wins):</b>
     </p>
-    <pre><code>
-&lt;extension
+    <pre><code>&lt;extension
     id="checkstyle.CheckConfiguration"
     point="net.sf.eclipsecs.core.configurations"&gt;
     &lt;check-configuration
@@ -40,6 +37,5 @@
         default-weight="10"&gt;
         &lt;property name="maxLineLength" value="50"/&gt;
      &lt;/check-configuration&gt;
-&lt;/extension&gt;
-        </code></pre>
+&lt;/extension&gt;</code></pre>
 </div>

--- a/docs/partials/custom-checks.html
+++ b/docs/partials/custom-checks.html
@@ -52,8 +52,7 @@
                 good idea to include this document type declaration to your metadata file: </p>
             <pre><code>&lt;!DOCTYPE checkstyle-metadata
     PUBLIC &quot;-//eclipse-cs//DTD Check Metadata 1.1//EN&quot;
-    &quot;http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd&quot;&gt;
-                </code></pre>
+    &quot;http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd&quot;&gt;</code></pre>
             <p>This way you can validate your metadata file against the dtd using your preferred XML editor.</p>
             <p> The dtd file itself contains an abundance of documentation on the tags and their attributes, further
                 further practical reference you may want to peek into the <code>net.sf.eclipsecs.checkstyle</code>

--- a/docs/partials/custom-filters.html
+++ b/docs/partials/custom-filters.html
@@ -15,8 +15,7 @@
     </p>
     <p>Example:</p>
     <p>Using the <code>net.sf.eclipsecs.core.filters</code> extension point in your <code>plugin.xml</code></p>
-    <pre><code>
-&lt;extension
+    <pre><code>&lt;extension
     id="checkstyle.CheckstyleFilters"
     point="net.sf.eclipsecs.core.filters"&gt;
     &lt;filter
@@ -24,8 +23,7 @@
         internal-name="SampleFilter"
         description="Sample Filter"
         class="net.sf.eclipsecs.sample.filter.SampleFilter"/&gt;
-&lt;/extension&gt;
-        </code></pre>
+&lt;/extension&gt;</code></pre>
     <p>The filter implementation class must implement the
             <code>net.sf.eclipsecs.core.projectconfig.filters.IFilter</code> interface.<br/> To make life a bit easier
         for you there is the <code>net.sf.eclipsecs.core.projectconfig.filters.AbstractFilter</code> class which

--- a/docs/partials/extensions.html
+++ b/docs/partials/extensions.html
@@ -18,7 +18,7 @@
         not as complicated as it sounds.</p>
     <p> The easiest way is to check out the sample eclipse-cs extension plugin from the Git repository, this sample
         plugin provides an example for each documented extension hook.</p>
-    <p>The repository location is: <code>git://git.code.sf.net/p/eclipse-cs/git</code><br/>The project to check out is:
+    <p>The repository location is: <code>https://github.com/checkstyle/eclipse-cs.git</code><br/>The project to check out is:
             <code>net.sf.eclipsecs.sample</code></p>
     <p>After you got the project in your workspace you can just disconnect it from the Git and rename the project and
         the plugins symbolic bundle name in <code>META-INF/MANIFEST.MF</code> to your liking.</p>

--- a/docs/partials/index.html
+++ b/docs/partials/index.html
@@ -36,7 +36,7 @@
                     <br />
                     <small>
                         <sup>2 </sup>
-                        Latest release 8.8.0, based on Checkstyle 8.8, see
+                        Latest release 8.10.0, based on Checkstyle 8.10, see
                         <a href="#!/releasenotes">release notes</a>
                     </small>
                 </div>

--- a/docs/partials/install.html
+++ b/docs/partials/install.html
@@ -10,11 +10,11 @@
             <p>
                 <a class="btn btn-primary btn-outline-inverse btn-lg" target="_blank"
                     href="http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=150"
-                    title="Drag and drop this link into a running Eclipse Indigo/Kepler/Luna workspace to install Checkstyle Plugin"
+                    title="Drag and drop this link into a running Eclipse Indigo/Juno/Kepler/Luna/Mars/Neon/Oxygen workspace to install Checkstyle Plugin"
                         ><i class="fa fa-plug"> </i> Install </a>
             </p>
             <ol>
-                <li>Drag&amp;Drop the link above to a running Eclipse Indigo/Juno/Kepler/Luna/Mars instance. This will trigger the
+                <li>Drag&amp;Drop the link above to a running Eclipse Indigo/Juno/Kepler/Luna/Mars/Neon/Oxygen instance. This will trigger the
                     Eclipse Marketplace client with the Eclipse Checkstyle Plugin being pre-selected for
                     installation.</li>
                 <li>Confirm the selection of features to install</li>

--- a/docs/partials/releasenotes.html
+++ b/docs/partials/releasenotes.html
@@ -1,6 +1,26 @@
 <div class="container" data-ng-controller="ReleaseNotesCtrl">
     <!-- <div data-google-ad=""/> -->
 
+    <div class="alert alert-info">
+        The slow rate of recent updates is owed to a shift in personal interest and how I spend my spare
+        time.
+        <p>
+            If you want to help keep this project afloat and steadily updated please send me a message or
+            <a href="https://sourceforge.net/p/eclipse-cs/discussion/274376/thread/3b44a5eb/">post to the
+                forums
+            </a>
+            .
+        </p>
+        <p>
+            Additionally activity has started to migrate the project to Github (
+            <a href="https://github.com/checkstyle/eclipse-cs">eclipse-cs Github page</a>
+            ), hoping this will make it easier for contributions.
+            Code and issue tracking have already been moved, other facilities will
+            follow over the course of the next weeks.
+        </p>
+        -- Lars
+    </div>
+
     <h1>Release notes <button class="btn btn-primary btn-sm" data-ng-click="expandAll()"><i class="fa fa-plus-square-o"
             > </i> Expand all</button></h1>
     <accordion data-close-others="false">

--- a/docs/partials/releases/8.10.0/release_notes.html
+++ b/docs/partials/releases/8.10.0/release_notes.html
@@ -1,0 +1,27 @@
+<div>
+    <p>Updates the Checkstyle core to version 8.10.</p>
+    <p>
+        Please note that this version requires
+        <strong>Java 8 as the minimum runtime environment</strong>
+        . This requires
+        you to run Eclipse on a Java 8 JVM in order to use this plugin version.
+    </p>
+    <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
+    <p>
+        Please read the
+        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+            release notes
+        </a>
+        for details on recent and potentially breaking changes in Checkstyle.
+        Checkstyle configuration files potentially
+        need to be adapted to this version.
+    </p>
+    <h3>Features</h3>
+    <ul>
+        <li><a href="https://github.com/checkstyle/eclipse-cs/issues/70">#70 Upgrade to Checkstyle 8.10</a></li>
+    </ul>
+    <h3>Bugfixes</h3>
+    <ul>
+        <li><a href="https://github.com/checkstyle/eclipse-cs/issues/48">#48 Package name check has wrong default in Sun configuration</a></li>
+    </ul>
+</div>

--- a/docs/partials/releases/8.5.0/release_notes.html
+++ b/docs/partials/releases/8.5.0/release_notes.html
@@ -14,18 +14,6 @@
         </a>
         for details on recent changes in Checkstyle.
     </p>
-    <div class="alert alert-info">
-        The slow rate of recent updates is owed to a shift in personal interest and how I spend my spare
-        time.
-        <br />
-        <br />
-        If you want to help keep this project afloat and steadily updated please send me a message or post to the
-        forums
-        (https://sourceforge.net/p/eclipse-cs/discussion/274376/thread/3b44a5eb/).
-        <br />
-        <br />
-        -- Lars
-    </div>
     <h3>Bugfixes</h3>
     <ul>
         <li>

--- a/docs/partials/releases/8.7.0/release_notes.html
+++ b/docs/partials/releases/8.7.0/release_notes.html
@@ -16,23 +16,4 @@
         Checkstyle configuration files potentially
         need to be adapted to this version.
     </p>
-    <div class="alert alert-info">
-        The slow rate of recent updates is owed to a shift in personal interest and how I spend my spare
-        time.
-        <p>
-            If you want to help keep this project afloat and steadily updated please send me a message or
-            <a href="https://sourceforge.net/p/eclipse-cs/discussion/274376/thread/3b44a5eb/">post to the
-                forums
-            </a>
-            .
-        </p>
-        <p>
-            Additionally activity has started to migrate the project to Github (
-            <a href="https://github.com/checkstyle/eclipse-cs">eclipse-cs Github page</a>
-            ), hoping this will make it easier for contributions.
-            Code and issue tracking have already been moved, other facilities will
-            follow over the course of the next weeks.
-        </p>
-        -- Lars
-    </div>
 </div>

--- a/docs/partials/releases/8.8.0/release_notes.html
+++ b/docs/partials/releases/8.8.0/release_notes.html
@@ -16,25 +16,6 @@
         Checkstyle configuration files potentially
         need to be adapted to this version.
     </p>
-    <div class="alert alert-info">
-        The slow rate of recent updates is owed to a shift in personal interest and how I spend my spare
-        time.
-        <p>
-            If you want to help keep this project afloat and steadily updated please send me a message or
-            <a href="https://sourceforge.net/p/eclipse-cs/discussion/274376/thread/3b44a5eb/">post to the
-                forums
-            </a>
-            .
-        </p>
-        <p>
-            Additionally activity has started to migrate the project to Github (
-            <a href="https://github.com/checkstyle/eclipse-cs">eclipse-cs Github page</a>
-            ), hoping this will make it easier for contributions.
-            Code and issue tracking have already been moved, other facilities will
-            follow over the course of the next weeks.
-        </p>
-        -- Lars
-    </div>
     <h3>Features</h3>
     <ul>
         <li><a href="https://github.com/checkstyle/eclipse-cs/issues/39">#39 Checkstyle 8.8 released</a></li>

--- a/docs/releases.json
+++ b/docs/releases.json
@@ -1,5 +1,10 @@
 [
   {
+    "version": "Release 8.10.0",
+    "template": "partials/releases/8.10.0/release_notes.html",
+    "open": true
+  }, 
+  {
     "version": "Release 8.8.0",
     "template": "partials/releases/8.8.0/release_notes.html",
     "open": true
@@ -16,8 +21,7 @@
   }, 
   {
     "version": "Release 8.5.0",
-    "template": "partials/releases/8.5.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.5.0/release_notes.html"
   },
   {
     "version": "Release 8.0.0",

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -4,77 +4,77 @@
             http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
   <url>
     <loc>https://checkstyle.github.io/eclipse-cs/</loc>
-    <lastmod>2018-02-20T06:27:25Z</lastmod>
+    <lastmod>2018-05-12T08:01:37Z</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.github.io/eclipse-cs/#!/releasenotes</loc>
-    <lastmod>2018-02-20T06:27:25Z</lastmod>
+    <lastmod>2018-05-12T08:01:37Z</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.github.io/eclipse-cs/#!/install</loc>
-    <lastmod>2018-02-20T06:27:25Z</lastmod>
+    <lastmod>2018-05-12T08:01:37Z</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.github.io/eclipse-cs/#!/project-setup</loc>
-    <lastmod>2018-02-20T06:27:25Z</lastmod>
+    <lastmod>2018-05-12T08:01:37Z</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.github.io/eclipse-cs/#!/custom-config</loc>
-    <lastmod>2018-02-20T06:27:25Z</lastmod>
+    <lastmod>2018-05-12T08:01:37Z</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.github.io/eclipse-cs/#!/filters</loc>
-    <lastmod>2018-02-20T06:27:25Z</lastmod>
+    <lastmod>2018-05-12T08:01:37Z</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.github.io/eclipse-cs/#!/configtypes</loc>
-    <lastmod>2018-02-20T06:27:25Z</lastmod>
+    <lastmod>2018-05-12T08:01:37Z</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.github.io/eclipse-cs/#!/properties</loc>
-    <lastmod>2018-02-20T06:27:25Z</lastmod>
+    <lastmod>2018-05-12T08:01:37Z</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.github.io/eclipse-cs/#!/filesets</loc>
-    <lastmod>2018-02-20T06:27:25Z</lastmod>
+    <lastmod>2018-05-12T08:01:37Z</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.github.io/eclipse-cs/#!/preferences</loc>
-    <lastmod>2018-02-20T06:27:25Z</lastmod>
+    <lastmod>2018-05-12T08:01:37Z</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.github.io/eclipse-cs/#!/extensions</loc>
-    <lastmod>2018-02-20T06:27:25Z</lastmod>
+    <lastmod>2018-05-12T08:01:37Z</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.github.io/eclipse-cs/#!/custom-checks</loc>
-    <lastmod>2018-02-20T06:27:25Z</lastmod>
+    <lastmod>2018-05-12T08:01:37Z</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.github.io/eclipse-cs/#!/builtin-config</loc>
-    <lastmod>2018-02-20T06:27:25Z</lastmod>
+    <lastmod>2018-05-12T08:01:37Z</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.github.io/eclipse-cs/#!/custom-filters</loc>
-    <lastmod>2018-02-20T06:27:25Z</lastmod>
+    <lastmod>2018-05-12T08:01:37Z</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.github.io/eclipse-cs/#!/faq</loc>
-    <lastmod>2018-02-20T06:27:25Z</lastmod>
+    <lastmod>2018-05-12T08:01:37Z</lastmod>
     <changefreq>weekly</changefreq>
   </url>
 </urlset>

--- a/docs/update/compositeArtifacts.xml
+++ b/docs/update/compositeArtifacts.xml
@@ -5,10 +5,10 @@
     <properties size='2'>
         <property name='p2.compressed' value='true' />
         <!-- get new time w/ date +%s000 -->
-        <property name='p2.timestamp' value='201802200627' />
+        <property name='p2.timestamp' value='201805120801' />
     </properties>
     <children size='2'>
-        <child location='https://dl.bintray.com/eclipse-cs/eclipse-cs/8.8.0/' />
+        <child location='https://dl.bintray.com/eclipse-cs/eclipse-cs/8.10.0/' />
         <child location='https://sevntu-checkstyle.github.io/sevntu.checkstyle/update-site/' />
     </children>
 </repository>

--- a/docs/update/compositeContent.xml
+++ b/docs/update/compositeContent.xml
@@ -5,10 +5,10 @@
     <properties size='2'>
         <property name='p2.compressed' value='true' />
         <!-- get new time w/ date +%s000 -->
-        <property name='p2.timestamp' value='201802200627' />
+        <property name='p2.timestamp' value='201805120801' />
     </properties>
     <children size='2'>
-        <child location='https://dl.bintray.com/eclipse-cs/eclipse-cs/8.8.0/' />
+        <child location='https://dl.bintray.com/eclipse-cs/eclipse-cs/8.10.0/' />
         <child location='https://sevntu-checkstyle.github.io/sevntu.checkstyle/update-site/' />
     </children>
 </repository>

--- a/net.sf.eclipsecs-feature/feature.xml
+++ b/net.sf.eclipsecs-feature/feature.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feature version="8.8.0.qualifier"
+<feature version="8.10.0.qualifier"
       id="net.sf.eclipsecs"
       label="%feature.label"
       provider-name="%feature.provider_name"
@@ -39,33 +39,33 @@
          id="net.sf.eclipsecs.branding"
          download-size="0"
          install-size="0"
-         version="8.8.0.qualifier"
+         version="8.10.0.qualifier"
          unpack="false"/>
 
    <plugin
          id="net.sf.eclipsecs.core"
          download-size="0"
          install-size="0"
-         version="8.8.0.qualifier"
+         version="8.10.0.qualifier"
          unpack="true"/>
 
    <plugin
          id="net.sf.eclipsecs.doc"
          download-size="0"
          install-size="0"
-         version="8.8.0.qualifier"
+         version="8.10.0.qualifier"
          unpack="false"/>
 
    <plugin
          id="net.sf.eclipsecs.checkstyle"
          download-size="0"
          install-size="0"
-         version="8.8.0.qualifier"/>
+         version="8.10.0.qualifier"/>
 
    <plugin
          id="net.sf.eclipsecs.ui"
          download-size="0"
          install-size="0"
-         version="8.8.0.qualifier"/>
+         version="8.10.0.qualifier"/>
 
 </feature>

--- a/net.sf.eclipsecs-feature/pom.xml
+++ b/net.sf.eclipsecs-feature/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>net.sf.eclipsecs.parent</artifactId>
         <groupId>net.sf.eclipsecs</groupId>
-        <version>8.8.0-SNAPSHOT</version>
+        <version>8.10.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>net.sf.eclipsecs</artifactId>

--- a/net.sf.eclipsecs-updatesite/.project
+++ b/net.sf.eclipsecs-updatesite/.project
@@ -18,7 +18,6 @@
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
-		<nature>org.maven.ide.eclipse.maven2Nature</nature>
 		<nature>org.eclipse.pde.UpdateSiteNature</nature>
 	</natures>
 </projectDescription>

--- a/net.sf.eclipsecs-updatesite/category.xml
+++ b/net.sf.eclipsecs-updatesite/category.xml
@@ -3,10 +3,10 @@
    <description name="Eclipse Checkstyle Plugin" url="http://eclipse-cs.sourceforge.net/update">
       Eclipse Checkstyle Plugin Update Site
    </description>
-   <feature url="features/net.sf.eclipsecs_8.8.0.qualifier.jar" id="net.sf.eclipsecs" version="8.8.0.qualifier">
+   <feature url="features/net.sf.eclipsecs_8.10.0.qualifier.jar" id="net.sf.eclipsecs" version="8.10.0.qualifier">
       <category name="Checkstyle"/>
    </feature>
-   <feature url="features/net.sf.eclipsecs.source_8.8.0.qualifier.jar" id="net.sf.eclipsecs.source" version="8.8.0.qualifier">
+   <feature url="features/net.sf.eclipsecs.source_8.10.0.qualifier.jar" id="net.sf.eclipsecs.source" version="8.10.0.qualifier">
       <category name="Checkstyle"/>
    </feature>
    <category-def name="Checkstyle" label="Checkstyle">

--- a/net.sf.eclipsecs-updatesite/pom.xml
+++ b/net.sf.eclipsecs-updatesite/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>net.sf.eclipsecs.parent</artifactId>
         <groupId>net.sf.eclipsecs</groupId>
-        <version>8.8.0-SNAPSHOT</version>
+        <version>8.10.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>net.sf.eclipsecs-updatesite</artifactId>

--- a/net.sf.eclipsecs.branding/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.branding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Checkstyle Plug-in
 Bundle-SymbolicName: net.sf.eclipsecs.branding
-Bundle-Version: 8.8.0.qualifier
+Bundle-Version: 8.10.0.qualifier
 Bundle-Vendor: http://eclipse-cs.sf.net/
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: net.sf.eclipsecs.branding

--- a/net.sf.eclipsecs.branding/pom.xml
+++ b/net.sf.eclipsecs.branding/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>net.sf.eclipsecs.parent</artifactId>
         <groupId>net.sf.eclipsecs</groupId>
-        <version>8.8.0-SNAPSHOT</version>
+        <version>8.10.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>net.sf.eclipsecs.branding</artifactId>

--- a/net.sf.eclipsecs.checkstyle/.classpath
+++ b/net.sf.eclipsecs.checkstyle/.classpath
@@ -3,6 +3,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="metadata/"/>
-	<classpathentry exported="true" kind="lib" path="checkstyle-8.9-all.jar" sourcepath="checkstyle-checkstyle-8.9.zip"/>
+	<classpathentry exported="true" kind="lib" path="checkstyle-8.10-all.jar" sourcepath="checkstyle-checkstyle-8.10.zip"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/net.sf.eclipsecs.checkstyle/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.checkstyle/META-INF/MANIFEST.MF
@@ -2,21 +2,21 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Checkstyle Core Library
 Bundle-SymbolicName: net.sf.eclipsecs.checkstyle
-Bundle-Version: 8.8.0.qualifier
+Bundle-Version: 8.10.0.qualifier
 Bundle-Vendor: http://eclipse-cs.sf.net/
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: .,
- antlr;version="8.8.0";
+ antlr;version="8.10.0";
   uses:="antlr.collections.impl,
    antlr.collections,
    antlr.ASdebug,
    antlr.debug",
- antlr.collections;version="8.8.0";uses:=antlr,
- com.google.common.base;version="8.8.0",
- com.google.common.cache;version="8.8.0",
- com.google.common.collect;version="8.8.0",
- com.google.common.io;version="8.8.0",
+ antlr.collections;version="8.10.0";uses:=antlr,
+ com.google.common.base;version="8.10.0",
+ com.google.common.cache;version="8.10.0",
+ com.google.common.collect;version="8.10.0",
+ com.google.common.io;version="8.10.0",
  com.puppycrawl.tools.checkstyle,
  com.puppycrawl.tools.checkstyle.api;
   uses:="org.xml.sax.helpers,
@@ -44,7 +44,7 @@ Export-Package: .,
  com.puppycrawl.tools.checkstyle.filefilters,
  com.puppycrawl.tools.checkstyle.filters,
  com.puppycrawl.tools.checkstyle.utils,
- org.apache.commons.beanutils;version="8.8.0"
+ org.apache.commons.beanutils;version="8.10.0"
 Bundle-ClassPath: .,
- checkstyle-8.9-all.jar
+ checkstyle-8.10-all.jar
 Automatic-Module-Name: net.sf.eclipsecs.checkstyle

--- a/net.sf.eclipsecs.checkstyle/build.properties
+++ b/net.sf.eclipsecs.checkstyle/build.properties
@@ -1,7 +1,6 @@
 bin.includes = META-INF/,\
                .,\
                license/,\
-               checkstyle-8.9-all.jar
+               checkstyle-8.10-all.jar
 jars.compile.order = .
-source.. = metadata/
 source.. = metadata/

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/coding/checkstyle-metadata.properties
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/coding/checkstyle-metadata.properties
@@ -34,9 +34,9 @@ ExplicitInitialization.name = Explicit Initialization
 ExplicitInitialization.onlyObjectReferences = whether only explicit initializations made to null for objects should be checked
 
 FallThrough.checkLastCaseGroup = Whether we need to check last case group or not.
-FallThrough.desc               = Checks for fall through in switch  statements Finds locations where a <code>case</code> contains Java code - but lacks a <code>break, return, throw</code> or <code>continue</code> statement.<br/>\r\nThe check honores special comments to supress the warning. By default the text "fallthru", "fall through", "fallthrough", "falls through" and "fallsthrough" are recognized (case sensitive). The comment containing this words must be a one-liner and must be on the last none-empty line before the <code>case</code> triggering the warning or on the same line before the <code>case</code> (urgly, but possible).\r\n<pre>\r\nswitch (i){\r\ncase 0:\r\n    i++; // fall through\r\n\r\ncase 1:\r\n    i++;\r\n    // falls through\r\ncase 2: {\r\n    i++;\r\n}\r\n// fallthrough\r\ncase 3:\r\n    i++;\r\n/* fallthru */case 4:\r\n    i++\r\n    break;\r\n}\r\n</pre>\u0009\r\nNote: the check works in assumption that there is no unreachable code in the <code>case</code>.
+FallThrough.desc               = Checks for fall through in switch  statements Finds locations where a <code>case</code> contains Java code - but lacks a <code>break, return, throw</code> or <code>continue</code> statement.<br/>\r\nThe check honors special comments to supress the warning. By default the text "fallthru", "fall through", "fallthrough", "falls through" and "fallsthrough" are recognized (case sensitive). The comment containing this words must be a one-liner and must be on the last none-empty line before the <code>case</code> triggering the warning or on the same line before the <code>case</code> (urgly, but possible).\r\n<pre>\r\nswitch (i){\r\ncase 0:\r\n    i++; // fall through\r\n\r\ncase 1:\r\n    i++;\r\n    // falls through\r\ncase 2: {\r\n    i++;\r\n}\r\n// fallthrough\r\ncase 3:\r\n    i++;\r\n/* fallthru */case 4:\r\n    i++\r\n    break;\r\n}\r\n</pre>\u0009\r\nNote: the check works in assumption that there is no unreachable code in the <code>case</code>.
 FallThrough.name               = Fall Through
-FallThrough.reliefPattern      = Regular expression to match the relief comment that supresses the warning about a fall through.
+FallThrough.reliefPattern      = Regular expression to match the relief comment that suppresses the warning about a fall through.
 
 FinalLocalVariable.desc   = Checks that local variables that never have their values changed are declared final. The check can be configured to also check that unchanged parameters are declared final.<br/>\r\nWhen configured to check parameters, the check ignores parameters of interface methods and abstract methods.
 FinalLocalVariable.name   = Final Local Variable
@@ -56,7 +56,7 @@ IllegalCatch.desc              = Catching java.lang.Exception, java.lang.Error o
 IllegalCatch.illegalClassNames = exception class names to reject
 IllegalCatch.name              = Illegal Catch
 
-IllegalInstantiation.classes = Comma seperated list of classes that should not be instantiated.
+IllegalInstantiation.classes = Comma separated list of classes that should not be instantiated.
 IllegalInstantiation.desc    = Checks for illegal instantiations where a factory method is preferred.<br/>\r\nRationale: Depending on the project, for some classes it might be preferable to create instances through factory methods rather than calling the constructor.\r\n<p>\r\nA simple example is the java.lang.Boolean class. In order to save memory and CPU cycles, it is preferable to use the predefined constants <code>TRUE</code> and <code>FALSE</code>. Constructor invocations should be replaced by calls to <code>Boolean.valueOf()</code>.\r\n</p>\r\nSome extremely performance sensitive projects may require the use of factory methods for other classes as well, to enforce the usage of number caches or object pools.
 IllegalInstantiation.name    = Illegal Instantiation
 
@@ -102,7 +102,7 @@ MagicNumber.ignoreAnnotation = Ignore magic numbers in annotation declarations.
 MagicNumber.ignoreFieldDeclaration = Ignore magic numbers in field declarations.
 MagicNumber.constantWaiverParentToken = Token that are allowed in the AST path from the number literal to the enclosing constant definition.
 
-MissingCtor.desc = Checks that classes (except abtract one) define a ctor and don't rely on the default one.
+MissingCtor.desc = Checks that classes (except abstract one) define a constructor and don't rely on the default one.
 MissingCtor.name = Missing Constructor
 
 MissingSwitchDefault.desc = Checks that switch statement has "default" clause.<br/>\r\nRationale: It's usually a good idea to introduce a default case in every switch statement. Even if the developer is sure that all currently possible cases are covered, this should be expressed in the default branch, e.g. by using an assertion. This way the code is protected aginst later changes, e.g. introduction of new types in an enumeration type.
@@ -112,7 +112,7 @@ ModifiedControlVariable.desc = Check for ensuring that for loop control variable
 ModifiedControlVariable.name = Modified Control Variable
 ModifiedControlVariable.skipEnhancedForLoopVariable = Controls whether to check enhanced-for-loop variable.
 
-MultipleStringLiterals.allowedDuplicates       = The maximum number of occurences to allow without generating a warning
+MultipleStringLiterals.allowedDuplicates       = The maximum number of occurrences to allow without generating a warning
 MultipleStringLiterals.desc                    = Checks for multiple occurrences of the same string literal within a single file.<br/>\r\nRationale: Code duplication makes maintenance more difficult, so it can be better to replace the multiple occurrences with a constant.
 MultipleStringLiterals.ignoreOccurrenceContext = Token type names where duplicate strings are ignored even if they don't match ignoredStringsRegexp. This allows you to exclude syntactical contexts like Annotations or static initializers from the check.
 MultipleStringLiterals.ignoreStringsRegexp     = Regexp pattern for ignored strings (with quotation marks)

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/imports/checkstyle-metadata.properties
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/imports/checkstyle-metadata.properties
@@ -10,7 +10,7 @@ AvoidStaticImport.excludes = Allows for certain classes via a star notation to b
 AvoidStaticImport.name     = Avoid Static Imports
 
 IllegalImport.desc        = Checks for imports from a set of illegal packages. By default, the check rejects all <code>sun.*</code> packages since programs that contain direct calls to the sun.* packages are <a href="http://java.sun.com/products/jdk/faq/faq-sun-packages.html" target="_blank">not 100% Pure Java</a>. To reject other packages, set property <code>illegalPkgs</code> to a list of the illegal packages.
-IllegalImport.illegalPkgs = Comma (',') seperated list of illegal packages.
+IllegalImport.illegalPkgs = Comma (',') separated list of illegal packages.
 IllegalImport.name        = Illegal Imports
 IllegalImport.illegalClasses = Class names to reject, if regexp variable is not set, checks if import equals class name. If regexp variable is set, then list of class name will be interpreted as regular expressions. Note, all properties for match will be used.
 IllegalImport.regexp = Whether the <b>illegalPkgs</b> and <b>illegalClasses</b> should be interpreted as regular expressions
@@ -20,7 +20,7 @@ ImportControl.name = Import Control
 ImportControl.file = The location of the file containing the import control configuration. It can be a regular file, URL or resource path. It will try loading the path as a URL first, then as a file, and finally as a resource. 
 ImportControl.path = Regular expression of file paths to which this check should apply. Files that don't match the pattern will not be checked. The pattern will be matched against the full absolute file path. 
 
-ImportOrder.caseSensitive = whether strings comprision should be case sensitive or not
+ImportOrder.caseSensitive = whether String comparison should be case sensitive or not
 ImportOrder.desc          = Checks the ordering/grouping of imports. Ensures that groups of imports come in a specific order (e.g., java. comes first, javax. comes first, then everything else) and imports within each group are in lexicographic order. Static imports must be at the end of a group and in lexicographic order amongst themselves.
 ImportOrder.groups        = list of imports groups (every group identified by string it's started)
 ImportOrder.name          = Import Order Check

--- a/net.sf.eclipsecs.checkstyle/pom.xml
+++ b/net.sf.eclipsecs.checkstyle/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>net.sf.eclipsecs.parent</artifactId>
         <groupId>net.sf.eclipsecs</groupId>
-        <version>8.8.0-SNAPSHOT</version>
+        <version>8.10.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>net.sf.eclipsecs.checkstyle</artifactId>

--- a/net.sf.eclipsecs.core/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: Checkstyle Plug-in
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: net.sf.eclipsecs.core;singleton:=true
-Bundle-Version: 8.8.0.qualifier
+Bundle-Version: 8.10.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .,
  lib/dom4j-1.6.1.jar

--- a/net.sf.eclipsecs.core/pom.xml
+++ b/net.sf.eclipsecs.core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>net.sf.eclipsecs.parent</artifactId>
         <groupId>net.sf.eclipsecs</groupId>
-        <version>8.8.0-SNAPSHOT</version>
+        <version>8.10.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>net.sf.eclipsecs.core</artifactId>

--- a/net.sf.eclipsecs.doc/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.doc/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: eclipse-cs Plugin and Checkstyle Documentation
 Bundle-SymbolicName: net.sf.eclipsecs.doc;singleton:=true
-Bundle-Version: 8.8.0.qualifier
+Bundle-Version: 8.10.0.qualifier
 Bundle-Vendor: http://eclipse-cs.sf.net/
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: net.sf.eclipsecs.doc

--- a/net.sf.eclipsecs.doc/pom.xml
+++ b/net.sf.eclipsecs.doc/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>net.sf.eclipsecs.parent</artifactId>
         <groupId>net.sf.eclipsecs</groupId>
-        <version>8.8.0-SNAPSHOT</version>
+        <version>8.10.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>net.sf.eclipsecs.doc</artifactId>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/index.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/index.html
@@ -36,7 +36,7 @@
                     <br />
                     <small>
                         <sup>2 </sup>
-                        Latest release 8.8.0, based on Checkstyle 8.8, see
+                        Latest release 8.10.0, based on Checkstyle 8.10, see
                         <a href="#!/releasenotes">release notes</a>
                     </small>
                 </div>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releasenotes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releasenotes.html
@@ -1,6 +1,26 @@
 <div class="container" data-ng-controller="ReleaseNotesCtrl">
     <!-- <div data-google-ad=""/> -->
 
+    <div class="alert alert-info">
+        The slow rate of recent updates is owed to a shift in personal interest and how I spend my spare
+        time.
+        <p>
+            If you want to help keep this project afloat and steadily updated please send me a message or
+            <a href="https://sourceforge.net/p/eclipse-cs/discussion/274376/thread/3b44a5eb/">post to the
+                forums
+            </a>
+            .
+        </p>
+        <p>
+            Additionally activity has started to migrate the project to Github (
+            <a href="https://github.com/checkstyle/eclipse-cs">eclipse-cs Github page</a>
+            ), hoping this will make it easier for contributions.
+            Code and issue tracking have already been moved, other facilities will
+            follow over the course of the next weeks.
+        </p>
+        -- Lars
+    </div>
+
     <h1>Release notes <button class="btn btn-primary btn-sm" data-ng-click="expandAll()"><i class="fa fa-plus-square-o"
             > </i> Expand all</button></h1>
     <accordion data-close-others="false">

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.10.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.10.0/release_notes.html
@@ -1,0 +1,27 @@
+<div>
+    <p>Updates the Checkstyle core to version 8.10.</p>
+    <p>
+        Please note that this version requires
+        <strong>Java 8 as the minimum runtime environment</strong>
+        . This requires
+        you to run Eclipse on a Java 8 JVM in order to use this plugin version.
+    </p>
+    <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
+    <p>
+        Please read the
+        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+            release notes
+        </a>
+        for details on recent and potentially breaking changes in Checkstyle.
+        Checkstyle configuration files potentially
+        need to be adapted to this version.
+    </p>
+    <h3>Features</h3>
+    <ul>
+        <li><a href="https://github.com/checkstyle/eclipse-cs/issues/70">#70 Upgrade to Checkstyle 8.10</a></li>
+    </ul>
+    <h3>Bugfixes</h3>
+    <ul>
+        <li><a href="https://github.com/checkstyle/eclipse-cs/issues/48">#48 Package name check has wrong default in Sun configuration</a></li>
+    </ul>
+</div>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.5.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.5.0/release_notes.html
@@ -14,18 +14,6 @@
         </a>
         for details on recent changes in Checkstyle.
     </p>
-    <div class="alert alert-info">
-        The slow rate of recent updates is owed to a shift in personal interest and how I spend my spare
-        time.
-        <br />
-        <br />
-        If you want to help keep this project afloat and steadily updated please send me a message or post to the
-        forums
-        (https://sourceforge.net/p/eclipse-cs/discussion/274376/thread/3b44a5eb/).
-        <br />
-        <br />
-        -- Lars
-    </div>
     <h3>Bugfixes</h3>
     <ul>
         <li>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.7.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.7.0/release_notes.html
@@ -16,23 +16,4 @@
         Checkstyle configuration files potentially
         need to be adapted to this version.
     </p>
-    <div class="alert alert-info">
-        The slow rate of recent updates is owed to a shift in personal interest and how I spend my spare
-        time.
-        <p>
-            If you want to help keep this project afloat and steadily updated please send me a message or
-            <a href="https://sourceforge.net/p/eclipse-cs/discussion/274376/thread/3b44a5eb/">post to the
-                forums
-            </a>
-            .
-        </p>
-        <p>
-            Additionally activity has started to migrate the project to Github (
-            <a href="https://github.com/checkstyle/eclipse-cs">eclipse-cs Github page</a>
-            ), hoping this will make it easier for contributions.
-            Code and issue tracking have already been moved, other facilities will
-            follow over the course of the next weeks.
-        </p>
-        -- Lars
-    </div>
 </div>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.8.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.8.0/release_notes.html
@@ -16,25 +16,6 @@
         Checkstyle configuration files potentially
         need to be adapted to this version.
     </p>
-    <div class="alert alert-info">
-        The slow rate of recent updates is owed to a shift in personal interest and how I spend my spare
-        time.
-        <p>
-            If you want to help keep this project afloat and steadily updated please send me a message or
-            <a href="https://sourceforge.net/p/eclipse-cs/discussion/274376/thread/3b44a5eb/">post to the
-                forums
-            </a>
-            .
-        </p>
-        <p>
-            Additionally activity has started to migrate the project to Github (
-            <a href="https://github.com/checkstyle/eclipse-cs">eclipse-cs Github page</a>
-            ), hoping this will make it easier for contributions.
-            Code and issue tracking have already been moved, other facilities will
-            follow over the course of the next weeks.
-        </p>
-        -- Lars
-    </div>
     <h3>Features</h3>
     <ul>
         <li><a href="https://github.com/checkstyle/eclipse-cs/issues/39">#39 Checkstyle 8.8 released</a></li>

--- a/net.sf.eclipsecs.doc/src/main/resources/releases.json
+++ b/net.sf.eclipsecs.doc/src/main/resources/releases.json
@@ -1,5 +1,10 @@
 [
   {
+    "version": "Release 8.10.0",
+    "template": "partials/releases/8.10.0/release_notes.html",
+    "open": true
+  }, 
+  {
     "version": "Release 8.8.0",
     "template": "partials/releases/8.8.0/release_notes.html",
     "open": true
@@ -16,8 +21,7 @@
   }, 
   {
     "version": "Release 8.5.0",
-    "template": "partials/releases/8.5.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.5.0/release_notes.html"
   },
   {
     "version": "Release 8.0.0",

--- a/net.sf.eclipsecs.sample/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.sample/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: eclipse-cs Extension Sample Plugin
 Bundle-SymbolicName: net.sf.eclipsecs.sample;singleton:=true
-Bundle-Version: 8.8.0.qualifier
+Bundle-Version: 8.10.0.qualifier
 Require-Bundle: net.sf.eclipsecs.checkstyle,
  net.sf.eclipsecs.core,
  net.sf.eclipsecs.ui

--- a/net.sf.eclipsecs.sample/pom.xml
+++ b/net.sf.eclipsecs.sample/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>net.sf.eclipsecs.parent</artifactId>
         <groupId>net.sf.eclipsecs</groupId>
-        <version>8.8.0-SNAPSHOT</version>
+        <version>8.10.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>net.sf.eclipsecs.sample</artifactId>

--- a/net.sf.eclipsecs.target/Update version numbers.launch
+++ b/net.sf.eclipsecs.target/Update version numbers.launch
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
+<booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
+<stringAttribute key="M2_GOALS" value="tycho-versions:set-version -DnewVersion=&quot;8.10.0-SNAPSHOT&quot;"/>
+<booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
+<booleanAttribute key="M2_OFFLINE" value="false"/>
+<stringAttribute key="M2_PROFILES" value=""/>
+<listAttribute key="M2_PROPERTIES"/>
+<stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
+<booleanAttribute key="M2_SKIP_TESTS" value="false"/>
+<intAttribute key="M2_THREADS" value="1"/>
+<booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
+<stringAttribute key="M2_USER_SETTINGS" value=""/>
+<booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+<stringAttribute key="org.eclipse.debug.core.ATTR_REFRESH_SCOPE" value="${workspace}"/>
+<listAttribute key="org.eclipse.debug.ui.favoriteGroups">
+<listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${git_work_tree:/net.sf.eclipsecs.core}"/>
+</launchConfiguration>

--- a/net.sf.eclipsecs.target/pom.xml
+++ b/net.sf.eclipsecs.target/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>net.sf.eclipsecs.parent</artifactId>
         <groupId>net.sf.eclipsecs</groupId>
-        <version>8.8.0-SNAPSHOT</version>
+        <version>8.10.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>net.sf.eclipsecs.target</artifactId>

--- a/net.sf.eclipsecs.ui/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Checkstyle Ui Plug-in
 Bundle-SymbolicName: net.sf.eclipsecs.ui;singleton:=true
-Bundle-Version: 8.8.0.qualifier
+Bundle-Version: 8.10.0.qualifier
 Bundle-Vendor: http://eclipse-cs.sf.net/
 Bundle-Activator: net.sf.eclipsecs.ui.CheckstyleUIPlugin
 Bundle-ActivationPolicy: lazy

--- a/net.sf.eclipsecs.ui/pom.xml
+++ b/net.sf.eclipsecs.ui/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>net.sf.eclipsecs.parent</artifactId>
         <groupId>net.sf.eclipsecs</groupId>
-        <version>8.8.0-SNAPSHOT</version>
+        <version>8.10.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>net.sf.eclipsecs.ui</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.sf.eclipsecs</groupId>
     <artifactId>net.sf.eclipsecs.parent</artifactId>
-    <version>8.8.0-SNAPSHOT</version>
+    <version>8.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>eclipse-cs Maven Parent</name>
 


### PR DESCRIPTION
* upgrade core library
* create release notes
* upgrade version numbers
* moved alert message of Lars out of each version, now on top of release
notes
* typo fixes in metadata
* packaged and updated documentation

There haven't been any changes in checkstyle/xdocs mentioning a newly
introduced config element since 8.6, so it seems safe to assume there
are no metadata changes.