### PR TITLE
infra: Use JDK 11 and 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,11 @@ matrix:
         - DESC="install (openjdk11)"
         - CMD="mvn install && git diff"
 
-    # JDK 13 (most recent Java version)
-    - jdk: openjdk13
+    # JDK 17 (most recent Java version)
+    - jdk: openjdk17
       arch: amd64
       env:
-        - DESC="install (openjdk13)"
+        - DESC="install (openjdk17)"
         - CMD="mvn install && git diff"
 
 script:


### PR DESCRIPTION
I haven't found any documentation on whether travis has jdk 17 installed. But if so, then we should use it to test on the LTS versions that are actually supported by our plugin.