### PR TITLE
Select newly created configurations

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationWorkingSetEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationWorkingSetEditor.java
@@ -235,10 +235,10 @@ public class CheckConfigurationWorkingSetEditor {
       fd.bottom = new FormAttachment(100);
       mUsageView.getControl().setLayoutData(fd);
     }
-    
+
     // enforce update of button enabled state
     mController.selectionChanged(new SelectionChangedEvent(mViewer, new StructuredSelection()));
-    
+
     return configComposite;
   }
 
@@ -481,6 +481,7 @@ public class CheckConfigurationWorkingSetEditor {
 
       mViewer.setInput(mWorkingSet.getWorkingCopies());
       mViewer.refresh(true);
+      mViewer.setSelection(new StructuredSelection(newConfig));
     }
   }
 


### PR DESCRIPTION
After creating a new configuration, the user cannot immediately
configure it, because the new configuration is not selected in the table
of existing configurations (and therefore all the related buttons are
disabled).

This change automatically selects the newly created configuration, and
therefore users can immediately use the "Configure" button.

![image](https://user-images.githubusercontent.com/406876/57125727-b1f44180-6d8a-11e9-9e8a-f29f8d12de7f.png)
