### PR TITLE
infra: gitignore temporary files of Tycho

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ show.patch
 *.DS_Store
 net.sf.eclipsecs-updatesite/workspace
 *.zip
+
+# Tycho generates multiple files during the build.
+# They are excluded from the timestamp calculation by default, but still can confuse developers in the staging view.
+.tycho-consumer-pom.xml
+.polyglot.*
+pom.tycho


### PR DESCRIPTION
While the build is running, Tycho generates several temporary files outside of the Maven target directories. If developers refresh their staging view during the build, they may be confused by those temporary files. Therefore gitignore them.