### PR TITLE
Fix the Checkstyle nature name

### DIFF
--- a/net.sf.eclipsecs.core/core.properties
+++ b/net.sf.eclipsecs.core/core.properties
@@ -4,7 +4,7 @@ CheckstyleBuilder.name = Checkstyle Builder
 
 CheckstyleMarker.name = Checkstyle Problem
 
-CheckstyleNature.name = CheckstyleNature
+CheckstyleNature.name = Checkstyle
 
 ExternalFileCheckConfiguration.label = External Configuration File
 


### PR DESCRIPTION
In recent Eclipse versions, project natures can be seen in the project
properties on the "Project natures" tab. Projects with enabled
Checkstyle list "CheckstyleNature" there. This change fixes the label.
This has no impact on the nature id and all the code testing for that
nature id.