### PR TITLE
Update to Tycho 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </modules>
 
     <properties>
-        <tycho-version>1.6.0</tycho-version>
+        <tycho-version>2.1.0</tycho-version>
         <tycho.scmUrl>scm:git:git://github.com:checkstyle/eclipse-cs.git</tycho.scmUrl>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.checkstyle.plugin.version>3.1.1</maven.checkstyle.plugin.version>


### PR DESCRIPTION
This is the last version which compile the neon target (which is based on Java 1.6, any newer version would require to move the target platform up.