### PR TITLE
Update target platform documentation

### DIFF
--- a/net.sf.eclipsecs.target/.project
+++ b/net.sf.eclipsecs.target/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
@@ -13,5 +18,6 @@
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
-<!-- generated with https://github.com/mbarbero/fr.obeo.releng.targetplatform -->
-<target name="Eclipse Checkstyle" sequenceNumber="1523084336">
+<!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
+<target name="Eclipse Checkstyle" sequenceNumber="1580415883">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
@@ -1,4 +1,5 @@
-// install http://mbarbero.github.io/fr.obeo.releng.targetplatform/p2/ to use this target definition
+// Install http://download.eclipse.org/cbi/tpd/3.0.0-SNAPSHOT/ to use this target definition.
+// Read https://github.com/eclipse-cbi/targetplatform-dsl for more details.
 target "Eclipse Checkstyle"
 with source configurePhase
 

--- a/net.sf.eclipsecs.target/readme.md
+++ b/net.sf.eclipsecs.target/readme.md
@@ -1,0 +1,27 @@
+## What's this?
+
+The .target file describes the minimum eclipse environment that eclipse-cs runs in.
+
+## How to use the target platform
+
+In the Maven build it is used automatically for compilation
+(see target-platform-configuration section in the parent POM).
+
+For development in Eclipse you have to load it manually, but only one time:
+Open the .target file and use the "Set As Active Target" hyperlink. This may take
+a while the first time, since plugins are loaded from the Internet.
+
+If you don't do that, the compilation happens against the eclipse plugins of 
+your IDE and you may call methods that don't exist in earlier versions, which
+will lead to runtime errors for end users.
+
+## How to update the target platform
+
+Target files are hard to maintain manually. Therefore we use a custom DSL to
+maintain the target platform, and to derive the .target file.
+
+Install https://github.com/eclipse-cbi/targetplatform-dsl to edit the .tpd
+file. After saving use the context menu of the .tpd file to create a new
+version of the .target file.
+
+Both the .target and .tpd files must be checked in after changes.

--- a/net.sf.eclipsecs.target/readme.txt
+++ b/net.sf.eclipsecs.target/readme.txt
@@ -1,2 +1,0 @@
-The .target file is derived from the .tpd file.
-Install https://github.com/mbarbero/fr.obeo.releng.targetplatform to edit the .tpd file and to create a new target.


### PR DESCRIPTION
The TPD editor plugin is hosted at a different location. Update the
comments where to find it, and regenerate the target platform. Also
enable the Xtext builder on the project.

There are no actual functional changes, this is just housekeeping.