### PR TITLE
infra: disable maven download messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,14 @@ jobs:
     - jdk: openjdk11
       env:
         - DESC="install (openjdk11)"
-        - CMD="mvn -e install"
+        - CMD="mvn --errors --batch-mode --no-transfer-progress install"
 
     # JDK 17 (most recent Java LTS version)
     - jdk: openjdk17
       arch: amd64
       env:
         - DESC="install (openjdk17)"
-        - CMD="mvn -e install"
+        - CMD="mvn --errors --batch-mode --no-transfer-progress install"
 
 script:
   - ./.ci/travis.sh init-m2-repo


### PR DESCRIPTION
Use the long versions of the options since others reading the file might not know the short versions. If the build fails on the no-progress option, then it needs to be removed. That one is only available in recent maven versions.