### PR TITLE
update Maven plugins

### DIFF
--- a/net.sf.eclipsecs.target/Maven update check.launch
+++ b/net.sf.eclipsecs.target/Maven update check.launch
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
+<booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
+<stringAttribute key="M2_GOALS" value="versions:display-dependency-updates versions:display-plugin-updates"/>
+<booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
+<booleanAttribute key="M2_OFFLINE" value="false"/>
+<stringAttribute key="M2_PROFILES" value=""/>
+<listAttribute key="M2_PROPERTIES"/>
+<stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
+<booleanAttribute key="M2_SKIP_TESTS" value="false"/>
+<intAttribute key="M2_THREADS" value="1"/>
+<booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
+<stringAttribute key="M2_USER_SETTINGS" value=""/>
+<booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${git_work_tree:/net.sf.eclipsecs.core}"/>
+</launchConfiguration>

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
     </modules>
 
     <properties>
-        <tycho-version>1.0.0</tycho-version>
-        <tycho-extras-version>1.0.0</tycho-extras-version>
+        <tycho-version>1.3.0</tycho-version>
+        <tycho-extras-version>1.3.0</tycho-extras-version>
         <tycho.scmUrl>scm:git:git://github.com:checkstyle/eclipse-cs.git</tycho.scmUrl>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -205,7 +205,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.20.1</version>
+                    <version>2.22.1</version>
                     <executions>
                         <execution>
                             <id>test</id>
@@ -223,7 +223,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.8.0</version>
                     <executions>
                         <execution>
                             <id>compiletests</id>


### PR DESCRIPTION
Update all the Maven plugins which have a fixed version. To simplify the
check for Maven updates in the future, a new shared launch config for
Eclipse has been added.

Still, some standard Maven plugins (and Maven itself) are not versioned,
which can lead to different build results, and should be changed.