### PR TITLE
unify and simplify branding

### DIFF
--- a/net.sf.eclipsecs.branding/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.branding/META-INF/MANIFEST.MF
@@ -1,8 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Eclipse Checkstyle Plug-in
+Bundle-Name: Eclipse Checkstyle Branding
 Bundle-SymbolicName: net.sf.eclipsecs.branding
 Bundle-Version: 8.12.0.qualifier
-Bundle-Vendor: Eclipse Checkstyle Plugin Development Team
+Bundle-Vendor: Eclipse Checkstyle Project
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: net.sf.eclipsecs.branding

--- a/net.sf.eclipsecs.branding/about.properties
+++ b/net.sf.eclipsecs.branding/about.properties
@@ -1,6 +1,6 @@
-aboutText=Eclipse Checkstyle Plugin {featureVersion}\n\
+aboutText=Eclipse Checkstyle {featureVersion}\n\
 \n\
-Checkstyle integration plugin for Eclipse, distributed under the terms of the GNU Lesser General Public License 2.1.\n\
+Checkstyle integration for Eclipse, distributed under the terms of the GNU Lesser General Public License 2.1.\n\
 Visit http://checkstyle.org/eclipse-cs/ for updates, documentation and support.\n\
 \n\
 (c) Copyright David Schneider, Lars K\u00f6dderitzsch and others, 2002-2018\n\
@@ -8,5 +8,4 @@ This software includes the following 3rd-party libraries:\n\
 Checkstyle, licensed under LGPL 2.1. Visit http://checkstyle.org/\n\
 Jakarta Commons Lang/IO, licensed under APL 2.0. Visit http://commons.apache.org/\n\
 DOM4J, licensed under BSD. Visit http://sourceforge.net/projects/dom4j/\n\
-iText, licensed under Affero General Public License. Visit http://itextpdf.com/\n\
 JFreeChart, licensed under LGPL 3. Visit http://www.jfree.org/jfreechart/

--- a/net.sf.eclipsecs.checkstyle/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.checkstyle/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Checkstyle Core Library
+Bundle-Name: Checkstyle Library
 Bundle-SymbolicName: net.sf.eclipsecs.checkstyle
 Bundle-Version: 8.12.0.qualifier
-Bundle-Vendor: Eclipse Checkstyle Plugin Development Team
+Bundle-Vendor: Eclipse Checkstyle Project
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: .,

--- a/net.sf.eclipsecs.core/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.core/META-INF/MANIFEST.MF
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
-Bundle-Name: Checkstyle Plug-in
+Bundle-Name: Eclipse Checkstyle
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: net.sf.eclipsecs.core;singleton:=true
 Bundle-Version: 8.12.0.qualifier
@@ -8,7 +8,7 @@ Bundle-ClassPath: .,
  lib/dom4j-1.6.1.jar
 Bundle-Activator: net.sf.eclipsecs.core.CheckstylePlugin
 Bundle-ActivationPolicy: lazy
-Bundle-Vendor: Eclipse Checkstyle Plugin Development Team
+Bundle-Vendor: Eclipse Checkstyle Project
 Require-Bundle: net.sf.eclipsecs.checkstyle;visibility:=reexport
 Eclipse-BuddyPolicy: registered
 Bundle-Localization: core

--- a/net.sf.eclipsecs.doc/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.doc/META-INF/MANIFEST.MF
@@ -1,8 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: eclipse-cs Plugin and Checkstyle Documentation
+Bundle-Name: Eclipse Checkstyle Documentation
 Bundle-SymbolicName: net.sf.eclipsecs.doc;singleton:=true
 Bundle-Version: 8.12.0.qualifier
-Bundle-Vendor: Eclipse Checkstyle Plugin Development Team
+Bundle-Vendor: Eclipse Checkstyle Project
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: net.sf.eclipsecs.doc

--- a/net.sf.eclipsecs.sample/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.sample/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: eclipse-cs Extension Sample Plugin
+Bundle-Name: Eclipse Checkstyle Extension Sample
 Bundle-SymbolicName: net.sf.eclipsecs.sample;singleton:=true
 Bundle-Version: 8.12.0.qualifier
 Require-Bundle: net.sf.eclipsecs.checkstyle,
@@ -8,7 +8,7 @@ Require-Bundle: net.sf.eclipsecs.checkstyle,
  net.sf.eclipsecs.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
-Bundle-Vendor: Eclipse Checkstyle Plugin Development Team
+Bundle-Vendor: Eclipse Checkstyle Project
 Import-Package: org.eclipse.core.resources,
  org.eclipse.jdt.core.dom,
  org.eclipse.jface.resource,

--- a/net.sf.eclipsecs.ui/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.ui/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Eclipse Checkstyle Ui Plug-in
+Bundle-Name: Eclipse Checkstyle UI
 Bundle-SymbolicName: net.sf.eclipsecs.ui;singleton:=true
 Bundle-Version: 8.12.0.qualifier
-Bundle-Vendor: Eclipse Checkstyle Plugin Development Team
+Bundle-Vendor: Eclipse Checkstyle Project
 Bundle-Activator: net.sf.eclipsecs.ui.CheckstyleUIPlugin
 Bundle-ActivationPolicy: lazy
 Require-Bundle: net.sf.eclipsecs.core,


### PR DESCRIPTION
* Looking at the plugins list of the checkstyle feature shows a wild mix
of plugin names. Therefore make them more unique and more simple. Also
shorten the provider name, since it isn't displayed nicely in the
Eclipse UI due to its size.
* Also remove "plugin" from the branding. That word doesn't add any
information and is even confusing, when being used for a feature name.
* Remove iText from components mentioned on about page, that library is
not used in current code.