### PR TITLE
supplemental: replace outdated links to checkstyle website

### DIFF
--- a/docs/partials/releases/10.0.0/release_notes.html
+++ b/docs/partials/releases/10.0.0/release_notes.html
@@ -7,7 +7,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/10.1.0/release_notes.html
+++ b/docs/partials/releases/10.1.0/release_notes.html
@@ -8,7 +8,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/4.3.0/release_notes.html
+++ b/docs/partials/releases/4.3.0/release_notes.html
@@ -2,7 +2,7 @@
     <ul>
         <li>
             <p>Update release to include the all new Checkstyle 4.3. Please check the <a
-                    href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle release notes</a> to see
+                    href="https://checkstyle.org/releasenotes.html">Checkstyle release notes</a> to see
                 what's new.</p>
         </li>
         <li>

--- a/docs/partials/releases/5.0.0beta2/release_notes.html
+++ b/docs/partials/releases/5.0.0beta2/release_notes.html
@@ -1,5 +1,5 @@
 <div>
-    <p>This release integrates the new <a href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle 5.0
+    <p>This release integrates the new <a href="https://checkstyle.org/releasenotes.html">Checkstyle 5.0
             beta2</a>. </p>
     <p>A few plugin bugs have been fixed over beta1, as well as a few new features incorporated.<br/> Most notable is
         likely the Configuration Editor support for custom Checkstyle messages (a feature new in CS 5). </p>

--- a/docs/partials/releases/5.0.0beta3/release_notes.html
+++ b/docs/partials/releases/5.0.0beta3/release_notes.html
@@ -1,5 +1,5 @@
 <div>
-    <p>This release integrates the new <a href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle 5.0
+    <p>This release integrates the new <a href="https://checkstyle.org/releasenotes.html">Checkstyle 5.0
             final</a>.<br/>Congratulations to the Checkstyle team for getting this major revision out the door.<br/></p>
     <p>Unfortunatly, the plugin itself is yet not ripe for its 5.0.0 final release.<br/>Because of the major
         restructurings done for the 5.0.0 stream large portions of the documentation are still outdated and need to be

--- a/docs/partials/releases/5.2.0/release_notes.html
+++ b/docs/partials/releases/5.2.0/release_notes.html
@@ -1,4 +1,4 @@
 <div>
-    <p>Upgraded Checkstyle core to 5.2.<br/> See <a href="http://checkstyle.sourceforge.net/releasenotes.html">here</a>
+    <p>Upgraded Checkstyle core to 5.2.<br/> See <a href="https://checkstyle.org/releasenotes.html">here</a>
         for more details.</p>
 </div>

--- a/docs/partials/releases/6.11.0/release_notes.html
+++ b/docs/partials/releases/6.11.0/release_notes.html
@@ -7,7 +7,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>This plugin version was superficially verified to be compatible with Eclipse Mars.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
 </div>

--- a/docs/partials/releases/6.14.0/release_notes.html
+++ b/docs/partials/releases/6.14.0/release_notes.html
@@ -6,7 +6,7 @@
     </p>
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
 

--- a/docs/partials/releases/6.16.0/release_notes.html
+++ b/docs/partials/releases/6.16.0/release_notes.html
@@ -6,7 +6,7 @@
     </p>
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
 

--- a/docs/partials/releases/6.19.0/release_notes.html
+++ b/docs/partials/releases/6.19.0/release_notes.html
@@ -6,7 +6,7 @@
     </p>
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
 

--- a/docs/partials/releases/6.2.0/release_notes.html
+++ b/docs/partials/releases/6.2.0/release_notes.html
@@ -7,7 +7,7 @@
         check have been removed without replacement.<br/> Also the configuration option <code>ignoreDirectoryName</code>
         of the <code>PackageDeclaration</code> checks has been removed.<br/>If your Checkstyle configuration uses one of
         those checks/options adaptations will be required in order to use your configuration with this
-        version.<br/>Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html"
+        version.<br/>Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html"
             >Checkstyle release notes</a> for details.</p>
     <h3>Bugfixes</h3>
     <ul>

