### PR TITLE
fix test classpath

### DIFF
--- a/.settings/org.eclipse.core.runtime.prefs
+++ b/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/net.sf.eclipsecs-feature/.settings/org.eclipse.core.runtime.prefs
+++ b/net.sf.eclipsecs-feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/net.sf.eclipsecs-updatesite/.settings/org.eclipse.core.runtime.prefs
+++ b/net.sf.eclipsecs-updatesite/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/net.sf.eclipsecs.branding/.settings/org.eclipse.core.runtime.prefs
+++ b/net.sf.eclipsecs.branding/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/net.sf.eclipsecs.checkstyle/.classpath
+++ b/net.sf.eclipsecs.checkstyle/.classpath
@@ -8,7 +8,11 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="metadata"/>
-	<classpathentry kind="src" path="test"/>
+	<classpathentry kind="src" output="target/test-classes" path="test">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/net.sf.eclipsecs.checkstyle/.settings/org.eclipse.core.runtime.prefs
+++ b/net.sf.eclipsecs.checkstyle/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/net.sf.eclipsecs.core/.settings/org.eclipse.core.runtime.prefs
+++ b/net.sf.eclipsecs.core/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/net.sf.eclipsecs.doc/.settings/org.eclipse.core.runtime.prefs
+++ b/net.sf.eclipsecs.doc/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/net.sf.eclipsecs.sample/.settings/org.eclipse.core.runtime.prefs
+++ b/net.sf.eclipsecs.sample/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/net.sf.eclipsecs.target/.settings/org.eclipse.core.runtime.prefs
+++ b/net.sf.eclipsecs.target/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/net.sf.eclipsecs.ui/.classpath
+++ b/net.sf.eclipsecs.ui/.classpath
@@ -7,7 +7,11 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="test"/>
+	<classpathentry kind="src" output="target/test-classes" path="test">
+		<attributes>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry exported="true" kind="lib" path="lib/jfreechart-1.0.19.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/jfreechart-1.0.19-swt.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/jcommon-1.0.23.jar"/>

--- a/net.sf.eclipsecs.ui/.settings/org.eclipse.core.runtime.prefs
+++ b/net.sf.eclipsecs.ui/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n


### PR DESCRIPTION
Two of the bundles contain nested tests. However, those have never been
available in Eclipse itself (only in Maven), since they are not on the
classpath of the plugins.

With this change the tests are shown as a separate test source folder
and can be run directly from eclipse. Also potential compiler errors in tests will now be visible immediately (while they were only visible in the maven build output before).

It is not possible to accidentally mix test and main sources, because Eclipse has a main/test classpath
separation (that's the additional attribute "test" with value "true" in the classpath entry).

![image](https://user-images.githubusercontent.com/406876/71909588-a0acd180-3170-11ea-8020-0736c40e5d92.png)