### PR TITLE
Multiple source cleanups

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -202,6 +202,15 @@
             <property name="ignoreSetter" value="true"/>
             <property name="setterCanReturnItsClass" value="true"/>
         </module>
+        <module name="IllegalInstantiation">
+            <property name="classes"
+                      value="org.xml.sax.SAXException, org.xml.sax.SAXParseException,
+                         org.apache.commons.beanutils.ConversionException,
+                         org.antlr.v4.runtime.misc.ParseCancellationException,
+                         antlr.RecognitionException, antlr.TokenStreamException,
+                         antlr.TokenStreamRecognitionException, antlr.ANTLRException,
+                         java.lang.StringBuffer"/>
+        </module>
         <module name="IllegalThrows"/>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL"/>

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
@@ -499,7 +499,7 @@ public class Auditor {
 
       final String message = error.getMessage();
 
-      StringBuffer prefix = new StringBuffer();
+      StringBuilder prefix = new StringBuilder();
       if (mAddRuleName) {
         prefix.append(getRuleName(error));
       }
@@ -510,7 +510,7 @@ public class Auditor {
         prefix.append(error.getModuleId());
       }
 
-      StringBuffer buf = new StringBuffer();
+      StringBuilder buf = new StringBuilder();
       if (prefix.length() > 0) {
         buf.append(prefix).append(": "); //$NON-NLS-1$
       }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/CheckerFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/CheckerFactory.java
@@ -226,9 +226,7 @@ public final class CheckerFactory {
             ModuleLoadOption.TRY_IN_ALL_REGISTERED_PACKAGES));
     try {
       checker.setCharset(project.getDefaultCharset());
-    } catch (UnsupportedEncodingException e) {
-      CheckstylePluginException.rethrow(e);
-    } catch (CoreException e) {
+    } catch (UnsupportedEncodingException | CoreException e) {
       CheckstylePluginException.rethrow(e);
     }
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckConfigurationFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckConfigurationFactory.java
@@ -262,9 +262,7 @@ public final class CheckConfigurationFactory {
           return FileVisitResult.CONTINUE;
         }
       });
-    } catch (IllegalStateException e) {
-      CheckstylePluginException.rethrow(e);
-    } catch (IOException e) {
+    } catch (IllegalStateException | IOException e) {
       CheckstylePluginException.rethrow(e);
     }
   }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ConfigurationWriter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ConfigurationWriter.java