--- a/docs/partials/releases/6.4.0/release_notes.html
+++ b/docs/partials/releases/6.4.0/release_notes.html
@@ -7,7 +7,7 @@
         check have been removed without replacement.<br/> Also the configuration option <code>ignoreDirectoryName</code>
         of the <code>PackageDeclaration</code> checks has been removed.<br/>If your Checkstyle configuration uses one of
         those checks/options adaptations will be required in order to use your configuration with this
-        version.<br/>Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html"
+        version.<br/>Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html"
             >Checkstyle release notes</a> for details.</p>
     <h3>Bugfixes</h3>
     <ul>

--- a/docs/partials/releases/6.5.0/release_notes.html
+++ b/docs/partials/releases/6.5.0/release_notes.html
@@ -6,7 +6,7 @@
     </p>
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
     <h3>Bugfixes</h3>

--- a/docs/partials/releases/6.8.0/release_notes.html
+++ b/docs/partials/releases/6.8.0/release_notes.html
@@ -7,7 +7,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>This plugin version was superficially verified to be compatible with Eclipse Mars.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
     <h3>Bugfixes</h3>

--- a/docs/partials/releases/6.9.0/release_notes.html
+++ b/docs/partials/releases/6.9.0/release_notes.html
@@ -7,7 +7,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>This plugin version was superficially verified to be compatible with Eclipse Mars.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
 </div>

--- a/docs/partials/releases/7.2.0/release_notes.html
+++ b/docs/partials/releases/7.2.0/release_notes.html
@@ -7,7 +7,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>This plugin version was superficially verified to be compatible with Eclipse Mars.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
     <h3>Features</h3>

--- a/docs/partials/releases/7.3.0/release_notes.html
+++ b/docs/partials/releases/7.3.0/release_notes.html
@@ -7,7 +7,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>This plugin version was superficially verified to be compatible with Eclipse Mars.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
     <h3>Features</h3>

--- a/docs/partials/releases/7.6.0/release_notes.html
+++ b/docs/partials/releases/7.6.0/release_notes.html
@@ -7,7 +7,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>This plugin version was superficially verified to be compatible with Eclipse Mars.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
     <h3>Features</h3>

--- a/docs/partials/releases/8.0.0/release_notes.html
+++ b/docs/partials/releases/8.0.0/release_notes.html
@@ -7,7 +7,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>This plugin version was superficially verified to be compatible with Eclipse Oxygen.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
 </div>

--- a/docs/partials/releases/8.10.0/release_notes.html
+++ b/docs/partials/releases/8.10.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.10.1/release_notes.html
+++ b/docs/partials/releases/8.10.1/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.11.0/release_notes.html
+++ b/docs/partials/releases/8.11.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.12.0/release_notes.html
+++ b/docs/partials/releases/8.12.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.13.0/release_notes.html
+++ b/docs/partials/releases/8.13.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.14.0/release_notes.html
+++ b/docs/partials/releases/8.14.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.15.0/release_notes.html
+++ b/docs/partials/releases/8.15.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.17.0/release_notes.html
+++ b/docs/partials/releases/8.17.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.18.0/release_notes.html
+++ b/docs/partials/releases/8.18.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.19.0/release_notes.html
+++ b/docs/partials/releases/8.19.0/release_notes.html
@@ -2,7 +2,7 @@
     <p>Updates the Checkstyle core to version 8.19.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.20.0/release_notes.html
