### PR TITLE
ci: replace tycho-source-feature-plugin

### DIFF
--- a/net.sf.eclipsecs-feature/pom.xml
+++ b/net.sf.eclipsecs-feature/pom.xml
@@ -12,25 +12,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.eclipse.tycho.extras</groupId>
-                <artifactId>tycho-source-feature-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <!-- These are bundles and feature that do not have a corresponding source version; NOT the ones 
-                            that we do not want source versions -->
-                        <plugin id="net.sf.eclipsecs.branding" />
-                        <plugin id="net.sf.eclipsecs.doc" />
-                    </excludes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>source-feature</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>source-feature</goal>
-                        </goals>
-                    </execution>
-                </executions>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-source-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -236,16 +236,9 @@
                     <groupId>org.eclipse.tycho</groupId>
                     <artifactId>tycho-p2-plugin</artifactId>
                     <version>${tycho-version}</version>
-                    <configuration>
-                        <!-- <baselineRepositories> -->
-                        <!-- <repository> -->
-                        <!-- <url>git://git.code.sf.net/p/eclipse-cs/git</url> -->
-                        <!-- </repository> -->
-                        <!-- </baselineRepositories> -->
-                    </configuration>
                     <executions>
                         <execution>
-                            <id>attached-p2-metadata</id>
+                            <id>attach-p2-metadata</id>
                             <phase>package</phase>
                             <goals>
                                 <goal>p2-metadata</goal>
@@ -264,6 +257,12 @@
                     <version>${tycho-version}</version>
                     <configuration>
                         <strictSrcIncludes>false</strictSrcIncludes>
+                        <excludes>
+                            <!-- These are bundles and feature that do not have a corresponding source version; NOT the ones 
+                                that we do not want source versions -->
+                            <plugin id="net.sf.eclipsecs.branding" />
+                            <plugin id="net.sf.eclipsecs.doc" />
+                        </excludes>
                     </configuration>
                     <executions>
                         <execution>
@@ -272,12 +271,13 @@
                                 <goal>plugin-source</goal>
                             </goals>
                         </execution>
+                        <execution>
+                            <id>feature-source</id>
+                            <goals>
+                                <goal>feature-source</goal>
+                            </goals>
+                        </execution>
                     </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.eclipse.tycho.extras</groupId>
-                    <artifactId>tycho-source-feature-plugin</artifactId>
-                    <version>${tycho-version}</version>
                 </plugin>
                 <!-- Disable default deployer. -->
                 <plugin>


### PR DESCRIPTION
The previously separate tycho-source-feature-plugin functionality is included in tycho-source-plugin meanwhile:
https://github.com/eclipse-tycho/tycho/blob/master/RELEASE_NOTES.md#tycho-source-feature-generation-moved-from-tycho-extras-to-tycho-core. Replacing it removes one warning from the Maven build.

Also move the configuration into the parent POM, since it is independent of the specific feature being built (i.e. could be reused if another feature would be built).

And remove some commented out configuration of the p2-metadata plugin. We wouldn't want to use it with those configuration values anyway.

Verified the source feature in the update site is identical to what it was before. BTW: I'm also committer on the Tycho project. :)