### PR TITLE
Issue #237: update to Checkstyle 8.34

### DIFF
--- a/net.sf.eclipsecs.checkstyle/.classpath
+++ b/net.sf.eclipsecs.checkstyle/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry exported="true" kind="lib" path="checkstyle-8.33-all.jar" sourcepath="checkstyle-checkstyle-8.33.zip"/>
+	<classpathentry exported="true" kind="lib" path="checkstyle-8.34-all.jar" sourcepath="checkstyle-checkstyle-8.34.zip"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/net.sf.eclipsecs.checkstyle/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.checkstyle/META-INF/MANIFEST.MF
@@ -46,5 +46,5 @@ Export-Package: .,
  com.puppycrawl.tools.checkstyle.utils,
  org.apache.commons.beanutils;version="8.33.0"
 Bundle-ClassPath: .,
- checkstyle-8.33-all.jar
+ checkstyle-8.34-all.jar
 Automatic-Module-Name: net.sf.eclipsecs.checkstyle

--- a/net.sf.eclipsecs.checkstyle/build.properties
+++ b/net.sf.eclipsecs.checkstyle/build.properties
@@ -1,6 +1,6 @@
 bin.includes = META-INF/,\
                .,\
                license/,\
-               checkstyle-8.33-all.jar
+               checkstyle-8.34-all.jar
 jars.compile.order = .
 source.. = metadata/

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/blocks/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/blocks/checkstyle-metadata.xml
@@ -155,6 +155,7 @@
                     <property-value-option value="INSTANCE_INIT"/>
                     <property-value-option value="ANNOTATION_DEF"/>
                     <property-value-option value="ENUM_DEF"/>
+                    <property-value-option value="INTERFACE_DEF"/>
                 </enumeration>
             </property-metadata>
             <message-key key="line.alone"/>

--- a/net.sf.eclipsecs.checkstyle/pom.xml
+++ b/net.sf.eclipsecs.checkstyle/pom.xml
@@ -11,7 +11,7 @@
     <name>Checkstyle Core Library Plugin</name>
     
     <properties>
-        <checkstyle.version>8.33</checkstyle.version>
+        <checkstyle.version>8.34</checkstyle.version>
     </properties>
     <build>
         <plugins>


### PR DESCRIPTION
Fixes #237.

Checking "INTERFACE_DEF token support in RightCurlyCheck".
![Screen Shot 2020-07-27 at 1 48 26 PM](https://user-images.githubusercontent.com/4010811/88590870-47bf6080-d010-11ea-9752-1ebb1de75195.png)
![Screen Shot 2020-07-27 at 1 47 54 PM](https://user-images.githubusercontent.com/4010811/88590875-48f08d80-d010-11ea-8f46-ba2fe7dd274a.png)