+++ b/docs/partials/releases/8.20.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.21.0/release_notes.html
+++ b/docs/partials/releases/8.21.0/release_notes.html
@@ -10,7 +10,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.22.0/release_notes.html
+++ b/docs/partials/releases/8.22.0/release_notes.html
@@ -10,7 +10,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.23.0/release_notes.html
+++ b/docs/partials/releases/8.23.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.24.0/release_notes.html
+++ b/docs/partials/releases/8.24.0/release_notes.html
@@ -7,7 +7,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.25.0/release_notes.html
+++ b/docs/partials/releases/8.25.0/release_notes.html
@@ -11,7 +11,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.26.0/release_notes.html
+++ b/docs/partials/releases/8.26.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.27.0/release_notes.html
+++ b/docs/partials/releases/8.27.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.28.0/release_notes.html
+++ b/docs/partials/releases/8.28.0/release_notes.html
@@ -7,7 +7,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.29.0/release_notes.html
+++ b/docs/partials/releases/8.29.0/release_notes.html
@@ -8,7 +8,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.30.0/release_notes.html
+++ b/docs/partials/releases/8.30.0/release_notes.html
@@ -10,7 +10,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.31.0/release_notes.html
+++ b/docs/partials/releases/8.31.0/release_notes.html
@@ -7,7 +7,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.32.0/release_notes.html
+++ b/docs/partials/releases/8.32.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.33.0/release_notes.html
+++ b/docs/partials/releases/8.33.0/release_notes.html
@@ -12,7 +12,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.34.0/release_notes.html
+++ b/docs/partials/releases/8.34.0/release_notes.html
@@ -7,7 +7,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.35.0/release_notes.html
+++ b/docs/partials/releases/8.35.0/release_notes.html
@@ -8,7 +8,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.36.1/release_notes.html
+++ b/docs/partials/releases/8.36.1/release_notes.html
@@ -12,7 +12,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.36.2/release_notes.html
+++ b/docs/partials/releases/8.36.2/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.37.0/release_notes.html
+++ b/docs/partials/releases/8.37.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.38.0/release_notes.html
+++ b/docs/partials/releases/8.38.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.39.0/release_notes.html
+++ b/docs/partials/releases/8.39.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.40.0/release_notes.html
+++ b/docs/partials/releases/8.40.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.41.0/release_notes.html
+++ b/docs/partials/releases/8.41.0/release_notes.html
@@ -7,7 +7,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.41.1/release_notes.html
+++ b/docs/partials/releases/8.41.1/release_notes.html
@@ -9,7 +9,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.42.0/release_notes.html
+++ b/docs/partials/releases/8.42.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.43.0/release_notes.html
+++ b/docs/partials/releases/8.43.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.44.0/release_notes.html
+++ b/docs/partials/releases/8.44.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.45.0/release_notes.html
+++ b/docs/partials/releases/8.45.0/release_notes.html
@@ -9,7 +9,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.45.1/release_notes.html
+++ b/docs/partials/releases/8.45.1/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.5.0/release_notes.html
+++ b/docs/partials/releases/8.5.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent changes in Checkstyle.

--- a/docs/partials/releases/8.7.0/release_notes.html
+++ b/docs/partials/releases/8.7.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/8.8.0/release_notes.html
+++ b/docs/partials/releases/8.8.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/9.0.0/release_notes.html
+++ b/docs/partials/releases/9.0.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/9.0.1/release_notes.html
+++ b/docs/partials/releases/9.0.1/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/9.1.0/release_notes.html
+++ b/docs/partials/releases/9.1.0/release_notes.html
@@ -8,7 +8,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/9.2.0/release_notes.html
+++ b/docs/partials/releases/9.2.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/9.2.1/release_notes.html
+++ b/docs/partials/releases/9.2.1/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/docs/partials/releases/9.3.0/release_notes.html
+++ b/docs/partials/releases/9.3.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs-feature/feature.properties
+++ b/net.sf.eclipsecs-feature/feature.properties
@@ -6,7 +6,7 @@ feature.provider_name = Eclipse Checkstyle Plugin Development Team
 updateSiteName = Eclipse Checkstyle Plug-in Updates
 
 description.text = This feature integrates Checkstyle into Eclipse.
-description.url = http://checkstyle.org/eclipse-cs/
+description.url = https://checkstyle.org/eclipse-cs/
 
 copyright.text =\
 Copyright (C) 2002-2016  David Schneider, Lars K\u00f6dderitzsch and others\n\

--- a/net.sf.eclipsecs.branding/about.properties
+++ b/net.sf.eclipsecs.branding/about.properties
@@ -1,11 +1,11 @@
 aboutText=Eclipse Checkstyle {featureVersion}\n\
 \n\
 Checkstyle integration for Eclipse, distributed under the terms of the GNU Lesser General Public License 2.1.\n\
-Visit http://checkstyle.org/eclipse-cs/ for updates, documentation and support.\n\
+Visit https://checkstyle.org/eclipse-cs/ for updates, documentation and support.\n\
 \n\
 (c) Copyright David Schneider, Lars K\u00f6dderitzsch and others, 2002-2018\n\
 This software includes the following 3rd-party libraries:\n\
