### PR TITLE
ci: upgrade Tycho to 3.0

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,11 +25,13 @@ jobs:
         path: ~/.m2/repository
         key: maven-cache-${{ hashFiles('**/pom.xml') }}
 
-    - name: Set up JDK ${{ matrix.jdk }}
+    - name: Set up JDKs
       uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
       with:
         distribution: temurin
-        java-version: ${{ matrix.jdk }}
+        java-version: |
+          11
+          17
 
     - name: Build with Maven
       run: ./mvnw --errors --no-transfer-progress install
@@ -40,6 +42,6 @@ jobs:
     - name: Publish Test Results
       uses: EnricoMi/publish-unit-test-result-action@4e121453199042300b654ee3b4b52720bc645dc6 # v2.13.0
       # we only want to attach test results one time, not for every matrix combination
-      if: startsWith(matrix.platform, 'ubuntu') && (matrix.jdk == 17)
+      if: startsWith(matrix.platform, 'ubuntu') && (matrix.jdk == 11)
       with:
         files: '**/target/surefire-reports/*.xml'

--- a/net.sf.eclipsecs.target/Maven update check.launch
+++ b/net.sf.eclipsecs.target/Maven update check.launch
@@ -18,7 +18,8 @@
         <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
     </listAttribute>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11/"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
     <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${git_work_tree:/eclipse-cs}"/>
 </launchConfiguration>

--- a/net.sf.eclipsecs.target/Maven verify.launch
+++ b/net.sf.eclipsecs.target/Maven verify.launch
@@ -18,7 +18,8 @@
         <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
     </listAttribute>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
-    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11/"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
     <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${git_work_tree:/eclipse-cs}"/>
 </launchConfiguration>

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Eclipse Checkstyle" sequenceNumber="1706381587">
+<target name="Eclipse Checkstyle" sequenceNumber="1707931034">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.jdt.feature.group" version="3.18.800.v20210611-1600"/>
@@ -16,15 +16,19 @@
       <repository location="https://download.eclipse.org/releases/2021-06/202106161001/"/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
-      <unit id="org.junit.jupiter.api" version="5.7.1.v20210222-1948"/>
-      <unit id="org.junit.jupiter.engine" version="5.7.1.v20210222-1948"/>
-      <unit id="org.junit.jupiter.params" version="5.7.1.v20210222-1948"/>
-      <unit id="org.junit.platform.commons" version="1.7.1.v20210222-1948"/>
-      <unit id="org.junit.platform.engine" version="1.7.1.v20210222-1948"/>
-      <unit id="org.junit.platform.launcher" version="1.7.1.v20210222-1948"/>
-      <unit id="org.junit.platform.runner" version="1.7.1.v20210222-1948"/>
-      <unit id="org.junit.platform.suite.api" version="1.7.1.v20210222-1948"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository"/>
+      <unit id="junit-jupiter-api" version="5.9.0"/>
+      <unit id="junit-jupiter-engine" version="5.9.0"/>
+      <unit id="junit-jupiter-migrationsupport" version="5.9.0"/>
+      <unit id="junit-jupiter-params" version="5.9.0"/>
+      <unit id="junit-platform-commons" version="1.9.0"/>
+      <unit id="junit-platform-engine" version="1.9.0"/>
+      <unit id="junit-platform-launcher" version="1.9.0"/>
+      <unit id="junit-platform-runner" version="1.9.0"/>
+      <unit id="junit-platform-suite-api" version="1.9.0"/>
+      <unit id="junit-platform-suite-commons" version="1.9.0"/>
+      <unit id="junit-vintage-engine" version="5.9.0"/>
+      <unit id="org.apiguardian.api" version="1.1.2"/>
+      <repository location="https://download.eclipse.org/releases/2022-09/202209141001/"/>
     </location>
     <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="SnakeYaml">
     <dependencies>

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
@@ -21,16 +21,23 @@ location "https://download.eclipse.org/releases/2021-06/202106161001/" {
 	org.eclipse.ui.trace
 }
 
