### PR TITLE
Fix #120: checkstyle version in preferences

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/Messages.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/Messages.java
@@ -174,6 +174,8 @@ public final class Messages extends NLS {
 
   public static String CheckstylePreferencePage_txtSuggestRebuild;
 
+  public static String CheckstylePreferencePage_version;
+
   public static String CheckstylePropertyPage_btnActivateCheckstyle;
 
   public static String CheckstylePropertyPage_btnChangeFilter;

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/messages.properties
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/messages.properties
@@ -148,6 +148,7 @@ CheckstylePreferencePage_titleRebuild = Rebuild suggested
 
 CheckstylePreferencePage_txtSuggestRebuild = Note: Changes to this option only become visible\nafter a full rebuild of your projects.
 
+CheckstylePreferencePage_version = The plugin uses Checkstyle version {0}.
 CheckstylePropertyPage_btnActivateCheckstyle = Checkstyle active for this project
 
 CheckstylePropertyPage_btnChangeFilter = Change...

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/preferences/CheckstylePreferencePage.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/preferences/CheckstylePreferencePage.java
@@ -20,7 +20,9 @@
 
 package net.sf.eclipsecs.ui.preferences;
 
+import java.net.URL;
 import java.util.Collection;
+import java.util.Enumeration;
 
 import net.sf.eclipsecs.core.CheckstylePluginPrefs;
 import net.sf.eclipsecs.core.builder.CheckerFactory;
@@ -36,6 +38,7 @@ import net.sf.eclipsecs.ui.config.CheckConfigurationWorkingSetEditor;
 import net.sf.eclipsecs.ui.util.SWTUtil;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialogWithToggle;
 import org.eclipse.jface.preference.PreferencePage;
@@ -57,7 +60,10 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
+import org.osgi.framework.Bundle;
 import org.osgi.service.prefs.BackingStoreException;
+
+import com.puppycrawl.tools.checkstyle.Main;
 
 /**
  * This class represents a preference page that is contributed to the Preferences dialog. By
@@ -102,10 +108,15 @@ public class CheckstylePreferencePage extends PreferencePage implements IWorkben
    */
   public CheckstylePreferencePage() {
     super();
+    setDescription(NLS.bind(Messages.CheckstylePreferencePage_version, getCheckstyleVersion()));
     setPreferenceStore(CheckstyleUIPlugin.getDefault().getPreferenceStore());
 
     mWorkingSet = CheckConfigurationFactory.newWorkingSet();
     initializeDefaults();
+  }
+
+  private String getCheckstyleVersion() {
+    return Main.class.getPackage().getImplementationVersion();
   }
 
   /**


### PR DESCRIPTION
Show the version as the preference page "description" field. The displayed version is the one of the embedded JAR, independent of the version of the Eclipse plugin (e.g. for the current plugin version 8.12 it shows 8.13 correctly).

![2018-12-29_15h50_05](https://user-images.githubusercontent.com/406876/50539504-acd77980-0b81-11e9-8dc1-7c1b9e0aba86.png)