-Checkstyle, licensed under LGPL 2.1. Visit http://checkstyle.org/\n\
+Checkstyle, licensed under LGPL 2.1. Visit https://checkstyle.org/\n\
 Jakarta Commons Lang/IO, licensed under APL 2.0. Visit http://commons.apache.org/\n\
 DOM4J, licensed under BSD. Visit http://sourceforge.net/projects/dom4j/\n\
 JFreeChart, licensed under LGPL 3. Visit http://www.jfree.org/jfreechart/

--- a/net.sf.eclipsecs.checkstyle/metadata/checkstyle_packages.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/checkstyle_packages.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE checkstyle-packages PUBLIC
     "-//Checkstyle//DTD Package Names Configuration 1.0//EN"
-    "http://checkstyle.org/dtds/packages_1_0.dtd">
+    "https://checkstyle.org/dtds/packages_1_0.dtd">
 
 <checkstyle-packages>
   <package name="com.puppycrawl.tools.checkstyle">

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/custom-checks.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/custom-checks.html
@@ -2,8 +2,8 @@
     <!-- <div data-google-ad=""/> -->
 
     <h1>Providing custom Checkstyle checks</h1>
-    <p> One great feature of Checkstyle is its extentablity. You can easily write own checks as explained <a
-            target="_blank" href="http://checkstyle.sourceforge.net/writingchecks.html">here <i
+    <p> One great feature of Checkstyle is its extensibility. You can easily write own checks as explained <a
+            target="_blank" href="https://checkstyle.org/writingchecks.html">here <i
                 class="fa fa-external-link"> </i></a> . <br/> To hook your checks into the eclipse-cs plugin you need to
         provide them as a extension plugin. </p>
     <p> In the further steps I am - for the sake of simplicity - assuming that you start off with the <a
@@ -20,8 +20,8 @@
                 reside there. <br/> In doing so you will be able to define your checks in your configuration file using
                 the logical check name - instead of needing to provide the fully qualified class name of your check.
                 <br/> For more info about the checkstyle packages files please read here: <a target="_blank"
-                    href="http://checkstyle.sourceforge.net/config.html#Packages"
-                    >http://checkstyle.sourceforge.net/config.html#Packages <i class="fa fa-external-link"> </i></a>
+                    href="https://checkstyle.org/config.html#Packages"
+                    >https://checkstyle.org/config.html#Packages <i class="fa fa-external-link"> </i></a>
             </p>
         </li>
         <li>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/custom-config.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/custom-config.html
@@ -102,47 +102,47 @@
     <p>Detailed information on the configuration options for each check can be found on the Checkstyle website:</p>
     <ul>
         <li>
-            <a target="_blank" href="http://checkstyle.sourceforge.net/config_javadoc.html">Javadoc Comments <i
+            <a target="_blank" href="https://checkstyle.org/config_javadoc.html">Javadoc Comments <i
                     class="fa fa-external-link"> </i></a>
         </li>
         <li>
-            <a target="_blank" href="http://checkstyle.sourceforge.net/config_naming.html">Naming Conventions <i
+            <a target="_blank" href="https://checkstyle.org/config_naming.html">Naming Conventions <i
                     class="fa fa-external-link"> </i></a>
         </li>
         <li>
-            <a target="_blank" href="http://checkstyle.sourceforge.net/config_imports.html">Imports <i
+            <a target="_blank" href="https://checkstyle.org/config_imports.html">Imports <i
                     class="fa fa-external-link"> </i></a>
         </li>
         <li>
-            <a target="_blank" href="http://checkstyle.sourceforge.net/config_sizes.html">Size Violations <i
+            <a target="_blank" href="https://checkstyle.org/config_sizes.html">Size Violations <i
                     class="fa fa-external-link"> </i></a>
         </li>
         <li>
-            <a target="_blank" href="http://checkstyle.sourceforge.net/config_whitespace.html">Whitespace <i
+            <a target="_blank" href="https://checkstyle.org/config_whitespace.html">Whitespace <i
                     class="fa fa-external-link"> </i></a>
         </li>
         <li>
-            <a target="_blank" href="http://checkstyle.sourceforge.net/config_modifier.html">Modifiers <i
+            <a target="_blank" href="https://checkstyle.org/config_modifier.html">Modifiers <i
                     class="fa fa-external-link"> </i></a>
         </li>
         <li>
