### PR TITLE
remove "Branding" from feature name in about dialog

### DIFF
--- a/net.sf.eclipsecs.branding/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.branding/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Eclipse Checkstyle Branding
+Bundle-Name: Eclipse Checkstyle
 Bundle-SymbolicName: net.sf.eclipsecs.branding
 Bundle-Version: 8.27.0.qualifier
 Bundle-Vendor: Eclipse Checkstyle Project


### PR DESCRIPTION
If an Eclipse feature specifies a branding plugin, then the icon, name
and some other meta data of that plugin are shown as "branding" of the
feature in the Eclipse about dialog. Therefore that specific plugin
should not be called "... branding".

Without this change, the about dialog shows the following: 
![image](https://user-images.githubusercontent.com/406876/71669829-52619200-2d6e-11ea-9a8b-6d051e2f159c.png)


