### PR TITLE
Fix minimum Eclipse version documentation

### DIFF
--- a/net.sf.eclipsecs.doc/src/main/resources/partials/index.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/index.html
@@ -8,7 +8,7 @@
                     <p style="margin-bottom: 5px;">
                         <a class="btn btn-primary btn-outline-inverse btn-lg" target="_blank"
                             href="http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=150"
-                            title="Drag and drop this link into a running Eclipse (&gt;Indigo) workspace to install the Eclipse Checkstyle Plugin">
+                            title="Drag and drop this link into a running Eclipse (Juno or higher version) workspace to install the Eclipse Checkstyle Plugin">
                             <i class="fa fa-plug">
                             </i>
                             Install
@@ -31,7 +31,7 @@
                     <small>
                         <sup>1 </sup>
                         Install via Eclipse Marketplace. Drag and drop this link into a running Eclipse
-                        (&gt;Indigo) workspace
+                        (Juno or higher version) workspace
                     </small>
                     <br />
                     <small>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/install.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/install.html
@@ -10,11 +10,11 @@
             <p>
                 <a class="btn btn-primary btn-outline-inverse btn-lg" target="_blank"
                     href="http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=150"
-                    title="Drag and drop this link into a running Eclipse Indigo/Juno/Kepler/Luna/Mars/Neon/Oxygen workspace to install Checkstyle Plugin"
+                    title="Drag and drop this link into a running Eclipse (Juno or higher version) workspace to install Checkstyle Plugin"
                         ><i class="fa fa-plug"> </i> Install </a>
             </p>
             <ol>
-                <li>Drag&amp;Drop the link above to a running Eclipse Indigo/Juno/Kepler/Luna/Mars/Neon/Oxygen instance. This will trigger the
+                <li>Drag&amp;Drop the link above to a running Eclipse instance (Juno or higher version). This will trigger the
                     Eclipse Marketplace client with the Eclipse Checkstyle Plugin being pre-selected for
                     installation.</li>
                 <li>Confirm the selection of features to install</li>


### PR DESCRIPTION
* remove wrong mentioning of Indigo as supported version
* don't list all Eclipse releases, to avoid the need for updating files
on every new Eclipse release
* use "Juno or higher version" instead of ">Indigo", since that is
easier to understand for end users