### PR TITLE
prefer using internalName in violation message

### DIFF
--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
@@ -524,7 +524,7 @@ public class Auditor {
       if (metaData == null) {
         return Messages.Auditor_txtUnknownModule;
       }
-      return metaData.getRuleName();
+      return metaData.getInternalName();
     }
   }
 }


### PR DESCRIPTION
with  the internalName:
* we easy search on web, such as https://checkstyle.sourceforge.io/checks.html
* and SuppressWarnings with the internalName when neeed
ie:
```
@SuppressWarnings({"checkstyle:WriteTag"})
```