-            <a target="_blank" href="http://checkstyle.sourceforge.net/config_blocks.html">Blocks <i
+            <a target="_blank" href="https://checkstyle.org/config_blocks.html">Blocks <i
                     class="fa fa-external-link"> </i></a>
         </li>
         <li>
-            <a target="_blank" href="http://checkstyle.sourceforge.net/config_headers.html">Headers <i
+            <a target="_blank" href="https://checkstyle.org/config_headers.html">Headers <i
                     class="fa fa-external-link"> </i></a>
         </li>
         <li>
-            <a target="_blank" href="http://checkstyle.sourceforge.net/config_coding.html">Coding Problems <i
+            <a target="_blank" href="https://checkstyle.org/config_coding.html">Coding Problems <i
                     class="fa fa-external-link"> </i></a>
         </li>
         <li>
-            <a href="http://checkstyle.sourceforge.net/config_design.html">Class Design <i class="fa fa-external-link"
+            <a href="https://checkstyle.org/config_design.html">Class Design <i class="fa fa-external-link"
                 > </i></a>
         </li>
         <li>
-            <a href="http://checkstyle.sourceforge.net/config_misc.html">Miscellaneous <i class="fa fa-external-link"
+            <a href="https://checkstyle.org/config_misc.html">Miscellaneous <i class="fa fa-external-link"
                 > </i></a>
         </li>
     </ul>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/index.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/index.html
@@ -66,7 +66,7 @@
                 <p class="text-justify">
                     The Eclipse Checkstyle Plugin (aka eclipse-cs) integrates the static source code
                     analyzer
-                    <a href="http://checkstyle.sourceforge.net/">
+                    <a href="https://checkstyle.org/">
                         Checkstyle
                         <i class="fa fa-external-link">
                         </i>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/properties.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/properties.html
@@ -2,7 +2,7 @@
     <!-- <div data-google-ad=""/> -->
 
     <h1>Property expansion in Checkstyle configuration files</h1>
-    <p>Checkstyle contains a <a target="_blank" href="http://checkstyle.sourceforge.net/config.html#Properties">feature
+    <p>Checkstyle contains a <a target="_blank" href="https://checkstyle.org/config.html#Properties">feature
                 <i class="fa fa-external-link"> </i></a> that lets you define module properties in a way that they can
         expanded dynamically when the configuration is loaded. <br/> Such a property is defined using the well known
             <code>${property_name}</code> notation.</p>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/10.0.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/10.0.0/release_notes.html
@@ -7,7 +7,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/10.1.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/10.1.0/release_notes.html
@@ -8,7 +8,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/4.3.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/4.3.0/release_notes.html
@@ -2,7 +2,7 @@
     <ul>
         <li>
             <p>Update release to include the all new Checkstyle 4.3. Please check the <a
-                    href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle release notes</a> to see
+                    href="https://checkstyle.org/releasenotes.html">Checkstyle release notes</a> to see
                 what's new.</p>
         </li>
         <li>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/5.0.0beta1/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/5.0.0beta1/release_notes.html
@@ -1,6 +1,6 @@
 <div>
     <p>This beta release of the plugin includes the recent Checkstyle 5.0beta1 (read <a
-            href="http://checkstyle.sourceforge.net/5.x/releasenotes.html">here</a>).</p>
+            href="https://checkstyle.org/releasenotes.html">here</a>).</p>
     <p>The 5.0.0 version of the plugin will be a major restructuring of the existing code. This includes splitting the
         grown, rather monolithic plugin into multiple smaller plugins where future development will be much easier to
         handle (hopefully).<br/> Most of the dissecting and putting-back-together has already taken place but is not yet

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/5.0.0beta2/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/5.0.0beta2/release_notes.html
@@ -1,5 +1,5 @@
 <div>
-    <p>This release integrates the new <a href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle 5.0
+    <p>This release integrates the new <a href="https://checkstyle.org/releasenotes.html">Checkstyle 5.0
             beta2</a>. </p>
     <p>A few plugin bugs have been fixed over beta1, as well as a few new features incorporated.<br/> Most notable is
         likely the Configuration Editor support for custom Checkstyle messages (a feature new in CS 5). </p>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/5.0.0beta3/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/5.0.0beta3/release_notes.html
