### PR TITLE
Use Tycho 1.6.0 and JDK 13 in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,22 +18,27 @@ addons:
 install:
   - ""
 
+# JDKs used in builds must be supported by Tycho.
+# Check https://wiki.eclipse.org/Tycho/Release_Notes to find supported versions.
 matrix:
   fast_finish: true
   include:
+    # JDK 8 (minimal supported Java version of eclipse-cs)
     - jdk: openjdk8
       env:
         - DESC="install (openjdk8)"
         - CMD="mvn install && git diff"
 
+    # JDK 11 (Long Term Support version)
     - jdk: openjdk11
       env:
         - DESC="install (openjdk11)"
         - CMD="mvn install && git diff"
 
-    - jdk: openjdk12
+    # JDK 13 (most recent Java version)
+    - jdk: openjdk13
       env:
-        - DESC="install (openjdk12)"
+        - DESC="install (openjdk13)"
         - CMD="mvn install && git diff"
 
 script:

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
     </modules>
 
     <properties>
-        <tycho-version>1.5.1</tycho-version>
-        <tycho-extras-version>1.5.1</tycho-extras-version>
+        <tycho-version>1.6.0</tycho-version>
+        <tycho-extras-version>1.6.0</tycho-extras-version>
         <tycho.scmUrl>scm:git:git://github.com:checkstyle/eclipse-cs.git</tycho.scmUrl>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
Use the most recent version of Tycho during builds. Since it no longer
supports JDK 12, also upgrade the build matrix to JDK 13 and document
the Java versions of the build matrix.