### PR TITLE
minor: add test package to travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,17 +23,35 @@ install:
 matrix:
   fast_finish: true
   include:
+    # JDK 8
+    - jdk: openjdk8
+      env:
+        - DESC="test package (openjdk8)"
+        - CMD="mvn test package && git diff"
+
     # JDK 8 (minimal supported Java version of eclipse-cs)
     - jdk: openjdk8
       env:
         - DESC="install (openjdk8)"
         - CMD="mvn install && git diff"
 
+    # JDK 11
+    - jdk: openjdk11
+      env:
+        - DESC="test package (openjdk11)"
+        - CMD="mvn test package && git diff"
+
     # JDK 11 (Long Term Support version)
     - jdk: openjdk11
       env:
         - DESC="install (openjdk11)"
         - CMD="mvn install && git diff"
+
+    # JDK 13
+    - jdk: openjdk13
+      env:
+        - DESC="test package (openjdk13)"
+        - CMD="mvn test package && git diff"
 
     # JDK 13 (most recent Java version)
     - jdk: openjdk13


### PR DESCRIPTION
Identified at https://github.com/checkstyle/eclipse-cs/pull/314#issuecomment-910288755 ,

Give a bit more automation by having CI run `test package` for contributors. For me, `install` did not run the same phases as `test package`,

No plugin testing needs to be done if CI passes as nothing was changed or affects plugin code.