### PR TITLE
Configure target platform for Java 8

### DIFF
--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Eclipse Checkstyle" sequenceNumber="1580415883">
+<target name="Eclipse Checkstyle" sequenceNumber="1590429360">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
@@ -10,4 +10,5 @@
       <repository location="http://download.eclipse.org/releases/juno/201303010900/"/>
     </location>
   </locations>
+  <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 </target>

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
@@ -2,6 +2,7 @@
 // Read https://github.com/eclipse-cbi/targetplatform-dsl for more details.
 target "Eclipse Checkstyle"
 with source configurePhase
+environment JavaSE-1.8
 
 // use the latest version of Juno only, to avoid downloading all children of the Juno composite update site
 location "http://download.eclipse.org/releases/juno/201303010900/" {


### PR DESCRIPTION
The Maven POM configures Java 8 as source and target level during
compilation already. However, in Eclipse the target platform definition
does not specify the JRE level, which can lead to inconsistencies during
development in seldom cases.

Most developers should not see any difference from this change, since
they should be using a JRE 8 for Eclipse CS development anyway.