### PR TITLE
allow parallel building with checkstyle

### DIFF
--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/CheckstyleBuilder.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/CheckstyleBuilder.java
@@ -54,6 +54,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.osgi.util.NLS;
 
 /**
@@ -206,7 +207,7 @@ public class CheckstyleBuilder extends IncrementalProjectBuilder {
    * Builds the selected resources.
    *
    * @param resources
-   *          the resourcesto build
+   *          the resources to build
    * @param configuration
    *          the project configuration
    * @param monitor
@@ -415,4 +416,8 @@ public class CheckstyleBuilder extends IncrementalProjectBuilder {
     return resources;
   }
 
+  @Override
+  public ISchedulingRule getRule(int kind, Map<String, String> args) {
+    return getProject();
+  }
 }


### PR DESCRIPTION
Since Eclipse Photon or Oxygen users can enable parallel building of the
workspace. However, parallel building requires all existing project
builders to implement a useful scheduling rule. If builders don't
implement that method, they automatically lock the workspace root.

A simple and still safe implementation for checkstyle is to lock only
the currently analyzed project. That allows all other builders to run on
the remaining projects in parallel.

See https://de.slideshare.net/mickaelistria/parallel-builds-in-eclipse-ide-workspace
for more technical background.