### PR TITLE
Fix some checkstyle violations

### DIFF
--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
@@ -416,10 +416,8 @@ public class Auditor {
      *          the audit error
      * @param markerAttributes
      *          the marker attributes
-     * @throws CoreException
      */
-    private void calculateMarkerOffset(AuditEvent error, Map<String, Object> markerAttributes)
-            throws CoreException {
+    private void calculateMarkerOffset(AuditEvent error, Map<String, Object> markerAttributes) {
 
       // lazy create the document for the current file
       if (mDocument == null) {

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckstyleConfigurationFile.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckstyleConfigurationFile.java
@@ -124,7 +124,7 @@ public class CheckstyleConfigurationFile {
    * Returns the resolved URL of the Checkstyle configuration file. Clients are expected to
    * <b>not</b> use this to access the underlying Checkstyle configuration file
    * 
-   * @return the resolved URL.
+   * @return the resolved URL
    */
   public URL getResolvedConfigFileURL() {
     return mResolvedConfigFileURL;

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ConfigurationType.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ConfigurationType.java
@@ -197,6 +197,7 @@ public abstract class ConfigurationType implements IConfigurationType {
    * @throws IOException
    *           error creating the property resolver
    * @throws URISyntaxException
+   *           if configuration file URL cannot be resolved
    */
   protected PropertyResolver getPropertyResolver(ICheckConfiguration config,
           CheckstyleConfigurationFile configFile) throws IOException, URISyntaxException {

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/FilesOlderThanOneDayFilter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/FilesOlderThanOneDayFilter.java
@@ -4,22 +4,22 @@ import org.eclipse.core.resources.IFile;
 
 public class FilesOlderThanOneDayFilter extends AbstractFilter {
 
-	private static final long MILLIS_IN_24_HOURS = 1000 * 60 * 60 * 24;
+  private static final long MILLIS_IN_24_HOURS = 1000 * 60 * 60 * 24;
 
-	@Override
-	public boolean accept(Object o) {
-		boolean goesThrough = true;
+  @Override
+  public boolean accept(Object o) {
+    boolean goesThrough = true;
 
-		if (o instanceof IFile) {
-			IFile file = (IFile) o;
-			if ((System.currentTimeMillis() - file.getLocalTimeStamp()) < MILLIS_IN_24_HOURS) {
-				goesThrough = true;
-			} else {
-				goesThrough = false;
-			}
-		}
+    if (o instanceof IFile) {
+      IFile file = (IFile) o;
+      if ((System.currentTimeMillis() - file.getLocalTimeStamp()) < MILLIS_IN_24_HOURS) {
+        goesThrough = true;
+      } else {
+        goesThrough = false;
+      }
+    }
 
-		return goesThrough;
-	}
+    return goesThrough;
+  }
 
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/CheckFileOnOpenPartListener.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/CheckFileOnOpenPartListener.java
@@ -69,7 +69,7 @@ import org.eclipse.ui.part.FileEditorInput;
  * PartListener implementation that listens for opening editor parts and runs Checkstyle on the
  * opened file if the UnOpenedFileFilter is active.
  *
- * @see https://sourceforge.net/p/eclipse-cs/feature-requests/93/
+ * @see <a href="https://sourceforge.net/p/eclipse-cs/feature-requests/93/">feature request</a>
  * @author Lars Ködderitzsch
  */
 public class CheckFileOnOpenPartListener implements IPartListener2 {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/marker/CheckstyleMarkerPropertyTester.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/marker/CheckstyleMarkerPropertyTester.java
@@ -23,7 +23,7 @@ public class CheckstyleMarkerPropertyTester extends PropertyTester {
     } catch (CoreException e) {
       CheckstyleLog.log(e);
     }
-    
+
     return false;
   }
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnQuickfix.java
@@ -52,7 +52,6 @@ import org.eclipse.swt.graphics.Image;
 /**
  * Quickfix implementation which simplifies a boolean if/return statement. It transforms an if
  * statement like
- *
  * <pre>
  * if (condition) {
  *   return true;
@@ -60,9 +59,7 @@ import org.eclipse.swt.graphics.Image;
  *   return false;
  * }
  * </pre>
- *
  * into a return statement like
- *
  * <pre>
  * return condition;
  * </pre>
@@ -72,7 +69,7 @@ import org.eclipse.swt.graphics.Image;
 public class SimplifyBooleanReturnQuickfix extends AbstractASTResolution {
 
   /**
-   * If the condition is of one of these expression types, the parantheses are not necessary when
+   * If the condition is of one of these expression types, the parentheses are not necessary when
    * negated. I.e the replacement can be written as <code>!condition</code> instead of
    * <code>!(condition)</code>.
    */

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilter.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilter.java
@@ -466,6 +466,7 @@ public class CheckstyleMarkerFilter implements Cloneable {
    * @param mon
    *          the progress monitor
    * @throws CoreException
+   *           if the resource does not exist or the project is not open
    */
   private List<IMarker> findCheckstyleMarkers(IResource[] resources, int depth, IProgressMonitor mon)
           throws CoreException {


### PR DESCRIPTION
This fixes the checkstyle violations that only have a small number of
occurrences:
* wrong Javadoc see tag
* not commented throws javadoc tags
* tabs versus space