### PR TITLE
fix wrong button label

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/messages.properties
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/messages.properties
@@ -136,7 +136,7 @@ CheckstylePreferencePage_msgRebuild = Some projects need to be rebuilt for the c
 
 CheckstylePreferencePage_nagRebuild = Don't ask me again
 
-CheckstylePreferencePage_titleCantDelete = Cant Delete
+CheckstylePreferencePage_titleCantDelete = Can't Delete
 
 CheckstylePreferencePage_titleCheckConfigs = Global Check Configurations
 
@@ -225,7 +225,7 @@ FileMatchPatternEditDialog_lblRegex = Match Regular Expression:
 
 FileMatchPatternEditDialog_message = Use Ctrl+Space for content assist.
 
-FileMatchPatternEditDialog_title = Input a file matching  regular expression pattern
+FileMatchPatternEditDialog_title = Input a file matching regular expression pattern
 
 FileMatchPatternEditDialog_titleRegexEditor = Checkstyle Regular Expression Editor
 
@@ -239,7 +239,7 @@ FileSetEditDialog_btnEdit = Edit...
 
 FileSetEditDialog_btnRemove = Remove
 
-FileSetEditDialog_btnUp = \\ Up
+FileSetEditDialog_btnUp = Up
 
 FileSetEditDialog_colInclude = Include
 
@@ -386,7 +386,7 @@ SimpleFileSetsEditor_nameAllFileset = all
 SimpleFileSetsEditor_titleSimpleConfig = Simple - use the following check configuration for all files
 PropertiesContentAssistProcessor_configLoc=Maps to the directory the configuration file lies in.
 ActivateProjectsPrintAction_msgActivateSelectedProjects=Activate Checkstyle for selected projects...
-DeactivateProjectsPrintAction_msgDeactivateSelectedProjects=Dectivate Checkstyle...
+DeactivateProjectsPrintAction_msgDeactivateSelectedProjects=Deactivate Checkstyle...
 ConfigureProjectFromBluePrintAction_msgSelectBlueprintProject=Select blueprint project for the Checkstyle configuration of the selected projects
 ConfigureProjectFromBluePrintAction_titleSelectBlueprintProject=Select blueprint project
 ConfigureProjectFromBluePrintAction_msgConfiguringFromBluePrint=Configuring projects from blueprint


### PR DESCRIPTION
The "Up" button in the enhanced configuration is labeled "\ Up"
accidentally. Also fix some other typos in the same file.