### PR TITLE
infra: fix Maven warning in Eclipse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,6 +360,19 @@
                                         <ignore></ignore>
                                     </action>
                                 </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-clean-plugin</artifactId>
+                                        <versionRange>[2.5,)</versionRange>
+                                        <goals>
+                                            <goal>clean</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
                             </pluginExecutions>
                         </lifecycleMappingMetadata>
                     </configuration>


### PR DESCRIPTION
Eclipse still warns about not being able to map the maven clean goal to the Eclipse build lifecycle. Since that maven goal is not necessary for a successful build, we can ignore it inside Eclipse, similar to the other goals of the resources plugin that have already been ignored.