### PR TITLE
infra: re-enable colored output on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,14 @@ jobs:
     - jdk: openjdk11
       env:
         - DESC="install (openjdk11)"
-        - CMD="mvn --errors --batch-mode --no-transfer-progress install"
+        - CMD="mvn --errors --no-transfer-progress install"
 
     # JDK 17 (most recent Java LTS version)
     - jdk: openjdk17
       arch: amd64
       env:
         - DESC="install (openjdk17)"
-        - CMD="mvn --errors --batch-mode --no-transfer-progress install"
+        - CMD="mvn --errors --no-transfer-progress install"
 
 script:
   - ./.ci/travis.sh init-m2-repo


### PR DESCRIPTION
This reverts a part of my previous PR. In early Maven versions the batch-mode option was the only way to suppress download messages. However, since Maven 3.5 it also suppresses the ANSI escape characters that cause colored output in the shell. That's why the current Travis console is no longer colored after the previous commit.

Long story short: On recent maven versions, only the -ntp option should be used, but not the batch-mode option. (I only learned this yesterday evening, otherwise I would have avoided adding it in the first place)