@@ -1,5 +1,5 @@
 <div>
-    <p>This release integrates the new <a href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle 5.0
+    <p>This release integrates the new <a href="https://checkstyle.org/releasenotes.html">Checkstyle 5.0
             final</a>.<br/>Congratulations to the Checkstyle team for getting this major revision out the door.<br/></p>
     <p>Unfortunatly, the plugin itself is yet not ripe for its 5.0.0 final release.<br/>Because of the major
         restructurings done for the 5.0.0 stream large portions of the documentation are still outdated and need to be

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/5.2.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/5.2.0/release_notes.html
@@ -1,4 +1,4 @@
 <div>
-    <p>Upgraded Checkstyle core to 5.2.<br/> See <a href="http://checkstyle.sourceforge.net/releasenotes.html">here</a>
+    <p>Upgraded Checkstyle core to 5.2.<br/> See <a href="https://checkstyle.org/releasenotes.html">here</a>
         for more details.</p>
 </div>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/6.11.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/6.11.0/release_notes.html
@@ -7,7 +7,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>This plugin version was superficially verified to be compatible with Eclipse Mars.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
 </div>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/6.14.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/6.14.0/release_notes.html
@@ -6,7 +6,7 @@
     </p>
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
 

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/6.16.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/6.16.0/release_notes.html
@@ -6,7 +6,7 @@
     </p>
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
 

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/6.19.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/6.19.0/release_notes.html
@@ -6,7 +6,7 @@
     </p>
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
 

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/6.2.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/6.2.0/release_notes.html
@@ -7,7 +7,7 @@
         check have been removed without replacement.<br/> Also the configuration option <code>ignoreDirectoryName</code>
         of the <code>PackageDeclaration</code> checks has been removed.<br/>If your Checkstyle configuration uses one of
         those checks/options adaptations will be required in order to use your configuration with this
-        version.<br/>Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html"
+        version.<br/>Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html"
             >Checkstyle release notes</a> for details.</p>
     <h3>Bugfixes</h3>
     <ul>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/6.4.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/6.4.0/release_notes.html
@@ -7,7 +7,7 @@
         check have been removed without replacement.<br/> Also the configuration option <code>ignoreDirectoryName</code>
         of the <code>PackageDeclaration</code> checks has been removed.<br/>If your Checkstyle configuration uses one of
         those checks/options adaptations will be required in order to use your configuration with this
-        version.<br/>Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html"
+        version.<br/>Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html"
             >Checkstyle release notes</a> for details.</p>
     <h3>Bugfixes</h3>
     <ul>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/6.5.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/6.5.0/release_notes.html
@@ -6,7 +6,7 @@
     </p>
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
     <h3>Bugfixes</h3>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/6.8.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/6.8.0/release_notes.html
@@ -7,7 +7,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>This plugin version was superficially verified to be compatible with Eclipse Mars.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
     <h3>Bugfixes</h3>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/6.9.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/6.9.0/release_notes.html
@@ -7,7 +7,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>This plugin version was superficially verified to be compatible with Eclipse Mars.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
 </div>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/7.2.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/7.2.0/release_notes.html
@@ -7,7 +7,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>This plugin version was superficially verified to be compatible with Eclipse Mars.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
     <h3>Features</h3>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/7.3.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/7.3.0/release_notes.html
@@ -7,7 +7,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>This plugin version was superficially verified to be compatible with Eclipse Mars.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
     <h3>Features</h3>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/7.6.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/7.6.0/release_notes.html
@@ -7,7 +7,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>This plugin version was superficially verified to be compatible with Eclipse Mars.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
     <h3>Features</h3>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.0.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.0.0/release_notes.html
@@ -7,7 +7,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>This plugin version was superficially verified to be compatible with Eclipse Oxygen.</p>
     <p>
-        Please read the <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        Please read the <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes</a> for details on recent changes in Checkstyle.
     </p>
 </div>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.10.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.10.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.10.1/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.10.1/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.11.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.11.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.12.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.12.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.13.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.13.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.14.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.14.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.15.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.15.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.16.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.16.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.17.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.17.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.18.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.18.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.19.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.19.0/release_notes.html
@@ -2,7 +2,7 @@
     <p>Updates the Checkstyle core to version 8.19.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.20.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.20.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.21.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.21.0/release_notes.html