@@ -92,7 +92,7 @@ public final class ConfigurationWriter {
       doc.addDocType(XMLTags.MODULE_TAG, "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN",
               "https://checkstyle.org/dtds/configuration_1_3.dtd");
 
-      String lineSeperator = System.getProperty("line.separator"); //$NON-NLS-1$
+      String lineSeperator = System.lineSeparator();
 
       String comment = lineSeperator
               + "    This configuration file was written by the eclipse-cs plugin configuration editor" //$NON-NLS-1$

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/GlobalCheckConfigurationWorkingSet.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/GlobalCheckConfigurationWorkingSet.java
@@ -224,9 +224,7 @@ public class GlobalCheckConfigurationWorkingSet implements ICheckConfigurationWo
       List<IProject> usingProjects = ProjectConfigurationFactory
               .getProjectsUsingConfig(workingCopies[i]);
 
-      for (IProject proj : usingProjects) {
-        projects.add(proj);
-      }
+      projects.addAll(usingProjects);
     }
 
     return projects;

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ConfigurationTypes.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ConfigurationTypes.java
@@ -86,12 +86,9 @@ public final class ConfigurationTypes {
         String internalName = elements[i].getAttribute(ATTR_INTERNAL_NAME);
 
         String definingPluginId = elements[i].getDeclaringExtension().getNamespaceIdentifier();
-        boolean isCreatable = Boolean.valueOf(elements[i].getAttribute(ATTR_CREATABLE))
-                .booleanValue();
-        boolean isEditable = Boolean.valueOf(elements[i].getAttribute(ATTR_EDITABLE))
-                .booleanValue();
-        boolean isConfigurable = Boolean.valueOf(elements[i].getAttribute(ATTR_CONFIGURABLE))
-                .booleanValue();
+        boolean isCreatable = Boolean.parseBoolean(elements[i].getAttribute(ATTR_CREATABLE));
+        boolean isEditable = Boolean.parseBoolean(elements[i].getAttribute(ATTR_EDITABLE));
+        boolean isConfigurable = Boolean.parseBoolean(elements[i].getAttribute(ATTR_CONFIGURABLE));
 
         IConfigurationType configType = (IConfigurationType) elements[i]
                 .createExecutableExtension(ATTR_CLASS);

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ExternalFileConfigurationType.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ExternalFileConfigurationType.java
@@ -103,8 +103,7 @@ public class ExternalFileConfigurationType extends ConfigurationType {
 
     boolean isConfigurable = true;
 
-    boolean isProtected = Boolean
-            .valueOf(checkConfiguration.getAdditionalData().get(KEY_PROTECT_CONFIG)).booleanValue();
+    boolean isProtected = Boolean.parseBoolean(checkConfiguration.getAdditionalData().get(KEY_PROTECT_CONFIG));
     isConfigurable = !isProtected;
 
     if (!isProtected) {

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ProjectConfigurationType.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ProjectConfigurationType.java
@@ -63,8 +63,7 @@ public class ProjectConfigurationType extends ConfigurationType {
   public boolean isConfigurable(ICheckConfiguration checkConfiguration) {
     boolean isConfigurable = true;
 
-    boolean isProtected = Boolean
-            .valueOf(checkConfiguration.getAdditionalData().get(KEY_PROTECT_CONFIG)).booleanValue();
+    boolean isProtected = Boolean.parseBoolean(checkConfiguration.getAdditionalData().get(KEY_PROTECT_CONFIG));
     isConfigurable = !isProtected;
 
     if (!isProtected) {

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/PropertyUtil.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/PropertyUtil.java
@@ -87,7 +87,7 @@ public final class PropertyUtil {
     final List<String> propertyRefs = new ArrayList<>();
     parsePropertyString(aValue, fragments, propertyRefs);
 
-    final StringBuffer sb = new StringBuffer();
+    final StringBuilder sb = new StringBuilder();
     final Iterator<String> i = fragments.iterator();
     final Iterator<String> j = propertyRefs.iterator();
     while (i.hasNext()) {

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/RemoteConfigurationType.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/RemoteConfigurationType.java
@@ -425,9 +425,7 @@ public class RemoteConfigurationType extends ConfigurationType {
         prefs.put(KEY_PASSWORD, password, true);
 
         sFailedWith401URLs.remove(resolvedCheckConfigurationURL.toString());
-      } catch (CheckstylePluginException e) {
-        CheckstyleLog.log(e);
-      } catch (StorageException e) {
+      } catch (CheckstylePluginException | StorageException e) {
         CheckstyleLog.log(e);
       }
     }
@@ -470,9 +468,7 @@ public class RemoteConfigurationType extends ConfigurationType {
 
         urlHash = urlHash.replace('/', '_');
         urlHash = urlHash.replace('\\', '_');
-      } catch (NoSuchAlgorithmException e) {
-        CheckstylePluginException.rethrow(e);
-      } catch (UnsupportedEncodingException e) {
+      } catch (NoSuchAlgorithmException | UnsupportedEncodingException e) {
         CheckstylePluginException.rethrow(e);
       }
       return "eclipse-cs/" + urlHash;

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/RemoteConfigurationType.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/RemoteConfigurationType.java
@@ -88,8 +88,7 @@ public class RemoteConfigurationType extends ConfigurationType {
   public CheckstyleConfigurationFile getCheckstyleConfiguration(
           ICheckConfiguration checkConfiguration) throws CheckstylePluginException {
 
-    boolean useCacheFile = Boolean
-            .valueOf(checkConfiguration.getAdditionalData().get(KEY_CACHE_CONFIG)).booleanValue();
+    boolean useCacheFile = Boolean.parseBoolean(checkConfiguration.getAdditionalData().get(KEY_CACHE_CONFIG));
 
     CheckstyleConfigurationFile data = new CheckstyleConfigurationFile();
 
@@ -195,8 +194,7 @@ public class RemoteConfigurationType extends ConfigurationType {
     RemoteConfigAuthenticator
             .removeCachedAuthInfo(checkConfiguration.getResolvedConfigurationFileURL());
 
-    boolean useCacheFile = Boolean
-            .valueOf(checkConfiguration.getAdditionalData().get(KEY_CACHE_CONFIG)).booleanValue();
+    boolean useCacheFile = Boolean.parseBoolean(checkConfiguration.getAdditionalData().get(KEY_CACHE_CONFIG));
 
     if (useCacheFile) {
       // remove the cached configuration file from the workspace metadata

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
@@ -707,7 +707,7 @@ public final class MetadataFactory {
 
       if (group == null) {
 
-        boolean hidden = Boolean.valueOf(groupEl.attributeValue(XMLTags.HIDDEN_TAG)).booleanValue();
+        boolean hidden = Boolean.parseBoolean(groupEl.attributeValue(XMLTags.HIDDEN_TAG));
         int priority = 0;
         try {
           priority = Integer.parseInt(groupEl.attributeValue(XMLTags.PRIORITY_TAG));
@@ -744,11 +744,10 @@ public final class MetadataFactory {
       String parentName = moduleEl.attributeValue(XMLTags.PARENT_TAG) != null
               ? moduleEl.attributeValue(XMLTags.PARENT_TAG).trim()
               : null;
-      boolean hidden = Boolean.valueOf(moduleEl.attributeValue(XMLTags.HIDDEN_TAG)).booleanValue();
+      boolean hidden = Boolean.parseBoolean(moduleEl.attributeValue(XMLTags.HIDDEN_TAG));
       boolean hasSeverity = !"false".equals(moduleEl.attributeValue(XMLTags.HAS_SEVERITY_TAG));
       boolean deletable = !"false".equals(moduleEl.attributeValue(XMLTags.DELETABLE_TAG)); //$NON-NLS-1$
-      boolean isSingleton = Boolean.valueOf(moduleEl.attributeValue(XMLTags.IS_SINGLETON_TAG))
-              .booleanValue();
+      boolean isSingleton = Boolean.parseBoolean(moduleEl.attributeValue(XMLTags.IS_SINGLETON_TAG));
 
       // create rule metadata
       RuleMetadata module = new RuleMetadata(name, internalName, parentName, severity, hidden,

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
@@ -337,9 +337,7 @@ public final class MetadataFactory {
       resultList.forEach(val -> modifiedConfigPropertyMetadata.getPropertyEnumeration().add(val));
     } else if (dataType == ConfigPropertyType.MultiCheck) {
       String result = CheckUtil.getModifiableTokens(moduleDetails.getName());
-      for (String val : result.split(",")) {
-        modifiedConfigPropertyMetadata.getPropertyEnumeration().add(val);
-      }
+      Collections.addAll(modifiedConfigPropertyMetadata.getPropertyEnumeration(), result.split(","));
     }
     return modifiedConfigPropertyMetadata;
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
@@ -382,7 +382,7 @@ public final class MetadataFactory {
       Class<?> checkClass = CheckstylePlugin.getDefault().getAddonExtensionClassLoader()
               .loadClass(module.getName());
 
-      Object moduleInstance = checkClass.newInstance();
+      Object moduleInstance = checkClass.getDeclaredConstructor().newInstance();
 
       if (moduleInstance instanceof AbstractFileSetCheck) {
         parent = XMLTags.CHECKER_MODULE;
@@ -834,7 +834,7 @@ public final class MetadataFactory {
 
             if (IOptionProvider.class.isAssignableFrom(providerClass)) {
 
-              IOptionProvider provider = (IOptionProvider) providerClass.newInstance();
+              IOptionProvider provider = (IOptionProvider) providerClass.getDeclaredConstructor().newInstance();
               property.getPropertyEnumeration().addAll(provider.getOptions());
             } else if (Enum.class.isAssignableFrom(providerClass)) {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/TransformCheckstyleRulesJob.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/TransformCheckstyleRulesJob.java
@@ -117,11 +117,7 @@ public class TransformCheckstyleRulesJob extends WorkspaceJob {
 
       final CheckstyleTransformer transformer = new CheckstyleTransformer(mProject, rules);
       transformer.transformRules();
-    } catch (CheckstyleException e) {
-      Status status = new Status(IStatus.ERROR, CheckstylePlugin.PLUGIN_ID, IStatus.ERROR,
-              e.getMessage(), e);
-      throw new CoreException(status);
-    } catch (CheckstylePluginException e) {
+    } catch (CheckstyleException | CheckstylePluginException e) {
       Status status = new Status(IStatus.ERROR, CheckstylePlugin.PLUGIN_ID, IStatus.ERROR,
               e.getMessage(), e);
       throw new CoreException(status);

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/PluginFilters.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/PluginFilters.java
@@ -87,13 +87,12 @@ public final class PluginFilters {
         String name = elements[i].getAttribute(ATTR_NAME);
         String internalName = elements[i].getAttribute(ATTR_INTERNAL_NAME);
         String desc = elements[i].getAttribute(ATTR_DESCRIPTION);
-        boolean readOnly = Boolean.valueOf(elements[i].getAttribute(ATTR_READONLY)).booleanValue();
+        boolean readOnly = Boolean.parseBoolean(elements[i].getAttribute(ATTR_READONLY));
 
         IFilter filter = (IFilter) elements[i].createExecutableExtension(ATTR_CLASS);
         filter.initialize(name, internalName, desc, readOnly);
 
-        boolean defaultState = Boolean.valueOf(elements[i].getAttribute(ATTR_SELECTED))
-                .booleanValue();
+        boolean defaultState = Boolean.parseBoolean(elements[i].getAttribute(ATTR_SELECTED));
 
         filter.setEnabled(defaultState);
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/ProjectConfigurationFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/ProjectConfigurationFactory.java
@@ -189,10 +189,8 @@ public final class ProjectConfigurationFactory {
       throw new CheckstylePluginException(NLS.bind(Messages.errorUnknownFileFormat, version));
     }
 
-    boolean useSimpleConfig = Boolean.valueOf(root.attributeValue(XMLTags.SIMPLE_CONFIG_TAG))
-            .booleanValue();
-    boolean syncFormatter = Boolean.valueOf(root.attributeValue(XMLTags.SYNC_FORMATTER_TAG))
-            .booleanValue();
+    boolean useSimpleConfig = Boolean.parseBoolean(root.attributeValue(XMLTags.SIMPLE_CONFIG_TAG));
+    boolean syncFormatter = Boolean.parseBoolean(root.attributeValue(XMLTags.SYNC_FORMATTER_TAG));
 
     List<ICheckConfiguration> checkConfigs = getLocalCheckConfigs(root, project);
     List<FileSet> fileSets = getFileSets(root, checkConfigs);
@@ -262,12 +260,12 @@ public final class ProjectConfigurationFactory {
     List<Element> fileSetElements = root.elements(XMLTags.FILESET_TAG);
     for (Element fileSetEl : fileSetElements) {
 
-      boolean local = Boolean.valueOf(fileSetEl.attributeValue(XMLTags.LOCAL_TAG)).booleanValue();
+      boolean local = Boolean.parseBoolean(fileSetEl.attributeValue(XMLTags.LOCAL_TAG));
 
       FileSet fileSet = new FileSet();
       fileSet.setName(fileSetEl.attributeValue(XMLTags.NAME_TAG));
       fileSet.setEnabled(
-              Boolean.valueOf(fileSetEl.attributeValue(XMLTags.ENABLED_TAG)).booleanValue());
+              Boolean.parseBoolean(fileSetEl.attributeValue(XMLTags.ENABLED_TAG)));
 
       // find the referenced check configuration
       ICheckConfiguration checkConfig = null;
@@ -291,8 +289,7 @@ public final class ProjectConfigurationFactory {
       for (Element patternEl : patternElements) {
         FileMatchPattern pattern = new FileMatchPattern(
                 patternEl.attributeValue(XMLTags.MATCH_PATTERN_TAG));
-        pattern.setIsIncludePattern(Boolean
-                .valueOf(patternEl.attributeValue(XMLTags.INCLUDE_PATTERN_TAG)).booleanValue());
+        pattern.setIsIncludePattern(Boolean.parseBoolean(patternEl.attributeValue(XMLTags.INCLUDE_PATTERN_TAG)));
         patterns.add(pattern);
       }
       fileSet.setFileMatchPatterns(patterns);
@@ -315,7 +312,7 @@ public final class ProjectConfigurationFactory {
       // guard against unknown/retired filters
       if (filter != null) {
         filter.setEnabled(
-                Boolean.valueOf(filterEl.attributeValue(XMLTags.ENABLED_TAG)).booleanValue());
+                Boolean.parseBoolean(filterEl.attributeValue(XMLTags.ENABLED_TAG)));
 
         // get the filter data
         List<String> filterData = new ArrayList<>();

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/ProjectConfigurationWorkingCopy.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/ProjectConfigurationWorkingCopy.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -245,9 +246,7 @@ public class ProjectConfigurationWorkingCopy implements Cloneable, IProjectConfi
   public List<ICheckConfiguration> getLocalCheckConfigurations() {
 
     List<ICheckConfiguration> l = new ArrayList<>();
-    for (ICheckConfiguration c : mLocalConfigWorkingSet.getWorkingCopies()) {
-      l.add(c);
-    }
+    Collections.addAll(l, mLocalConfigWorkingSet.getWorkingCopies());
 
     return l;
   }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/NonSrcDirsFilter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/NonSrcDirsFilter.java
@@ -32,11 +32,10 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.core.JavaModelException;
 
 /**
  * Implementation of a filter that filters all ressources that are not within a source directory.
- * 
+ *
  * @author Lars Ködderitzsch
  */
 public class NonSrcDirsFilter extends AbstractFilter {
@@ -76,7 +75,7 @@ public class NonSrcDirsFilter extends AbstractFilter {
 
   /**
    * Gets all source paths of a project.
-   * 
+   *
    * @param project
    *          the project
    * @return the list of source paths
@@ -95,8 +94,6 @@ public class NonSrcDirsFilter extends AbstractFilter {
           }
         }
       }
-    } catch (JavaModelException e) {
-      CheckstyleLog.log(e);
     } catch (CoreException e) {
       CheckstyleLog.log(e);
     }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/PackageFilter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/PackageFilter.java
@@ -121,7 +121,7 @@ public class PackageFilter extends AbstractFilter {
   @Override
   public String getPresentableFilterData() {
 
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
 
     int size = mData != null ? mData.size() : 0;
     for (int i = 0; i < size; i++) {

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/CheckstyleTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/CheckstyleTransformer.java
@@ -99,7 +99,7 @@ public class CheckstyleTransformer {
       try {
         transformationClass = CheckstylePlugin.getDefault().getAddonExtensionClassLoader()
                 .loadClass(name);
-        final CTransformationClass transObj = (CTransformationClass) transformationClass
+        final CTransformationClass transObj = (CTransformationClass) transformationClass.getDeclaredConstructor()
                 .newInstance();
         transObj.setRule(rule);
         mTransformationClasses.add(transObj);
@@ -107,7 +107,7 @@ public class CheckstyleTransformer {
         // + rule.getName() + "\"");
       } catch (final ClassNotFoundException e) {
         // NOOP there is just no appropriate transformer class
-      } catch (final InstantiationException | IllegalAccessException e) {
+      } catch (final ReflectiveOperationException e) {
         CheckstylePluginException.rethrow(e);
       }
     }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/CheckstyleTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/CheckstyleTransformer.java
@@ -107,9 +107,7 @@ public class CheckstyleTransformer {
         // + rule.getName() + "\"");
       } catch (final ClassNotFoundException e) {
         // NOOP there is just no appropriate transformer class
-      } catch (final InstantiationException e) {
-        CheckstylePluginException.rethrow(e);
-      } catch (final IllegalAccessException e) {
+      } catch (final InstantiationException | IllegalAccessException e) {
         CheckstylePluginException.rethrow(e);
       }
     }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/FormatterTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/FormatterTransformer.java
@@ -106,9 +106,7 @@ public class FormatterTransformer {
 
       } catch (final ClassNotFoundException e) {
         // NOOP no appropriate transformer class present
-      } catch (final InstantiationException e) {
-        CheckstylePluginException.rethrow(e);
-      } catch (final IllegalAccessException e) {
+      } catch (final InstantiationException | IllegalAccessException e) {
         CheckstylePluginException.rethrow(e);
       }
     }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/FormatterTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/FormatterTransformer.java
@@ -97,7 +97,7 @@ public class FormatterTransformer {
         transformationClass = CheckstylePlugin.getDefault().getAddonExtensionClassLoader()
                 .loadClass(name);
 
-        final FTransformationClass transObj = (FTransformationClass) transformationClass
+        final FTransformationClass transObj = (FTransformationClass) transformationClass.getDeclaredConstructor()
                 .newInstance();
 
         transObj.setValue(mFormatterSetting.getFormatterSettings().get(rule));
@@ -106,7 +106,7 @@ public class FormatterTransformer {
 
       } catch (final ClassNotFoundException e) {
         // NOOP no appropriate transformer class present
-      } catch (final InstantiationException | IllegalAccessException e) {
+      } catch (final ReflectiveOperationException e) {
         CheckstylePluginException.rethrow(e);
       }
     }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/util/XMLUtil.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/util/XMLUtil.java
@@ -45,7 +45,7 @@ public final class XMLUtil {
 
   /**
    * Creates a pretty printed representation of the document as a byte array.
-   * 
+   *
    * @param document
    *          the document
    * @return the document as a byte array (UTF-8)
@@ -66,7 +66,7 @@ public final class XMLUtil {
 
   /**
    * Entity resolver which handles mapping public DTDs to internal DTD resource.
-   * 
+   *
    * @author Lars Ködderitzsch
    */
   public static class InternalDtdEntityResolver implements EntityResolver {
@@ -75,7 +75,7 @@ public final class XMLUtil {
 
     /**
      * Creates the entity resolver using a mapping of public DTD name to internal DTD resource.
-     * 
+     *
      * @param public2InternalDtdMap
      *          the public2internal DTD mapping
      */
@@ -95,6 +95,7 @@ public final class XMLUtil {
 
         final InputStream dtdIS = getClass().getClassLoader().getResourceAsStream(dtdResourceName);
         if (dtdIS == null) {
+          // -@cs[IllegalInstantiation] SAXException is in the overridden method signature
           throw new SAXException("Unable to load internal dtd " + dtdResourceName); //$NON-NLS-1$
         }
         return new InputSource(dtdIS);

--- a/net.sf.eclipsecs.sample/src/net/sf/eclipsecs/sample/checks/MethodLimitQuickfix.java
+++ b/net.sf.eclipsecs.sample/src/net/sf/eclipsecs/sample/checks/MethodLimitQuickfix.java
@@ -15,11 +15,13 @@ public class MethodLimitQuickfix extends AbstractASTResolution {
   /**
    * {@inheritDoc}
    */
+  @Override
   protected ASTVisitor handleGetCorrectingASTVisitor(final IRegion lineInfo,
       final int markerStartOffset) {
 
     return new ASTVisitor() {
 
+      @Override
       @SuppressWarnings("unchecked")
       public boolean visit(MethodDeclaration node) {
 
@@ -43,6 +45,7 @@ public class MethodLimitQuickfix extends AbstractASTResolution {
   /**
    * {@inheritDoc}
    */
+  @Override
   public String getDescription() {
     return "Sample MethodLimit Quickfix";
   }
@@ -50,6 +53,7 @@ public class MethodLimitQuickfix extends AbstractASTResolution {
   /**
    * {@inheritDoc}
    */
+  @Override
   public String getLabel() {
     return "Sample MethodLimit Quickfix";
   }
@@ -57,6 +61,7 @@ public class MethodLimitQuickfix extends AbstractASTResolution {
   /**
    * {@inheritDoc}
    */
+  @Override
   public Image getImage() {
     return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_CHANGE);
   }

--- a/net.sf.eclipsecs.sample/src/net/sf/eclipsecs/sample/filter/SampleFilter.java
+++ b/net.sf.eclipsecs.sample/src/net/sf/eclipsecs/sample/filter/SampleFilter.java
@@ -6,6 +6,7 @@ import net.sf.eclipsecs.core.projectconfig.filters.AbstractFilter;
 @ThreadSafe
 public class SampleFilter extends AbstractFilter {
 
+  @Override
   public boolean accept(Object element) {
 
     return false;

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/CheckstyleUIPlugin.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/CheckstyleUIPlugin.java
@@ -21,6 +21,7 @@
 package net.sf.eclipsecs.ui;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 
@@ -101,9 +102,7 @@ public class CheckstyleUIPlugin extends AbstractUIPlugin {
             for (IWorkbenchPage page : pages) {
 
               IEditorReference[] editorRefs = page.getEditorReferences();
-              for (IEditorReference ref : editorRefs) {
-                parts.add(ref);
-              }
+              Collections.addAll(parts, editorRefs);
             }
 
             mPartListener.partsOpened(parts);

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/CheckstyleUIPlugin.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/CheckstyleUIPlugin.java
@@ -43,6 +43,7 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
@@ -81,7 +82,7 @@ public class CheckstyleUIPlugin extends AbstractUIPlugin {
             QUICKFIX_PROVIDER_EXT_PT_ID);
 
     // add listeners for the Check-On-Open support
-    final IWorkbench workbench = getWorkbench();
+    final IWorkbench workbench = PlatformUI.getWorkbench();
     workbench.getDisplay().asyncExec(new Runnable() {
       @Override
       public void run() {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/ActivateProjectsAction.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/ActivateProjectsAction.java
@@ -81,7 +81,7 @@ public class ActivateProjectsAction implements IObjectActionDelegate {
    * 
    * @author Lars Ködderitzsch
    */
-  private class BulkCheckstyleActivateJob extends WorkspaceJob {
+  private static class BulkCheckstyleActivateJob extends WorkspaceJob {
 
     private Collection<IProject> mProjectsToActivate;
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/ClearSelectedFilesAction.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/ClearSelectedFilesAction.java
@@ -84,7 +84,7 @@ public class ClearSelectedFilesAction implements IObjectActionDelegate {
    * 
    * @author Lars Ködderitzsch
    */
-  private class ClearMarkersJob extends WorkspaceJob {
+  private static class ClearMarkersJob extends WorkspaceJob {
 
     private Collection<IResource> mResourcesToClear;
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/ConfigureProjectFromBluePrintAction.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/ConfigureProjectFromBluePrintAction.java
@@ -120,7 +120,7 @@ public class ConfigureProjectFromBluePrintAction implements IObjectActionDelegat
    * 
    * @author Lars Ködderitzsch
    */
-  private class BulkConfigureJob extends WorkspaceJob {
+  private static class BulkConfigureJob extends WorkspaceJob {
 
     private final IProject mBlueprint;
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/ConfigureProjectFromBluePrintAction.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/ConfigureProjectFromBluePrintAction.java
@@ -22,6 +22,7 @@ package net.sf.eclipsecs.ui.actions;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import net.sf.eclipsecs.core.config.CheckConfigurationWorkingCopy;
@@ -90,9 +91,7 @@ public class ConfigureProjectFromBluePrintAction implements IObjectActionDelegat
 
     IProject[] projects = CheckstyleUIPlugin.getWorkspace().getRoot().getProjects();
     List<IProject> filteredProjects = new ArrayList<>();
-    for (int i = 0; i < projects.length; i++) {
-      filteredProjects.add(projects[i]);
-    }
+    Collections.addAll(filteredProjects, projects);
 
     filteredProjects.removeAll(mSelectedProjects);
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/DeactivateProjectsAction.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/DeactivateProjectsAction.java
@@ -81,7 +81,7 @@ public class DeactivateProjectsAction implements IObjectActionDelegate {
    * 
    * @author Lars Ködderitzsch
    */
-  private class BulkCheckstyleActivateJob extends WorkspaceJob {
+  private static class BulkCheckstyleActivateJob extends WorkspaceJob {
 
     private Collection<IProject> mProjectsToDeactivate;
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
@@ -802,7 +802,7 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
    *
    * @author Lars Ködderitzsch
    */
-  private class MetaDataContentProvider implements ITreeContentProvider {
+  private static class MetaDataContentProvider implements ITreeContentProvider {
 
     /**
      * @see org.eclipse.jface.viewers.IStructuredContentProvider#getElements(java.lang.Object)
@@ -951,7 +951,7 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
    *
    * @author Lars Ködderitzsch
    */
-  private class ModuleLabelProvider extends LabelProvider
+  private static class ModuleLabelProvider extends LabelProvider
           implements ITableLabelProvider, ITableComparableProvider, ITableSettingsProvider {
 
     /**
@@ -1030,7 +1030,7 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
    *
    * @author Lars Ködderitzsch
    */
-  private class RuleGroupModuleFilter extends ViewerFilter {
+  private static class RuleGroupModuleFilter extends ViewerFilter {
 
     /** the current rule group. */
     private RuleGroupMetadata mCurrentGroup;

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
@@ -1128,7 +1128,7 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
    * @return HTML converted description
    */
   public static String getDescriptionHtml(String description) {
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
     buf.append("<html><body style=\"margin: 3px; font-size: 11px; ");
     buf.append("font-family: verdana, 'trebuchet MS', helvetica, sans-serif;\">");
     buf.append(description != null ? description

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/ResolvablePropertiesDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/ResolvablePropertiesDialog.java
@@ -425,7 +425,7 @@ public class ResolvablePropertiesDialog extends TitleAreaDialog {
 
         if (!unresolvedProps.isEmpty()) {
 
-          StringBuffer buf = new StringBuffer();
+          StringBuilder buf = new StringBuilder();
           it = unresolvedProps.iterator();
           while (it.hasNext()) {
             buf.append("\t${").append(it.next().getPropertyName()).append("}\n");

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ConfigurationTypesUI.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ConfigurationTypesUI.java
@@ -39,7 +39,7 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 /**
  * Register for the configuration types ui thats use the
  * <i>net.sf.eclipsecs.ui.configtypesui </i> extension point.
- * 
+ *
  * @author Lars Ködderitzsch
  */
 public final class ConfigurationTypesUI {
@@ -106,7 +106,7 @@ public final class ConfigurationTypesUI {
 
   /**
    * Creates the editor for a given configuration type.
-   * 
+   *
    * @param configType
    *          the configuration type
    * @return the editor
@@ -122,9 +122,9 @@ public final class ConfigurationTypesUI {
     if (editorClass != null) {
 
       try {
-        ICheckConfigurationEditor editor = editorClass.newInstance();
+        ICheckConfigurationEditor editor = editorClass.getDeclaredConstructor().newInstance();
         return editor;
-      } catch (InstantiationException | IllegalAccessException | ClassCastException e) {
+      } catch (ClassCastException | ReflectiveOperationException e) {
         CheckstylePluginException.rethrow(e);
       }
     }
@@ -134,7 +134,7 @@ public final class ConfigurationTypesUI {
 
   /**
    * Return an image for the given configuration type.
-   * 
+   *
    * @param configType
    *          the configuration type
    * @return the image representing the configuration type or <code>null</code>

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ConfigurationTypesUI.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ConfigurationTypesUI.java
@@ -124,11 +124,7 @@ public final class ConfigurationTypesUI {
       try {
         ICheckConfigurationEditor editor = editorClass.newInstance();
         return editor;
-      } catch (InstantiationException e) {
-        CheckstylePluginException.rethrow(e);
-      } catch (IllegalAccessException e) {
-        CheckstylePluginException.rethrow(e);
-      } catch (ClassCastException e) {
+      } catch (InstantiationException | IllegalAccessException | ClassCastException e) {
         CheckstylePluginException.rethrow(e);
       }
     }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ExternalFileConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ExternalFileConfigurationEditor.java
@@ -197,9 +197,7 @@ public class ExternalFileConfigurationEditor implements ICheckConfigurationEdito
       mDescription.setText(mWorkingCopy.getDescription());
     }
 
-    mChkProtectConfig.setSelection(Boolean.valueOf(
-            mWorkingCopy.getAdditionalData().get(ExternalFileConfigurationType.KEY_PROTECT_CONFIG))
-            .booleanValue());
+    mChkProtectConfig.setSelection(Boolean.parseBoolean(mWorkingCopy.getAdditionalData().get(ExternalFileConfigurationType.KEY_PROTECT_CONFIG)));
 
     return contents;
   }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ProjectConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ProjectConfigurationEditor.java
@@ -234,9 +234,7 @@ public class ProjectConfigurationEditor implements ICheckConfigurationEditor {
       mDescription.setText(mWorkingCopy.getDescription());
     }
 
-    mChkProtectConfig.setSelection(Boolean.valueOf(
-            mWorkingCopy.getAdditionalData().get(ExternalFileConfigurationType.KEY_PROTECT_CONFIG))
-            .booleanValue());
+    mChkProtectConfig.setSelection(Boolean.parseBoolean(mWorkingCopy.getAdditionalData().get(ExternalFileConfigurationType.KEY_PROTECT_CONFIG)));
 
     return contents;
   }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/RemoteConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/RemoteConfigurationEditor.java
@@ -186,9 +186,7 @@ public class RemoteConfigurationEditor implements ICheckConfigurationEditor {
       mDescription.setText(mWorkingCopy.getDescription());
     }
 
-    mChkCacheConfig.setSelection(Boolean
-            .valueOf(mWorkingCopy.getAdditionalData().get(RemoteConfigurationType.KEY_CACHE_CONFIG))
-            .booleanValue());
+    mChkCacheConfig.setSelection(Boolean.parseBoolean(mWorkingCopy.getAdditionalData().get(RemoteConfigurationType.KEY_CACHE_CONFIG)));
 
     if (mWorkingCopy.getLocation() != null) {
       try {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetBoolean.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetBoolean.java
@@ -60,7 +60,7 @@ public class ConfigPropertyWidgetBoolean extends ConfigPropertyWidgetAbstractBas
       mCheckbox.setLayoutData(new GridData());
 
       String initValue = getInitValue();
-      mCheckbox.setSelection(Boolean.valueOf(initValue).booleanValue());
+      mCheckbox.setSelection(Boolean.parseBoolean(initValue));
 
     }
     return mCheckbox;
@@ -76,6 +76,6 @@ public class ConfigPropertyWidgetBoolean extends ConfigPropertyWidgetAbstractBas
     ConfigPropertyMetadata metadata = getConfigProperty().getMetaData();
     String defaultValue = metadata.getOverrideDefault() != null ? metadata.getOverrideDefault()
             : metadata.getDefaultValue();
-    mCheckbox.setSelection(Boolean.valueOf(defaultValue).booleanValue());
+    mCheckbox.setSelection(Boolean.parseBoolean(defaultValue));
   }
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetMultiCheck.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetMultiCheck.java
@@ -129,7 +129,7 @@ public class ConfigPropertyWidgetMultiCheck extends ConfigPropertyWidgetAbstract
    */
   @Override
   public String getValue() {
-    StringBuffer buffer = new StringBuffer(""); //$NON-NLS-1$
+    StringBuilder buffer = new StringBuilder(""); //$NON-NLS-1$
 
     Object[] checkedElements = mTable.getCheckedElements();
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetMultiCheck.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetMultiCheck.java
@@ -186,11 +186,11 @@ public class ConfigPropertyWidgetMultiCheck extends ConfigPropertyWidgetAbstract
   @Override
   public void preferenceChange(PreferenceChangeEvent event) {
     if (CheckstyleUIPluginPrefs.PREF_TRANSLATE_TOKENS.equals(event.getKey())) {
-      mTranslateTokens = Boolean.valueOf((String) event.getNewValue()).booleanValue();
+      mTranslateTokens = Boolean.parseBoolean((String) event.getNewValue());
       mTable.refresh(true);
     }
     if (CheckstyleUIPluginPrefs.PREF_SORT_TOKENS.equals(event.getKey())) {
-      mSortTokens = Boolean.valueOf((String) event.getNewValue()).booleanValue();
+      mSortTokens = Boolean.parseBoolean((String) event.getNewValue());
       installSorter(mSortTokens);
     }
   }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/preferences/CheckstylePreferencePage.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/preferences/CheckstylePreferencePage.java
@@ -447,10 +447,7 @@ public class CheckstylePreferencePage extends PreferencePage implements IWorkben
                   NLS.bind(Messages.errorFailedRebuild, e.getMessage()), e, true);
         }
       }
-    } catch (CheckstylePluginException e) {
-      CheckstyleUIPlugin.errorDialog(getShell(),
-              NLS.bind(Messages.errorFailedSavePreferences, e.getLocalizedMessage()), e, true);
-    } catch (BackingStoreException e) {
+    } catch (CheckstylePluginException | BackingStoreException e) {
       CheckstyleUIPlugin.errorDialog(getShell(),
               NLS.bind(Messages.errorFailedSavePreferences, e.getLocalizedMessage()), e, true);
     }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/CheckConfigurationContentProvider.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/CheckConfigurationContentProvider.java
@@ -50,7 +50,7 @@ class CheckConfigurationContentProvider implements IStructuredContentProvider {
 
     List<ICheckConfiguration> configurations = new ArrayList<>();
 
-    if (inputElement != null && inputElement instanceof ProjectConfigurationWorkingCopy) {
+    if (inputElement instanceof ProjectConfigurationWorkingCopy) {
       ICheckConfiguration[] localConfigs = ((ProjectConfigurationWorkingCopy) inputElement)
               .getLocalCheckConfigWorkingSet().getWorkingCopies();
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/CheckstylePropertyPage.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/CheckstylePropertyPage.java
@@ -174,9 +174,7 @@ public class CheckstylePropertyPage extends PropertyPage {
       mProjectConfig = new ProjectConfigurationWorkingCopy(projectConfig);
 
       mCheckstyleInitiallyActivated = project.hasNature(CheckstyleNature.NATURE_ID);
-    } catch (CoreException e) {
-      handleConfigFileError(e, project);
-    } catch (CheckstylePluginException e) {
+    } catch (CoreException | CheckstylePluginException e) {
       handleConfigFileError(e, project);
     }
   }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/CheckstylePropertyPage.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/CheckstylePropertyPage.java
@@ -354,7 +354,7 @@ public class CheckstylePropertyPage extends PropertyPage {
       @Override
       public String getText(Object element) {
 
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
 
         if (element instanceof IFilter) {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/FileMatchPatternEditDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/FileMatchPatternEditDialog.java
@@ -145,10 +145,7 @@ public class FileMatchPatternEditDialog extends TitleAreaDialog {
       }
 
       mPattern.setIsIncludePattern(mIncludeButton.getSelection());
-    } catch (PatternSyntaxException e) {
-      this.setErrorMessage(e.getLocalizedMessage());
-      return;
-    } catch (CheckstylePluginException e) {
+    } catch (PatternSyntaxException | CheckstylePluginException e) {
       this.setErrorMessage(e.getLocalizedMessage());
       return;
     }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/CheckFileOnOpenPartListener.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/CheckFileOnOpenPartListener.java
@@ -319,13 +319,7 @@ public class CheckFileOnOpenPartListener implements IPartListener2 {
           CheckstyleLog.log(e1);
         }
       }
-    } catch (NoSuchMethodException e1) {
-      CheckstyleLog.log(e1);
-    } catch (SecurityException e1) {
-      CheckstyleLog.log(e1);
-    } catch (IllegalAccessException e1) {
-      CheckstyleLog.log(e1);
-    } catch (InvocationTargetException e1) {
+    } catch (NoSuchMethodException | SecurityException | IllegalAccessException | InvocationTargetException e1) {
       CheckstyleLog.log(e1);
     }
 
@@ -344,13 +338,7 @@ public class CheckFileOnOpenPartListener implements IPartListener2 {
 
       IMemento memento = (IMemento) getMementoMethod.invoke(e, (Object[]) null);
       return memento;
-    } catch (NoSuchMethodException e1) {
-      CheckstyleLog.log(e1);
-    } catch (SecurityException e1) {
-      CheckstyleLog.log(e1);
-    } catch (IllegalAccessException e1) {
-      CheckstyleLog.log(e1);
-    } catch (InvocationTargetException e1) {
+    } catch (NoSuchMethodException | SecurityException | IllegalAccessException | InvocationTargetException e1) {
       CheckstyleLog.log(e1);
     }
     return null;
@@ -394,11 +382,7 @@ public class CheckFileOnOpenPartListener implements IPartListener2 {
 
         affected = unOpenedFilesFilterActive && !filtered;
       }
-    } catch (CoreException e) {
-      // should never happen, since editor cannot be open
-      // when project isn't
-      CheckstyleLog.log(e);
-    } catch (CheckstylePluginException e) {
+    } catch (CoreException | CheckstylePluginException e) {
       CheckstyleLog.log(e);
     }
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/CheckFileOnOpenPartListener.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/CheckFileOnOpenPartListener.java
@@ -230,7 +230,7 @@ public class CheckFileOnOpenPartListener implements IPartListener2 {
 
     IEditorInput input = null;
 
-    if (part != null && part instanceof IEditorPart) {
+    if (part instanceof IEditorPart) {
 
       IEditorPart editor = (IEditorPart) part;
       input = editor.getEditorInput();

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/PackageFilterEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/PackageFilterEditor.java
@@ -206,7 +206,7 @@ public class PackageFilterEditor implements IFilterEditor {
    *
    * @author Lars Ködderitzsch
    */
-  private class SourceFolderContentProvider implements ITreeContentProvider {
+  private static class SourceFolderContentProvider implements ITreeContentProvider {
 
     /**
      * @see org.eclipse.jface.viewers.ITreeContentProvider#getChildren(java.lang.Object)

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/PluginFilterEditors.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/PluginFilterEditors.java
@@ -112,11 +112,7 @@ public final class PluginFilterEditors {
       try {
         IFilterEditor editor = editorClass.newInstance();
         return editor;
-      } catch (InstantiationException e) {
-        CheckstylePluginException.rethrow(e);
-      } catch (IllegalAccessException e) {
-        CheckstylePluginException.rethrow(e);
-      } catch (ClassCastException e) {
+      } catch (InstantiationException | IllegalAccessException | ClassCastException e) {
         CheckstylePluginException.rethrow(e);
       }
     }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/PluginFilterEditors.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/PluginFilterEditors.java
@@ -34,7 +34,7 @@ import org.eclipse.core.runtime.Platform;
 /**
  * Register for the filter editors thats use the
  * <i>net.sf.eclipsecs.ui.filtereditors </i> extension point.
- * 
+ *
  * @author Lars Ködderitzsch
  */
 public final class PluginFilterEditors {
@@ -84,7 +84,7 @@ public final class PluginFilterEditors {
 
   /**
    * Determines if a given filter has an editor.
-   * 
+   *
    * @param filter
    *          the filter
    * @return <code>true</code> if the filter has an editor, <code>false</code>
@@ -96,7 +96,7 @@ public final class PluginFilterEditors {
 
   /**
    * Creates the filter editor for a given filter.
-   * 
+   *
    * @param filter
    *          the filter
    * @return the filter editor
@@ -110,9 +110,9 @@ public final class PluginFilterEditors {
     if (editorClass != null) {
 
       try {
-        IFilterEditor editor = editorClass.newInstance();
+        IFilterEditor editor = editorClass.getDeclaredConstructor().newInstance();
         return editor;
-      } catch (InstantiationException | IllegalAccessException | ClassCastException e) {
+      } catch (ClassCastException | ReflectiveOperationException | SecurityException e) {
         CheckstylePluginException.rethrow(e);
       }
     }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/AbstractASTResolution.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/AbstractASTResolution.java
@@ -200,11 +200,7 @@ public abstract class AbstractASTResolution extends WorkbenchMarkerResolution
       if (mAutoCommit) {
         textFileBuffer.commit(monitor, false);
       }
-    } catch (CoreException e) {
-      CheckstyleLog.log(e, Messages.AbstractASTResolution_msgErrorQuickfix);
-    } catch (MalformedTreeException e) {
-      CheckstyleLog.log(e, Messages.AbstractASTResolution_msgErrorQuickfix);
-    } catch (BadLocationException e) {
+    } catch (CoreException | MalformedTreeException | BadLocationException e) {
       CheckstyleLog.log(e, Messages.AbstractASTResolution_msgErrorQuickfix);
     } finally {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/CheckstyleMarkerResolutionGenerator.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/CheckstyleMarkerResolutionGenerator.java
@@ -36,7 +36,7 @@ import org.eclipse.ui.IMarkerResolutionGenerator2;
 
 /**
  * Profides marker resolutions (quickfixes) for Checkstyle markers.
- * 
+ *
  * @author Lars Ködderitzsch
  */
 public class CheckstyleMarkerResolutionGenerator implements IMarkerResolutionGenerator2 {
@@ -104,11 +104,11 @@ public class CheckstyleMarkerResolutionGenerator implements IMarkerResolutionGen
         Class<?> quickfixClass = CheckstyleUIPlugin.getDefault().getQuickfixExtensionClassLoader()
                 .loadClass(quickfixClassName);
 
-        ICheckstyleMarkerResolution fix = (ICheckstyleMarkerResolution) quickfixClass.newInstance();
+        ICheckstyleMarkerResolution fix = (ICheckstyleMarkerResolution) quickfixClass.getDeclaredConstructor().newInstance();
         fix.setRuleMetaData(ruleMetadata);
         fixes.add(fix);
       }
-    } catch (InstantiationException | ClassNotFoundException | IllegalAccessException e) {
+    } catch (ReflectiveOperationException | IllegalArgumentException | SecurityException e) {
       CheckstyleLog.log(e);
     }
     return fixes;

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/CheckstyleMarkerResolutionGenerator.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/CheckstyleMarkerResolutionGenerator.java
@@ -108,11 +108,7 @@ public class CheckstyleMarkerResolutionGenerator implements IMarkerResolutionGen
         fix.setRuleMetaData(ruleMetadata);
         fixes.add(fix);
       }
-    } catch (InstantiationException e) {
-      CheckstyleLog.log(e);
-    } catch (ClassNotFoundException e) {
-      CheckstyleLog.log(e);
-    } catch (IllegalAccessException e) {
+    } catch (InstantiationException | ClassNotFoundException | IllegalAccessException e) {
       CheckstyleLog.log(e);
     }
     return fixes;

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/FixCheckstyleMarkersAction.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/FixCheckstyleMarkersAction.java
@@ -77,8 +77,7 @@ public class FixCheckstyleMarkersAction implements IObjectActionDelegate {
 
     Object element = selection.getFirstElement();
 
-    @SuppressWarnings("cast")
-    IFile file = (IFile) ((IAdaptable) element).getAdapter(IFile.class);
+    IFile file = ((IAdaptable) element).getAdapter(IFile.class);
     if (file != null) {
 
       // call the fixing job

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/ExplicitInitializationQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/ExplicitInitializationQuickfix.java
@@ -70,15 +70,7 @@ public class ExplicitInitializationQuickfix extends AbstractASTResolution {
       in.close();
       final String snippet = new String(buffer, resource.getCharset());
       mFieldName = snippet.substring(0, snippet.indexOf('=')).trim();
-    } catch (final CoreException e) {
-      handleRetrieveFieldNameException(e);
-    } catch (final IOException e) {
-      handleRetrieveFieldNameException(e);
-    } catch (final IndexOutOfBoundsException e) {
-      handleRetrieveFieldNameException(e);
-    } catch (final ClassCastException e) {
-      handleRetrieveFieldNameException(e);
-    } catch (final NullPointerException e) {
+    } catch (final CoreException | IOException | IndexOutOfBoundsException | ClassCastException | NullPointerException e) {
       handleRetrieveFieldNameException(e);
     }
   }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityQuickfix.java
@@ -139,11 +139,7 @@ public class StringLiteralEqualityQuickfix extends AbstractASTResolution {
             List<ASTNode> list = (List<ASTNode>) listMethod.invoke(node.getParent(), (Object[]) null);
             list.set(list.indexOf(node), replacementNode);
           }
-        } catch (InvocationTargetException e) {
-          CheckstyleLog.log(e);
-        } catch (IllegalAccessException e) {
-          CheckstyleLog.log(e);
-        } catch (NoSuchMethodException e) {
+        } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
           CheckstyleLog.log(e);
         }
       }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/AbstractStatsView.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/AbstractStatsView.java
@@ -220,8 +220,7 @@ public abstract class AbstractStatsView extends ViewPart {
    */
   protected final void refresh() {
 
-    @SuppressWarnings("cast")
-    final IWorkbenchSiteProgressService service = (IWorkbenchSiteProgressService) getSite()
+    final IWorkbenchSiteProgressService service = getSite()
             .getAdapter(IWorkbenchSiteProgressService.class);
 
     // rebuild statistics data
@@ -336,13 +335,12 @@ public abstract class AbstractStatsView extends ViewPart {
     }
   }
 
-  @SuppressWarnings("cast")
   private void considerAdaptable(IAdaptable adaptable, Collection<IResource> resources) {
 
-    IResource resource = (IResource) adaptable.getAdapter(IResource.class);
+    IResource resource = adaptable.getAdapter(IResource.class);
 
     if (resource == null) {
-      resource = (IResource) adaptable.getAdapter(IFile.class);
+      resource = adaptable.getAdapter(IFile.class);
     }
 
     if (resource != null) {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/MarkerStatsView.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/MarkerStatsView.java
@@ -539,7 +539,7 @@ public class MarkerStatsView extends AbstractStatsView {
    *
    * @author Lars Ködderitzsch
    */
-  private class MasterContentProvider implements IStructuredContentProvider {
+  private static class MasterContentProvider implements IStructuredContentProvider {
     private Object[] mCurrentMarkerStats;
 
     @Override

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilter.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilter.java
@@ -366,7 +366,7 @@ public class CheckstyleMarkerFilter implements Cloneable {
 
       String setting = settings.get(TAG_ENABLED);
       if (setting != null) {
-        mEnabled = Boolean.valueOf(setting).booleanValue();
+        mEnabled = Boolean.parseBoolean(setting);
       }
 
       setting = settings.get(TAG_ON_RESOURCE);
@@ -386,7 +386,7 @@ public class CheckstyleMarkerFilter implements Cloneable {
 
       setting = settings.get(TAG_SELECT_BY_SEVERITY);
       if (setting != null) {
-        mSelectBySeverity = Boolean.valueOf(setting).booleanValue();
+        mSelectBySeverity = Boolean.parseBoolean(setting);
       }
 
       setting = settings.get(TAG_SEVERITY);
@@ -400,7 +400,7 @@ public class CheckstyleMarkerFilter implements Cloneable {
 
       setting = settings.get(TAG_SELECT_BY_REGEX);
       if (setting != null) {
-        mFilterByRegex = Boolean.valueOf(setting).booleanValue();
+        mFilterByRegex = Boolean.parseBoolean(setting);
       }
 
       String[] regex = settings.getArray(TAG_REGULAR_EXPRESSIONS);

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilter.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilter.java
@@ -484,7 +484,7 @@ public class CheckstyleMarkerFilter implements Cloneable {
         resultList.addAll(markers);
       }
     }
-    
+
     if (!mEnabled) {
       return resultList;
     }
@@ -607,8 +607,7 @@ public class CheckstyleMarkerFilter implements Cloneable {
     List<IResource> result = new ArrayList<>(elements.length);
 
     for (int idx = 0; idx < elements.length; idx++) {
-      @SuppressWarnings("cast")
-      IResource next = (IResource) elements[idx].getAdapter(IResource.class);
+      IResource next = elements[idx].getAdapter(IResource.class);
 
       if (next != null) {
         result.add(next);

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilter.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilter.java
@@ -28,8 +28,6 @@ import java.util.HashSet;
 import java.util.List;
 
 import net.sf.eclipsecs.core.builder.CheckstyleMarker;
-import net.sf.eclipsecs.ui.CheckstyleUIPlugin;
-
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -39,6 +37,7 @@ import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.ui.IWorkingSet;
+import org.eclipse.ui.PlatformUI;
 
 /**
  * Filter class for Checkstyle markers. This filter is used by the Checkstyle statistics views.
@@ -380,7 +379,7 @@ public class CheckstyleMarkerFilter implements Cloneable {
 
       setting = settings.get(TAG_WORKING_SET);
       if (setting != null) {
-        setWorkingSet(CheckstyleUIPlugin.getDefault().getWorkbench().getWorkingSetManager()
+        setWorkingSet(PlatformUI.getWorkbench().getWorkingSetManager()
                 .getWorkingSet(setting));
       }
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilterDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilterDialog.java
@@ -398,7 +398,7 @@ public class CheckstyleMarkerFilterDialog extends TitleAreaDialog {
    */
   private void initRegexLabel() {
 
-    StringBuffer buf = new StringBuffer();
+    StringBuilder buf = new StringBuilder();
 
     int size = mRegularExpressions != null ? mRegularExpressions.size() : 0;
     for (int i = 0; i < size; i++) {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/table/EnhancedCheckBoxTableViewer.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/table/EnhancedCheckBoxTableViewer.java
@@ -846,7 +846,7 @@ public class EnhancedCheckBoxTableViewer extends EnhancedTableViewer implements 
         return "{}"; //$NON-NLS-1$
       }
 
-      StringBuffer buffer = new StringBuffer();
+      StringBuilder buffer = new StringBuilder();
       buffer.append('{');
       for (int i = elementData.length; --i >= 0;) {
         HashMapEntry entry = elementData[i];


### PR DESCRIPTION
I was going to fix some deprecations, but doing so I noticed that the code would get littered with more and more duplicated catch-clauses due to newly introduced exception types in the non deprecated methods. Therefore I converted catch to multi-catch and ran some other cleanups. All changes were done fully automated, except for removing some no longer necessary @SupressWarning statements.