### PR TITLE
Focus name field in configuration editor

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/BuiltInConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/BuiltInConfigurationEditor.java
@@ -37,7 +37,7 @@ import org.eclipse.swt.widgets.Text;
 /**
  * Implementation of a location editor with only a not editable text field. This
  * is used to just show the location.
- * 
+ *
  * @author Lars Ködderitzsch
  */
 public class BuiltInConfigurationEditor implements ICheckConfigurationEditor {
@@ -93,6 +93,7 @@ public class BuiltInConfigurationEditor implements ICheckConfigurationEditor {
     mConfigName.setEditable(false);
     gd = new GridData(GridData.FILL_HORIZONTAL);
     mConfigName.setLayoutData(gd);
+    mConfigName.setFocus();
 
     Label lblConfigLocation = new Label(contents, SWT.NULL);
     lblConfigLocation.setText(Messages.CheckConfigurationPropertiesDialog_lblLocation);

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ExternalFileConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ExternalFileConfigurationEditor.java
@@ -117,6 +117,7 @@ public class ExternalFileConfigurationEditor implements ICheckConfigurationEdito
     mConfigName = new Text(contents, SWT.LEFT | SWT.SINGLE | SWT.BORDER);
     gd = new GridData(GridData.FILL_HORIZONTAL);
     mConfigName.setLayoutData(gd);
+    mConfigName.setFocus();
 
     Label lblConfigLocation = new Label(contents, SWT.NULL);
     lblConfigLocation.setText(Messages.CheckConfigurationPropertiesDialog_lblLocation);

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ICheckConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ICheckConfigurationEditor.java
@@ -30,14 +30,14 @@ import org.eclipse.swt.widgets.Shell;
 
 /**
  * Interface for the check configuration type specific location editor.
- * 
+ *
  * @author Lars Ködderitzsch
  */
 public interface ICheckConfigurationEditor {
 
   /**
    * Initializes the configuration editor with its properties.
-   * 
+   *
    * @param checkConfiguration
    *          the working copy
    * @param dialog
@@ -49,7 +49,7 @@ public interface ICheckConfigurationEditor {
   /**
    * Create the editor control. This method is always called after the
    * initialize method.
-   * 
+   *
    * @param parent
    *          the parent composite
    * @param shell
@@ -60,10 +60,10 @@ public interface ICheckConfigurationEditor {
 
   /**
    * Returns the edited working copy.
-   * 
+   *
    * @return the edited working copy
    * @throws CheckstylePluginException
-   *           an validation error occured when setting the editor data to the
+   *           a validation error occurred when setting the editor data to the
    *           working copy
    */
   CheckConfigurationWorkingCopy getEditedWorkingCopy() throws CheckstylePluginException;

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ProjectConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ProjectConfigurationEditor.java
@@ -139,6 +139,7 @@ public class ProjectConfigurationEditor implements ICheckConfigurationEditor {
     mConfigName = new Text(contents, SWT.LEFT | SWT.SINGLE | SWT.BORDER);
     gd = new GridData(GridData.FILL_HORIZONTAL);
     mConfigName.setLayoutData(gd);
+    mConfigName.setFocus();
 
     Label lblConfigLocation = new Label(contents, SWT.NULL);
     lblConfigLocation.setText(Messages.CheckConfigurationPropertiesDialog_lblLocation);

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/RemoteConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/RemoteConfigurationEditor.java
@@ -109,6 +109,7 @@ public class RemoteConfigurationEditor implements ICheckConfigurationEditor {
     mConfigName = new Text(contents, SWT.LEFT | SWT.SINGLE | SWT.BORDER);
     gd = new GridData(GridData.FILL_HORIZONTAL);
     mConfigName.setLayoutData(gd);
+    mConfigName.setFocus();
 
     Label lblConfigLocation = new Label(contents, SWT.NULL);
     lblConfigLocation.setText(Messages.CheckConfigurationPropertiesDialog_lblLocation);


### PR DESCRIPTION
When a configuration editor is opened, no control has the focus.
Keyboard users must explicitly use tab for being able to input
something. Let us always focus the name input field instead.

Unfortunately the name field is implemented 5 times in 5 different
configuration editors, therefore the same change is applied 5 times.

![image](https://user-images.githubusercontent.com/406876/57125537-1236b380-6d8a-11e9-9043-6f9ee5b61e65.png)
