### PR TITLE
ci: fix warnings in maven console

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,15 @@
                     <version>${tycho-version}</version>
                     <executions>
                         <execution>
+                            <!-- this execution is bound via default lifecycle bindings of the tycho-p2-plugin -->
+                            <id>default-p2-metadata-default</id>
+                            <configuration>
+                                <!-- disable the default metadata generation since that conflicts with source feature generation -->
+                                <attachP2Metadata>false</attachP2Metadata>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <!-- explicitly attach metadata later via this custom execution -->
                             <id>attach-p2-metadata</id>
                             <phase>package</phase>
                             <goals>


### PR DESCRIPTION
Fix the warnings `[WARNING] artifact
foo:bar:p2metadata:10.3.3-SNAPSHOT already attached, replace previous instance` by disabling the default metadata generation. Unfortunately this extra step is necessary when creating source features, since the attaching of metadata needs to be delayed then.