### PR TITLE
Have separate test classpath in Eclipse

### DIFF
--- a/net.sf.eclipsecs.checkstyle/.classpath
+++ b/net.sf.eclipsecs.checkstyle/.classpath
@@ -8,7 +8,11 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="metadata"/>
-	<classpathentry kind="src" path="test"/>
+	<classpathentry kind="src" output="target/test-classes" path="test">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/net.sf.eclipsecs.checkstyle/build.properties
+++ b/net.sf.eclipsecs.checkstyle/build.properties
@@ -3,4 +3,5 @@ bin.includes = META-INF/,\
                license/,\
                checkstyle-8.13-all.jar
 jars.compile.order = .
-source.. = metadata/
+source.. = metadata/,\
+           test/

--- a/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/ChecksTest.java
+++ b/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/ChecksTest.java
@@ -51,7 +51,7 @@ public class ChecksTest {
 
   private static void validateEclipseCsMetaXmlFile(File file, String packge,
           Set<Class<?>> packgeModules) throws Exception {
-    Assert.assertTrue("'checkstyle-metadata.xml' must exist in eclipsecs in inside " + packge,
+    Assert.assertTrue("'checkstyle-metadata.xml' must exist in eclipsecs inside " + packge,
             file.exists());
 
     final String input = new String(Files.readAllBytes(file.toPath()), UTF_8);

--- a/net.sf.eclipsecs.ui/.classpath
+++ b/net.sf.eclipsecs.ui/.classpath
@@ -7,7 +7,11 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="test"/>
+	<classpathentry kind="src" output="target/test-classes" path="test">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry exported="true" kind="lib" path="lib/jfreechart-1.0.14.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/jfreechart-1.0.14-swt.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/jcommon-1.0.16.jar"/>

--- a/net.sf.eclipsecs.ui/build.properties
+++ b/net.sf.eclipsecs.ui/build.properties
@@ -9,7 +9,7 @@ bin.includes = icons/,\
                lib/jfreechart-1.0.14.jar,\
                lib/jcommon-1.0.16.jar
 jars.compile.order = .
-source.. = src/
-source.. = src/
+source.. = src/,\
+           test/
 additional.bundles = org.eclipse.jdt.core,\
                      org.eclipse.core.runtime


### PR DESCRIPTION
Maven has separate classpaths for main and test code. Eclipse supports
the same separation since Photon:
https://www.eclipse.org/eclipse/news/4.8/jdt.php. This change enables
classpath separation in Eclipse by marking test sources as such. It
avoids accidental usage of test related classes from main code.

The change is downwards compatible, so development with an older Eclipse
version still works fine.