### PR TITLE
Issue #316: Allow third party checks to have a custom group name

### DIFF
--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
@@ -723,9 +723,7 @@ public final class MetadataFactory {
       }
 
       // process the modules
-      if (OTHER_GROUP_NAME.equals(groupName)) {
-        processModules(groupEl, group, metadataBundle);
-      }
+      processModules(groupEl, group, metadataBundle);
     }
   }
 


### PR DESCRIPTION
Issue #316

This seems to resolve the issue for me. I would need an explanation on how to verify the configuration menu works as intended, especially with modules with properties from sevntu.

I believe the issue is we are preventing third parties from creating their own custom group. Sevntu names it's group `SevNTU checks`. We were only allowing names `Other` in.

This may have been intended to prevent third parties from adding their own checks to Checkstyle's main groups?

Screenshot of test usage:
![eclipse-cs](https://user-images.githubusercontent.com/5427943/131607728-620e7d2d-d03f-46f2-9ae3-1c6ac37efd73.png)

Screenshot clearly shows highest eclipse-cs version and sevntu checks with descriptions. I was concerned that nothing was showing on the right hand side of the dialog under "Configured modules for group" and wanted to know how to test this more.