@@ -10,7 +10,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.22.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.22.0/release_notes.html
@@ -10,7 +10,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.23.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.23.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.24.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.24.0/release_notes.html
@@ -7,7 +7,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.25.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.25.0/release_notes.html
@@ -11,7 +11,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.26.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.26.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.27.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.27.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.28.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.28.0/release_notes.html
@@ -7,7 +7,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.29.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.29.0/release_notes.html
@@ -8,7 +8,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.30.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.30.0/release_notes.html
@@ -10,7 +10,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.31.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.31.0/release_notes.html
@@ -7,7 +7,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.32.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.32.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.33.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.33.0/release_notes.html
@@ -12,7 +12,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.34.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.34.0/release_notes.html
@@ -7,7 +7,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.35.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.35.0/release_notes.html
@@ -8,7 +8,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.36.1/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.36.1/release_notes.html
@@ -12,7 +12,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.36.2/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.36.2/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.37.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.37.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.38.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.38.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.39.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.39.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.40.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.40.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.41.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.41.0/release_notes.html
@@ -7,7 +7,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.41.1/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.41.1/release_notes.html
@@ -9,7 +9,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.42.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.42.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.43.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.43.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.44.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.44.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.45.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.45.0/release_notes.html
@@ -9,7 +9,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.45.1/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.45.1/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.5.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.5.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.7.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.7.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.8.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/8.8.0/release_notes.html
@@ -9,7 +9,7 @@
     <p>This restriction does not affect the ability to analyze Java 5 or lower level source code.</p>
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">Checkstyle
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">Checkstyle
             release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/9.0.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/9.0.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/9.0.1/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/9.0.1/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/9.1.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/9.1.0/release_notes.html
@@ -8,7 +8,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/9.2.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/9.2.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/9.2.1/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/9.2.1/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/9.3.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/9.3.0/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/src/main/templates/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/templates/release_notes.html
@@ -6,7 +6,7 @@
     
     <p>
         Please read the
-        <a target="_blank" href="http://checkstyle.sourceforge.net/releasenotes.html">
+        <a target="_blank" href="https://checkstyle.org/releasenotes.html">
             Checkstyle release notes
         </a>
         for details on recent and potentially breaking changes in Checkstyle.

--- a/net.sf.eclipsecs.doc/toc.xml
+++ b/net.sf.eclipsecs.doc/toc.xml
@@ -21,5 +21,5 @@
     </topic>
     <topic label="Release notes" href="docs/index.html#!/releasenotes"/>
     <topic label="FAQ" href="docs/index.html#!/faq"/>
-    <topic label="Checkstyle documentation" href="http://checkstyle.sourceforge.net/"/>
+    <topic label="Checkstyle documentation" href="https://checkstyle.org/"/>
 </toc>

--- a/net.sf.eclipsecs.sample/src/checkstyle_packages.xml
+++ b/net.sf.eclipsecs.sample/src/checkstyle_packages.xml
@@ -2,12 +2,12 @@
 
 <!DOCTYPE checkstyle-packages PUBLIC
     "-//Checkstyle//DTD Package Names Configuration 1.0//EN"
-    "http://checkstyle.org/dtds/packages_1_0.dtd">
+    "https://checkstyle.org/dtds/packages_1_0.dtd">
 
 <checkstyle-packages>
     <!--
       Define the Java packages where your custom Checkstyle module classes (checks, filters) reside here.
-      See http://checkstyle.sourceforge.net/config.html#Packages for more info.
+      See https://checkstyle.org/config.html#Packages for more info.
       -->
     <package name="net.sf.eclipsecs.sample.checks">
         <package name="dummysubpackage"/>


### PR DESCRIPTION
* Replace links to sourceforge by links to the checkstyle domain.
* Replace http by https. This avoids warnings in browsers that are configured for https only (which is what triggered my change initially)
* All links have been tested. There was just a single unreachable link to some beta release notes, it has been replaced by a link to the main release notes.
* Changes in eclipse specific files like feature.xml etc. will not have any functional impact, they are rather used in the about dialog and similar places.

It might be that a small amount of these changes may be overridden by the next checkstyle version update, since they may come from the main checkstyle project. That's okay and I may have a look into the documentation there also.