### PR TITLE
reproduce patch filter bug

### DIFF
--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
@@ -75,7 +75,7 @@ public class Auditor {
   private IProgressMonitor mMonitor;
 
   /** Map containing the file resources to audit. */
-  private final Map<String, IFile> mFiles = new HashMap<>();
+  private final Map<String, IFile> mFiles = new HashMap<>(); // CustomDeclarationOrder is raised here when the patch-filter is removed from checkstyle_sevntu_checks.xml
 
   /** Add the check rule name to the message. */
   private boolean mAddRuleName = false;


### PR DESCRIPTION
**This is not meant to be merged! I'm trying to show that the patch-filter still doesn't work correctly.**

Auditor.java line 78 is the first violation reported by "mvn verify" if the patch filters are removed in the checkstyle_sevntu_checks.xml. So by adding a very long comment there we should _still_ see that same error, even if patch-filter is NOT removed.

This PR does not have any errors locally. The "show.patch" file is as expected:
```
diff --git a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
index cc6a8495..e23d4329 100644
--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
@@ -75,7 +75,7 @@ public class Auditor {
   private IProgressMonitor mMonitor;
 
   /** Map containing the file resources to audit. */
-  private final Map<String, IFile> mFiles = new HashMap<>();
+  private final Map<String, IFile> mFiles = new HashMap<>(); // CustomDeclarationOrder is raised here when the patch-filter is removed from checkstyle_sevntu_checks.xml
 
   /** Add the check rule name to the message. */
   private boolean mAddRuleName = false;
```
I expect that the CI system raises a violation there.