### PR TITLE
Replace boxing constructors

### DIFF
--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
@@ -176,7 +176,7 @@ public class Auditor {
       project.deleteMarkers(CheckstyleMarker.MARKER_ID, false, IResource.DEPTH_ZERO);
 
       Map<String, Object> attrs = new HashMap<>();
-      attrs.put(IMarker.PRIORITY, new Integer(IMarker.PRIORITY_NORMAL));
+      attrs.put(IMarker.PRIORITY, Integer.valueOf(IMarker.PRIORITY_NORMAL));
       attrs.put(IMarker.SEVERITY, Integer.valueOf(IMarker.SEVERITY_ERROR));
       attrs.put(IMarker.MESSAGE, NLS.bind(Messages.Auditor_msgMsgCheckstyleInternalError, null));
 
@@ -325,8 +325,8 @@ public class Auditor {
             mMarkerAttributes.put(CheckstyleMarker.MODULE_NAME, metaData.getInternalName());
             mMarkerAttributes.put(CheckstyleMarker.MESSAGE_KEY,
                     error.getLocalizedMessage().getKey());
-            mMarkerAttributes.put(IMarker.PRIORITY, new Integer(IMarker.PRIORITY_NORMAL));
-            mMarkerAttributes.put(IMarker.SEVERITY, new Integer(getSeverityValue(severity)));
+            mMarkerAttributes.put(IMarker.PRIORITY, Integer.valueOf(IMarker.PRIORITY_NORMAL));
+            mMarkerAttributes.put(IMarker.SEVERITY, Integer.valueOf(getSeverityValue(severity)));
             mMarkerAttributes.put(IMarker.LINE_NUMBER, Integer.valueOf(error.getLine()));
             mMarkerAttributes.put(IMarker.MESSAGE, getMessage(error));
 
@@ -335,7 +335,7 @@ public class Auditor {
 
             // enables own category under Java Problem Type
             // setting for Problems view (RFE 1530366)
-            mMarkerAttributes.put("categoryId", new Integer(999)); //$NON-NLS-1$
+            mMarkerAttributes.put("categoryId", Integer.valueOf(999)); //$NON-NLS-1$
 
             // create a marker for the actual resource
             IMarker marker = mResource.createMarker(CheckstyleMarker.MARKER_ID);

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/CheckerFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/CheckerFactory.java
@@ -125,7 +125,7 @@ public final class CheckerFactory {
       }
 
       // store checker in cache
-      Long modified = new Long(configFileData.getModificationStamp());
+      Long modified = Long.valueOf(configFileData.getModificationStamp());
       sCheckerMap.put(cacheKey, checker);
       sModifiedMap.put(cacheKey, modified);
     }
@@ -183,7 +183,7 @@ public final class CheckerFactory {
 
       // compare modification times of the configs
       Long oldTime = sModifiedMap.get(cacheKey);
-      Long newTime = new Long(modificationStamp);
+      Long newTime = Long.valueOf(modificationStamp);
 
       // no match - remove checker from cache
       if (oldTime == null || oldTime.compareTo(newTime) != 0) {

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/CheckstyleBuilder.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/CheckstyleBuilder.java
@@ -181,14 +181,14 @@ public class CheckstyleBuilder extends IncrementalProjectBuilder {
       project.deleteMarkers(CheckstyleMarker.MARKER_ID, false, IResource.DEPTH_INFINITE);
 
       Map<String, Object> markerAttributes = new HashMap<>();
-      markerAttributes.put(IMarker.PRIORITY, new Integer(IMarker.PRIORITY_HIGH));
-      markerAttributes.put(IMarker.SEVERITY, new Integer(IMarker.SEVERITY_ERROR));
+      markerAttributes.put(IMarker.PRIORITY, Integer.valueOf(IMarker.PRIORITY_HIGH));
+      markerAttributes.put(IMarker.SEVERITY, Integer.valueOf(IMarker.SEVERITY_ERROR));
       markerAttributes.put(IMarker.MESSAGE,
               NLS.bind(Messages.CheckstyleBuilder_msgWrongBuilderOrder, project.getName()));
 
       // enables own category under Java Problem Type
       // setting for Problems view (RFE 1530366)
-      markerAttributes.put("categoryId", new Integer(999)); //$NON-NLS-1$
+      markerAttributes.put("categoryId", Integer.valueOf(999)); //$NON-NLS-1$
 
       // create a marker for the actual resource
       IMarker marker = project.createMarker(CheckstyleMarker.MARKER_ID);

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
@@ -971,19 +971,19 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
         switch (columnIndex) {
 
           case 0:
-            text = new String();
+            text = "";
             break;
           case 1:
-            text = module.getName() != null ? module.getName() : new String();
+            text = module.getName() != null ? module.getName() : "";
             break;
           case 2:
-            text = module.getSeverity() != null ? module.getSeverity().name() : new String();
+            text = module.getSeverity() != null ? module.getSeverity().name() : "";
             break;
           case 3:
-            text = module.getComment() != null ? module.getComment() : new String();
+            text = module.getComment() != null ? module.getComment() : "";
             break;
           default:
-            text = new String();
+            text = "";
             break;
         }
       }
@@ -996,8 +996,8 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
     @Override
     public Comparable<?> getComparableValue(Object element, int col) {
       if (element instanceof Module && col == 0) {
-        return Severity.ignore.equals(((Module) element).getSeverity()) ? new Integer(0)
-                : new Integer(1);
+        return Severity.ignore.equals(((Module) element).getSeverity()) ? Integer.valueOf(0)
+                : Integer.valueOf(1);
       }
 
       return getColumnText(element, col);

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/modifier/ModifierOrderQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/modifier/ModifierOrderQuickfix.java
@@ -97,7 +97,7 @@ public class ModifierOrderQuickfix extends AbstractASTResolution {
         int modifierIndex1 = MODIFIER_ORDER.indexOf(m1.getKeyword());
         int modifierIndex2 = MODIFIER_ORDER.indexOf(m2.getKeyword());
 
-        return new Integer(modifierIndex1).compareTo(new Integer(modifierIndex2));
+        return Integer.valueOf(modifierIndex1).compareTo(Integer.valueOf(modifierIndex2));
       }
     });
 
@@ -144,7 +144,7 @@ public class ModifierOrderQuickfix extends AbstractASTResolution {
         // find the range from first to last modifier. marker must be in between
         int minPos = modifiers.stream().mapToInt(Modifier::getStartPosition).min().getAsInt();
         int maxPos = modifiers.stream().mapToInt(Modifier::getStartPosition).max().getAsInt();
-        
+
         if (minPos <= markerStartOffset && markerStartOffset <= maxPos) {
           List<?> reorderedModifiers = reOrderModifiers(node.modifiers());
           node.modifiers().clear();

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/GraphPieDataset.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/GraphPieDataset.java
@@ -79,7 +79,7 @@ public class GraphPieDataset extends AbstractDataset implements PieDataset {
     // markers que l'on comptera dans une catégorie "Autres" car ils
     // représentent trop peu de %
     int leftCount = 0;
-    float mCount = new Float(stats.getMarkerCount()).floatValue();
+    float mCount = stats.getMarkerCount();
     // et on remplit
     for (Iterator<MarkerStat> iter = markerStatCollection.iterator(); iter.hasNext();) {
       MarkerStat markerStat = iter.next();
@@ -256,6 +256,6 @@ public class GraphPieDataset extends AbstractDataset implements PieDataset {
    *          the value.
    */
   public void setValue(final Comparable<?> key, final double value) {
-    setValue(key, new Double(value));
+    setValue(key, Double.valueOf(value));
   }
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/GraphStatsView.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/GraphStatsView.java
@@ -581,9 +581,9 @@ public class GraphStatsView extends AbstractStatsView {
       Stats stats = getStats();
       if (stats != null) {
         String text = NLS.bind(Messages.GraphStatsView_lblViewMessage,
-                new Object[] { new Integer(stats.getMarkerCount()),
-                    new Integer(stats.getMarkerStats().size()),
-                    new Integer(stats.getMarkerCountAll()) });
+                new Object[] { Integer.valueOf(stats.getMarkerCount()),
+                    Integer.valueOf(stats.getMarkerStats().size()),
+                    Integer.valueOf(stats.getMarkerCountAll()) });
         mLabelDesc.setText(text);
       } else {
         mLabelDesc.setText("");
@@ -591,7 +591,7 @@ public class GraphStatsView extends AbstractStatsView {
     } else {
 
       String text = NLS.bind(Messages.MarkerStatsView_lblDetailMessage, new Object[] {
-          mCurrentDetailCategory, new Integer(mDetailViewer.getTable().getItemCount()) });
+          mCurrentDetailCategory, Integer.valueOf(mDetailViewer.getTable().getItemCount()) });
       mLabelDesc.setText(text);
     }
   }
@@ -720,7 +720,7 @@ public class GraphStatsView extends AbstractStatsView {
 
       switch (colIndex) {
         case 0:
-          comparable = new Integer(marker.getAttribute(IMarker.SEVERITY, Integer.MAX_VALUE) * -1);
+          comparable = Integer.valueOf(marker.getAttribute(IMarker.SEVERITY, Integer.MAX_VALUE) * -1);
           break;
         case 1:
           comparable = marker.getResource().getName();
@@ -729,10 +729,10 @@ public class GraphStatsView extends AbstractStatsView {
           comparable = marker.getResource().getParent().getFullPath().toString();
           break;
         case 3:
-          comparable = new Integer(marker.getAttribute(IMarker.LINE_NUMBER, Integer.MAX_VALUE));
+          comparable = Integer.valueOf(marker.getAttribute(IMarker.LINE_NUMBER, Integer.MAX_VALUE));
           break;
         case 4:
-          comparable = marker.getAttribute(IMarker.MESSAGE, "").toString();
+          comparable = marker.getAttribute(IMarker.MESSAGE, "");
           break;
 
         default:

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/MarkerStatsView.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/MarkerStatsView.java
@@ -475,9 +475,9 @@ public class MarkerStatsView extends AbstractStatsView {
       Stats stats = getStats();
       if (stats != null) {
         String text = NLS.bind(Messages.MarkerStatsView_lblOverviewMessage,
-                new Object[] { new Integer(stats.getMarkerCount()),
-                    new Integer(stats.getMarkerStats().size()),
-                    new Integer(stats.getMarkerCountAll()) });
+                new Object[] { Integer.valueOf(stats.getMarkerCount()),
+                    Integer.valueOf(stats.getMarkerStats().size()),
+                    Integer.valueOf(stats.getMarkerCountAll()) });
         mDescLabel.setText(text);
       } else {
         mDescLabel.setText("");
@@ -485,7 +485,7 @@ public class MarkerStatsView extends AbstractStatsView {
     } else {
 
       String text = NLS.bind(Messages.MarkerStatsView_lblDetailMessage, new Object[] {
-          mCurrentDetailCategory, new Integer(mDetailViewer.getTable().getItemCount()) });
+          mCurrentDetailCategory, Integer.valueOf(mDetailViewer.getTable().getItemCount()) });
       mDescLabel.setText(text);
     }
   }
@@ -659,13 +659,13 @@ public class MarkerStatsView extends AbstractStatsView {
 
       switch (colIndex) {
         case 0:
-          comparable = new Integer(stat.getMaxSeverity() * -1);
+          comparable = Integer.valueOf(stat.getMaxSeverity() * -1);
           break;
         case 1:
           comparable = stat.getIdentifiant();
           break;
         case 2:
-          comparable = new Integer(stat.getCount());
+          comparable = Integer.valueOf(stat.getCount());
           break;
 
         default:
@@ -758,7 +758,7 @@ public class MarkerStatsView extends AbstractStatsView {
 
       switch (colIndex) {
         case 0:
-          comparable = new Integer(marker.getAttribute(IMarker.SEVERITY, Integer.MAX_VALUE) * -1);
+          comparable = Integer.valueOf(marker.getAttribute(IMarker.SEVERITY, Integer.MAX_VALUE) * -1);
           break;
         case 1:
           comparable = marker.getResource().getName();
@@ -767,7 +767,7 @@ public class MarkerStatsView extends AbstractStatsView {
           comparable = marker.getResource().getParent().getFullPath().toString();
           break;
         case 3:
-          comparable = new Integer(marker.getAttribute(IMarker.LINE_NUMBER, Integer.MAX_VALUE));
+          comparable = Integer.valueOf(marker.getAttribute(IMarker.LINE_NUMBER, Integer.MAX_VALUE));
           break;
         case 4:
           comparable = marker.getAttribute(IMarker.MESSAGE, "");


### PR DESCRIPTION
Boxing constructors of primitive types are deprecated in newer versions
of Java and should not be used.