-// matching release of JUnit 5 from Eclipse Orbit
-location "https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository" {
-	org.junit.jupiter.api
-	org.junit.jupiter.engine
-	org.junit.jupiter.params
-	org.junit.platform.commons
-	org.junit.platform.engine
-	org.junit.platform.launcher
-	org.junit.platform.runner
-	org.junit.platform.suite.api
+// You must use 2022-06 or newer as Eclipse IDE to run the unit tests.
+// With that version Eclipse started consuming many libraries directly from Maven instead of re-bundling them in Eclipse Orbit.
+// Unfortunately the JUnit runtime support (the connection between test engine and IDE/Tycho) therefore had a breaking change
+// in the JUnit bundle names, therefore old IDEs can't run the tests anymore.
+location "https://download.eclipse.org/releases/2022-09/202209141001/" {
+	junit-jupiter-api
+	junit-jupiter-engine
+	junit-jupiter-migrationsupport
+	junit-jupiter-params
+	junit-platform-commons
+	junit-platform-engine
+	junit-platform-launcher
+	junit-platform-runner
+	junit-platform-suite-api
+	junit-platform-suite-commons
+	junit-vintage-engine
+	org.apiguardian.api
 }
 
 // If the following part has errors and no syntax highlighting, then please use Help>About>Installation>Installed Software>Target Platform DSL>Uninstall.

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <maven-site-plugin-version>3.12.1</maven-site-plugin-version>
         <maven-surefire-plugin-version>3.2.5</maven-surefire-plugin-version>
         <maven-version>3.6.3</maven-version>
-        <tycho-version>2.7.5</tycho-version>
+        <tycho-version>4.0.5</tycho-version>
         <versions-maven-plugin-version>2.16.2</versions-maven-plugin-version>
 
         <!-- sevntu and patch-filters need to use a compatible/compiled version with checkstyle -->
@@ -49,6 +49,7 @@
 
         <!-- ignore all versions with non numerical parts during versions:display-plugin-updates -->
         <maven.version.ignore>.*[a-zA-Z]+.*</maven.version.ignore>
+        <maven.compiler.release>11</maven.compiler.release>
     </properties>
 
     <scm>
@@ -117,7 +118,6 @@
                         see https://github.com/eclipse-tycho/tycho/issues/1660 -->
                         <file>${maven.multiModuleProjectDirectory}/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target</file>
                     </target>
-                    <resolver>p2</resolver>
                     <environments>
                         <environment>
                             <os>win32</os>
@@ -218,6 +218,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>tycho-bnd-plugin</artifactId>
+                    <version>${tycho-version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.eclipse.tycho</groupId>
                     <artifactId>tycho-compiler-plugin</artifactId>
                     <version>${tycho-version}</version>
                 </plugin>
@@ -255,7 +260,7 @@
                     <dependencies>
                         <!-- generate timestamps from last git change of any file in this module -->
                         <dependency>
-                            <groupId>org.eclipse.tycho.extras</groupId>
+                            <groupId>org.eclipse.tycho</groupId>
                             <artifactId>tycho-buildtimestamp-jgit</artifactId>
                             <version>${tycho-version}</version>
                         </dependency>
@@ -371,10 +376,6 @@
                             </goals>
                         </execution>
                     </executions>
-                    <configuration>
-                        <source>11</source>
-                        <target>11</target>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
That is the most recent version as of today. One of the plugins has been moved from tycho.extras to tycho core, therefore the groupid is different.

Also fix the warnings `[WARNING] artifact
foo:bar:p2metadata:10.3.3-SNAPSHOT already attached, replace previous instance` by disabling the default metadata generation. Unfortunately this extra step is necessary when creating source features, since the attaching of metadata needs to be delayed then.

There are new warnings at the very end of the build like `No digest algorithm is available to verify download`. That's an open issue in Tycho but it doesn't break the build, see
https://github.com/eclipse-tycho/tycho/issues/1482

Finally the target platform also needs to be updated. Tycho 3.0 resolves the JUnit classpath container of the .classpath files against the bundle names introduced in Eclipse 2022-06. Most thirdparty libraries have been changed from repackaging in Eclipse Orbit to "consume as is" from Maven. This does not affect the EclipseCS plugin created by the build, since the new JUnit bundles are only needed at IDE or build time.