### PR TITLE
avoid flickering during filter update

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
@@ -546,19 +546,23 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
      */
     @Override
     public void modifyText(ModifyEvent e) {
+      mTreeViewer.getControl().setRedraw(false);
+      try {
+        if (!mDefaultFilterText.equals(mTxtTreeFilter.getText())
+                && !Strings.isNullOrEmpty(mTxtTreeFilter.getText())) {
 
-      if (!mDefaultFilterText.equals(mTxtTreeFilter.getText())
-              && !Strings.isNullOrEmpty(mTxtTreeFilter.getText())) {
+          if (!Arrays.asList(mTableViewer.getFilters()).contains(mTreeFilter)) {
+            mTreeViewer.addFilter(mTreeFilter);
+          }
 
-        if (!Arrays.asList(mTableViewer.getFilters()).contains(mTreeFilter)) {
-          mTreeViewer.addFilter(mTreeFilter);
+          mTreeViewer.refresh();
+          mTreeViewer.expandAll();
+        } else {
+          mTreeViewer.removeFilter(mTreeFilter);
+          mTreeViewer.refresh();
         }
-
-        mTreeViewer.refresh();
-        mTreeViewer.expandAll();
-      } else {
-        mTreeViewer.removeFilter(mTreeFilter);
-        mTreeViewer.refresh();
+      } finally {
+        mTreeViewer.getControl().setRedraw(true);
       }
     }
 


### PR DESCRIPTION
When updating the list of modules matching the given text filter,
disable redrawing the underlying OS control. Otherwise there is a
flickering effect, since the control is redrawn for every item being
processed by the filter by default.

With redrawing disabled, the control is only drawn once all items have
been filtered, and there is no more flickering.