### PR TITLE
Upgrade Maven dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,6 @@
 
     <properties>
         <tycho-version>1.6.0</tycho-version>
-        <tycho-extras-version>1.6.0</tycho-extras-version>
         <tycho.scmUrl>scm:git:git://github.com:checkstyle/eclipse-cs.git</tycho.scmUrl>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -48,7 +47,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -124,12 +123,12 @@
                         <dependency>
                             <groupId>org.eclipse.tycho.extras</groupId>
                             <artifactId>tycho-buildtimestamp-jgit</artifactId>
-                            <version>${tycho-extras-version}</version>
+                            <version>${tycho-version}</version>
                         </dependency>
                         <dependency>
                             <groupId>org.eclipse.tycho.extras</groupId>
                             <artifactId>tycho-sourceref-jgit</artifactId>
-                            <version>${tycho-extras-version}</version>
+                            <version>${tycho-version}</version>
                         </dependency>
                     </dependencies>
                     <configuration>
@@ -188,7 +187,7 @@
                 <plugin>
                     <groupId>org.eclipse.tycho.extras</groupId>
                     <artifactId>tycho-source-feature-plugin</artifactId>
-                    <version>${tycho-extras-version}</version>
+                    <version>${tycho-version}</version>
                 </plugin>
                 <plugin>
                     <groupId>com.carrotgarden.maven</groupId>
@@ -251,7 +250,7 @@
                             <configuration>
                                 <rules>
                                     <requireMavenVersion>
-                                        <version>3.6.2</version>
+                                        <version>3.6.3</version>
                                     </requireMavenVersion>
                                     <requireReleaseDeps/>
                                 </rules>


### PR DESCRIPTION
* enforce latest Maven 3.6.3 (it is available on Travis, according to
their specs)
* use latest junit 4 (but not yet junit 5)
* remove separate version for tycho-extras (tycho-extras has been merged
with tycho in 1.6, so they are definitely always versioned together now,
even though the maven group id is still different)