### PR TITLE
Hint with rule name for suppression

### DIFF
--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/RuleMetadata.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/RuleMetadata.java
@@ -32,7 +32,7 @@ import net.sf.eclipsecs.core.config.Severity;
  */
 public class RuleMetadata {
 
-  /** The diplay name of the module. */
+  /** The display name of the module. */
   private final String mName;
 
   /** The internal name of the module. */

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/Messages.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/Messages.java
@@ -493,6 +493,8 @@ public final class Messages extends NLS {
   
   public static String MarkerPropertyPage_Module;
 
+  public static String MarkerPropertyPage_SuppressionHint;
+
   public static String MarkerPropertyPage_Group;
 
   public static String MarkerPropertyPage_Description;

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/messages.properties
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/messages.properties
@@ -439,4 +439,5 @@ MarkerPropertyPage_Issue=Issue:
 MarkerPropertyPage_Module=Module:
 MarkerPropertyPage_Group=Group:
 MarkerPropertyPage_Description=Description:
+MarkerPropertyPage_SuppressionHint=For suppression comments use "{0}"
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/marker/MarkerPropertyPage.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/marker/MarkerPropertyPage.java
@@ -3,11 +3,13 @@ package net.sf.eclipsecs.ui.properties.marker;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.resource.JFaceResources;
+import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
@@ -63,7 +65,22 @@ public class MarkerPropertyPage extends PropertyPage {
       new Label(composite, SWT.NONE).setImage(
               CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.MODULE_ICON));
       new Label(composite, SWT.NONE).setText(Messages.MarkerPropertyPage_Module);
-      new Label(composite, SWT.NONE).setText(metaData.getRuleName());
+
+      RowLayout rowLayout = new RowLayout(SWT.HORIZONTAL);
+      rowLayout.marginLeft = 0;
+      rowLayout.marginTop = 0;
+      rowLayout.marginBottom = 0;
+      rowLayout.marginRight = 0;
+      Composite nameComposite = new Composite(composite, SWT.NONE);
+      nameComposite.setLayout(rowLayout);
+      
+      new Label(nameComposite, SWT.NONE).setText(metaData.getRuleName());
+
+      Label helpIcon = new Label(nameComposite, SWT.NONE);
+      helpIcon.setImage(
+              CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.HELP_ICON));
+      helpIcon.setToolTipText(NLS.bind(Messages.MarkerPropertyPage_SuppressionHint, 
+              metaData.getInternalName()));
 
       Label descriptionLabel = new Label(composite, SWT.NONE);
       descriptionLabel.setText(Messages.MarkerPropertyPage_Description);


### PR DESCRIPTION
from #110

In the marker properties dialog have a hint showing the internal rule
name. While the human readable name is useful to locate a check in the
configuration dialog, the internal rule name is needed to create
suppression comments.