### PR TITLE
Issue #391: disable context help

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
@@ -166,6 +166,7 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
           CheckConfigurationWorkingCopy config) {
     super(parentShell);
     setShellStyle(getShellStyle() | SWT.RESIZE | SWT.MAX);
+    setHelpAvailable(false);
     mConfiguration = config;
   }
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationPropertiesDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationPropertiesDialog.java
@@ -64,7 +64,7 @@ import org.eclipse.swt.widgets.Shell;
 /**
  * Dialog to show/edit the properties (name, location, description) of a check
  * configuration. Also used to create new check configurations.
- * 
+ *
  * @author Lars Ködderitzsch
  */
 public class CheckConfigurationPropertiesDialog extends TitleAreaDialog {
@@ -96,7 +96,7 @@ public class CheckConfigurationPropertiesDialog extends TitleAreaDialog {
 
   /**
    * Creates the properties dialog for check configurations.
-   * 
+   *
    * @param parent
    *          the parent shell
    * @param checkConfig
@@ -108,6 +108,7 @@ public class CheckConfigurationPropertiesDialog extends TitleAreaDialog {
   public CheckConfigurationPropertiesDialog(Shell parent, CheckConfigurationWorkingCopy checkConfig,
           ICheckConfigurationWorkingSet workingSet) {
     super(parent);
+    setHelpAvailable(false);
     mWorkingSet = workingSet;
     mCheckConfig = checkConfig;
   }
@@ -118,7 +119,7 @@ public class CheckConfigurationPropertiesDialog extends TitleAreaDialog {
 
   /**
    * Returns the working set this dialog is operating on.
-   * 
+   *
    * @return the check configuration working set
    */
   public ICheckConfigurationWorkingSet getCheckConfigurationWorkingSet() {
@@ -127,7 +128,7 @@ public class CheckConfigurationPropertiesDialog extends TitleAreaDialog {
 
   /**
    * Sets the template for a new check configuration.
-   * 
+   *
    * @param template
    *          the template configuration
    */
@@ -137,7 +138,7 @@ public class CheckConfigurationPropertiesDialog extends TitleAreaDialog {
 
   /**
    * Get the check configuration from the editor.
-   * 
+   *
    * @return the check configuration
    */
   public CheckConfigurationWorkingCopy getCheckConfiguration() {
@@ -155,7 +156,7 @@ public class CheckConfigurationPropertiesDialog extends TitleAreaDialog {
 
   /**
    * Creates the dialogs main contents.
-   * 
+   *
    * @param parent
    *          the parent composite
    */
@@ -359,7 +360,7 @@ public class CheckConfigurationPropertiesDialog extends TitleAreaDialog {
 
   /**
    * Creates the configuration type specific location editor.
-   * 
+   *
    * @param configType
    *          the configuration type
    */
@@ -438,7 +439,7 @@ public class CheckConfigurationPropertiesDialog extends TitleAreaDialog {
 
   /**
    * Creates a non conflicting name out of a name proposal.
-   * 
+   *
    * @param config
    *          the working copy to set the name on
    * @param checkConfigName

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/ResolvablePropertiesDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/ResolvablePropertiesDialog.java
@@ -118,6 +118,7 @@ public class ResolvablePropertiesDialog extends TitleAreaDialog {
   public ResolvablePropertiesDialog(Shell parent, CheckConfigurationWorkingCopy checkConfig) {
     super(parent);
     setShellStyle(getShellStyle() | SWT.RESIZE | SWT.MAX);
+    setHelpAvailable(false);
     mCheckConfig = checkConfig;
   }
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/ResolvablePropertyEditDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/ResolvablePropertyEditDialog.java
@@ -66,6 +66,7 @@ public class ResolvablePropertyEditDialog extends TitleAreaDialog {
    */
   ResolvablePropertyEditDialog(Shell parent, ResolvableProperty prop) {
     super(parent);
+    setHelpAvailable(false);
     setShellStyle(getShellStyle() | SWT.RESIZE);
     mProperty = prop;
   }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/RuleConfigurationEditDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/RuleConfigurationEditDialog.java
@@ -109,6 +109,7 @@ public class RuleConfigurationEditDialog extends TitleAreaDialog {
   RuleConfigurationEditDialog(Shell parent, Module rule, boolean readonly, String title) {
     super(parent);
     setShellStyle(getShellStyle() | SWT.RESIZE);
+    setHelpAvailable(false);
     mRule = rule;
     mReadonly = readonly;
     mTitle = title;

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/FileMatchPatternEditDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/FileMatchPatternEditDialog.java
@@ -51,7 +51,7 @@ import org.eclipse.ui.contentassist.ContentAssistHandler;
 
 /**
  * Dialog to edit file match patterns.
- * 
+ *
  * @author David Schneider
  * @author Lars Ködderitzsch
  */
@@ -65,7 +65,7 @@ public class FileMatchPatternEditDialog extends TitleAreaDialog {
 
   /**
    * Creates a file matching pattern editor dialog.
-   * 
+   *
    * @param parentShell
    *          the parent shell
    * @param pattern
@@ -73,12 +73,13 @@ public class FileMatchPatternEditDialog extends TitleAreaDialog {
    */
   public FileMatchPatternEditDialog(Shell parentShell, FileMatchPattern pattern) {
     super(parentShell);
+    setHelpAvailable(false);
     mPattern = pattern;
   }
 
   /**
    * Returns the pattern edited by this dialog.
-   * 
+   *
    * @return the pattern
    */
   public FileMatchPattern getPattern() {
@@ -168,7 +169,7 @@ public class FileMatchPatternEditDialog extends TitleAreaDialog {
 
   /**
    * Creates the content assistant.
-   * 
+   *
    * @return the content assistant
    */
   private SubjectControlContentAssistant createContentAssistant() {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/FileSetEditDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/FileSetEditDialog.java
@@ -133,6 +133,7 @@ public class FileSetEditDialog extends TitleAreaDialog {
           CheckstylePropertyPage propsPage) throws CheckstylePluginException {
     super(parent);
     setShellStyle(getShellStyle() | SWT.RESIZE);
+    setHelpAvailable(false);
     mProject = project;
     mFileSet = fileSet;
     mPropertyPage = propsPage;

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilterDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilterDialog.java
@@ -137,6 +137,7 @@ public class CheckstyleMarkerFilterDialog extends TitleAreaDialog {
   public CheckstyleMarkerFilterDialog(Shell shell, CheckstyleMarkerFilter filter) {
 
     super(shell);
+    setHelpAvailable(false);
     mFilter = filter;
   }
 


### PR DESCRIPTION
Search for all classes derived from TitleAreaDialog and disable help in their constructor. Also used the type hierarchy to verify all classes had been found.
![grafik](https://user-images.githubusercontent.com/406876/201510544-2ff1adb6-2e4d-441a-a694-2ca89c9325e8.png)
