### PR TITLE
infra: automatically mark target folders derived

### DIFF
--- a/.derived
+++ b/.derived
@@ -4,6 +4,3 @@
 # target folders of eclipse and maven
 target
 bin
-
-# set the 'docs' folder as derived
-docs

--- a/net.sf.eclipsecs-feature/.derived
+++ b/net.sf.eclipsecs-feature/.derived
@@ -4,6 +4,3 @@
 # target folders of eclipse and maven
 target
 bin
-
-# set the 'docs' folder as derived
-docs

--- a/net.sf.eclipsecs-updatesite/.derived
+++ b/net.sf.eclipsecs-updatesite/.derived
@@ -4,6 +4,3 @@
 # target folders of eclipse and maven
 target
 bin
-
-# set the 'docs' folder as derived
-docs

--- a/net.sf.eclipsecs.branding/.derived
+++ b/net.sf.eclipsecs.branding/.derived
@@ -4,6 +4,3 @@
 # target folders of eclipse and maven
 target
 bin
-
-# set the 'docs' folder as derived
-docs

--- a/net.sf.eclipsecs.checkstyle/.derived
+++ b/net.sf.eclipsecs.checkstyle/.derived
@@ -4,6 +4,3 @@
 # target folders of eclipse and maven
 target
 bin
-
-# set the 'docs' folder as derived
-docs

--- a/net.sf.eclipsecs.core/.derived
+++ b/net.sf.eclipsecs.core/.derived
@@ -4,6 +4,3 @@
 # target folders of eclipse and maven
 target
 bin
-
-# set the 'docs' folder as derived
-docs

--- a/net.sf.eclipsecs.sample/.derived
+++ b/net.sf.eclipsecs.sample/.derived
@@ -4,6 +4,3 @@
 # target folders of eclipse and maven
 target
 bin
-
-# set the 'docs' folder as derived
-docs

--- a/net.sf.eclipsecs.target/.derived
+++ b/net.sf.eclipsecs.target/.derived
@@ -4,6 +4,3 @@
 # target folders of eclipse and maven
 target
 bin
-
-# set the 'docs' folder as derived
-docs

--- a/net.sf.eclipsecs.ui/.derived
+++ b/net.sf.eclipsecs.ui/.derived
@@ -4,6 +4,3 @@
 # target folders of eclipse and maven
 target
 bin
-
-# set the 'docs' folder as derived
-docs


### PR DESCRIPTION
Eclipse has the ability of not showing generated or otherwise derived resources by explicitly marking them as derived. That simplifies file searches. Files can be marked automatically using an additional plugin. Developers not using that plugin will not notice any difference from this change.