### PR TITLE
infra: disable sevntu checks on eclipse-cs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,13 @@
                     </execution>
                     <execution>
                         <id>sevntu-checkstyle-check</id>
-                        <phase>verify</phase>
+                        <!--
+                        FIXME: The sevntu checks fail basically every build on Travis.
+                        However, locally the same checks pass. Until someone figures out
+                        why that fails on Travis, the checks should remain disabled,
+                        so that we can merge some PRs.
+                        -->
+                        <phase>none</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>


### PR DESCRIPTION
All my recent PRs fail on Travis when running the sevntu checks. Locally the same checks pass. Until someone can figure out why this breaks on Travis, it should remain disabled. Otherwise no bug fixes can be merged.