### PR TITLE
Issue #405: exception during workbench shutdown

### DIFF
--- a/net.sf.eclipsecs.sample/src/net/sf/eclipsecs/sample/checks/MethodLimitQuickfix.java
+++ b/net.sf.eclipsecs.sample/src/net/sf/eclipsecs/sample/checks/MethodLimitQuickfix.java
@@ -63,6 +63,6 @@ public class MethodLimitQuickfix extends AbstractASTResolution {
    */
   @Override
   public Image getImage() {
-    return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_CHANGE);
+    return CheckstyleUIPluginImages.CORRECTION_CHANGE.getImage();
   }
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/CheckstyleMarkerImageProvider.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/CheckstyleMarkerImageProvider.java
@@ -29,7 +29,7 @@ import org.eclipse.ui.texteditor.IAnnotationImageProvider;
 
 /**
  * Image provider for Checkstyle markers.
- * 
+ *
  * @author Lars Ködderitzsch
  */
 public class CheckstyleMarkerImageProvider implements IAnnotationImageProvider {
@@ -41,11 +41,11 @@ public class CheckstyleMarkerImageProvider implements IAnnotationImageProvider {
   public Image getManagedImage(Annotation annotation) {
     String type = annotation.getType();
     if (CheckstyleMarker.ERROR_TYPE.equals(type)) {
-      return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.MARKER_ERROR);
+      return CheckstyleUIPluginImages.MARKER_ERROR.getImage();
     } else if (CheckstyleMarker.WARNING_TYPE.equals(type)) {
-      return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.MARKER_WARNING);
+      return CheckstyleUIPluginImages.MARKER_WARNING.getImage();
     } else if (CheckstyleMarker.INFO_TYPE.equals(type)) {
-      return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.MARKER_INFO);
+      return CheckstyleUIPluginImages.MARKER_INFO.getImage();
     }
 
     return null;

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/CheckstyleUIPluginImages.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/CheckstyleUIPluginImages.java
@@ -20,8 +20,7 @@
 
 package net.sf.eclipsecs.ui;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.function.Supplier;
 
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ResourceLocator;
@@ -35,142 +34,113 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
  *
  * @author Lars Ködderitzsch
  */
-public abstract class CheckstyleUIPluginImages {
+public enum CheckstyleUIPluginImages {
 
   /** Image descriptor for the plugin logo. */
-  public static final ImageDescriptor PLUGIN_LOGO;
-
+  PLUGIN_LOGO(() -> AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
+          "icons/eclipse-cs-little.png")),
   /** Image descriptor for the error marker. */
-  public static final ImageDescriptor MARKER_ERROR;
-
+  MARKER_ERROR(() -> AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
+          "icons/checkstyle_error.gif")),
   /** Image descriptor for the warning marker. */
-  public static final ImageDescriptor MARKER_WARNING;
-
+  MARKER_WARNING(() -> AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
+          "icons/checkstyle_warning.gif")),
   /** Image descriptor for the info marker. */
-  public static final ImageDescriptor MARKER_INFO;
-
+  MARKER_INFO(() -> AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
+          "icons/checkstyle_info.gif")),
   /** Image descriptor for the help icon. */
-  public static final ImageDescriptor HELP_ICON;
-
+  HELP_ICON(() -> PlatformUI.getWorkbench().getSharedImages()
+          .getImageDescriptor(ISharedImages.IMG_LCL_LINKTO_HELP)),
   /** Image descriptor for the add correction icon. */
-  public static final ImageDescriptor CORRECTION_ADD;
-
+  CORRECTION_ADD(() -> AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
+          "icons/add_correction.gif")),
   /** Image descriptor for the change correction icon. */
-  public static final ImageDescriptor CORRECTION_CHANGE;
-
+  CORRECTION_CHANGE(() -> AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
+          "icons/correction_change.gif")),
   /** Image descriptor for the remove correction icon. */
-  public static final ImageDescriptor CORRECTION_REMOVE;
-
+  CORRECTION_REMOVE(() -> AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
+          "icons/remove_correction.gif")),
   /** Image descriptor for the tick icon. */
-  public static final ImageDescriptor TICK_ICON;
+  TICK_ICON(() -> AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
+          "icons/tick.gif")),
 
   /** Image descriptor for the filter icon. */
-  public static final ImageDescriptor FILTER_ICON;
-
+  FILTER_ICON(() -> ResourceLocator.imageDescriptorFromBundle("org.eclipse.ui.ide",
+          "platform:/plugin/org.eclipse.ui.ide/icons/full/elcl16/filter_ps.png")
+          .orElse(MARKER_ERROR.getImageDescriptor())),
   /** Image descriptor for the Checkstyle violation view icon. */
-  public static final ImageDescriptor LIST_VIEW_ICON;
-
+  LIST_VIEW_ICON(() -> AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
+          "icons/listingView.gif")),
   /** Image descriptor for the graph view icon. */
-  public static final ImageDescriptor GRAPH_VIEW_ICON;
-
+  GRAPH_VIEW_ICON(() -> AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
+          "icons/graphView.gif")),
   /** Image descriptor for the graph view icon. */
-  public static final ImageDescriptor EXPORT_REPORT_ICON;
+  EXPORT_REPORT_ICON(() -> AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
+          "icons/exportReport.gif")),
 
   /** Image descriptor for the module group icon. */
-  public static final ImageDescriptor MODULEGROUP_ICON;
-
+  MODULEGROUP_ICON(() -> AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
+          "icons/modulegroup.gif")),
   /** Image descriptor for the ticked module group icon. */
-  public static final ImageDescriptor MODULEGROUP_TICKED_ICON;
-
+  MODULEGROUP_TICKED_ICON(() -> AbstractUIPlugin
+          .imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID, "icons/modulegroup_used.gif")),
   /** Image descriptor for the module icon. */
-  public static final ImageDescriptor MODULE_ICON;
-
+  MODULE_ICON(() -> AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
+          "icons/module.gif")),
   /** Image descriptor for the ticked module icon. */
-  public static final ImageDescriptor MODULE_TICKED_ICON;
-
+  MODULE_TICKED_ICON(() -> AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
+          "icons/module_used.gif")),
   /** Image descriptor for the refresh icon. */
-  public static final ImageDescriptor REFRESH_ICON;
-
-  /** Image cache. */
-  private static final Map<ImageDescriptor, Image> CACHED_IMAGES = new HashMap<>();
-
-  static {
-
-    PLUGIN_LOGO = AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
-            "icons/eclipse-cs-little.png"); //$NON-NLS-1$
-    MARKER_ERROR = AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
-            "icons/checkstyle_error.gif"); //$NON-NLS-1$
-    MARKER_WARNING = AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
-            "icons/checkstyle_warning.gif"); //$NON-NLS-1$
-    MARKER_INFO = AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
-            "icons/checkstyle_info.gif"); //$NON-NLS-1$
-    HELP_ICON = PlatformUI.getWorkbench().getSharedImages()
-            .getImageDescriptor(ISharedImages.IMG_LCL_LINKTO_HELP);
-    CORRECTION_ADD = AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
-            "icons/add_correction.gif"); //$NON-NLS-1$
-    CORRECTION_CHANGE = AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
-            "icons/correction_change.gif"); //$NON-NLS-1$
-    CORRECTION_REMOVE = AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
-            "icons/remove_correction.gif"); //$NON-NLS-1$
-    TICK_ICON = AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
-            "icons/tick.gif"); //$NON-NLS-1$
-
-    FILTER_ICON = ResourceLocator.imageDescriptorFromBundle("org.eclipse.ui.ide",
-            "platform:/plugin/org.eclipse.ui.ide/icons/full/elcl16/filter_ps.png")
-            .orElse(MARKER_ERROR);
-    LIST_VIEW_ICON = AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
-            "icons/listingView.gif"); //$NON-NLS-1$
-    GRAPH_VIEW_ICON = AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
-            "icons/graphView.gif"); //$NON-NLS-1$
-    EXPORT_REPORT_ICON = AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
-            "icons/exportReport.gif"); //$NON-NLS-1$
-
-    MODULEGROUP_ICON = AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
-            "icons/modulegroup.gif"); //$NON-NLS-1$
-    MODULEGROUP_TICKED_ICON = AbstractUIPlugin
-            .imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID, "icons/modulegroup_used.gif"); //$NON-NLS-1$
-    MODULE_ICON = AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
-            "icons/module.gif"); //$NON-NLS-1$
-    MODULE_TICKED_ICON = AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
-            "icons/module_used.gif"); //$NON-NLS-1$
-    REFRESH_ICON = ResourceLocator.imageDescriptorFromBundle("org.eclipse.search",
-            "platform:/plugin/org.eclipse.search/icons/full/elcl16/refresh.png")
-            .orElse(MARKER_ERROR);
-  }
+  REFRESH_ICON(() -> ResourceLocator.imageDescriptorFromBundle("org.eclipse.search",
+          "platform:/plugin/org.eclipse.search/icons/full/elcl16/refresh.png")
+          .orElse(MARKER_ERROR.getImageDescriptor()));
 
   /**
-   * Hidden default constructor.
+   * lazy creation factory
    */
-  private CheckstyleUIPluginImages() {
-    // NOOP
+  private Supplier<ImageDescriptor> factory;
+
+  /**
+   * image descriptor
+   */
+  private ImageDescriptor imageDescriptor;
+
+  /**
+   * image that got created from the descriptor
+   */
+  private Image image;
+
+  private CheckstyleUIPluginImages(Supplier<ImageDescriptor> factory) {
+    this.factory = factory;
+  }
+
+  public ImageDescriptor getImageDescriptor() {
+    if (imageDescriptor == null) {
+      imageDescriptor = factory.get();
+    }
+    return imageDescriptor;
   }
 
   /**
    * Gets an image from a given descriptor.
    *
-   * @param descriptor
-   *          the descriptor
    * @return the image
    */
-  public static Image getImage(ImageDescriptor descriptor) {
-
-    Image image = CACHED_IMAGES.get(descriptor);
+  public Image getImage() {
     if (image == null) {
-      image = descriptor.createImage();
-      CACHED_IMAGES.put(descriptor, image);
+      image = getImageDescriptor().createImage();
     }
     return image;
   }
 
   /**
-   * Disposes the cached images and clears the cache.
+   * Disposes the cached images.
    */
   public static void clearCachedImages() {
-
-    for (Image image : CACHED_IMAGES.values()) {
-      image.dispose();
+    for (CheckstyleUIPluginImages value : values()) {
+      if (value.image != null) {
+        value.image.dispose();
+      }
     }
-
-    CACHED_IMAGES.clear();
   }
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
@@ -464,7 +464,7 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
     }
 
     // set the logo
-    this.setTitleImage(CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.PLUGIN_LOGO));
+    this.setTitleImage(CheckstyleUIPluginImages.PLUGIN_LOGO.getImage());
 
     mAddButton.setEnabled(mConfigurable);
     mRemoveButton.setEnabled(mConfigurable);
@@ -908,14 +908,13 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
 
       if (element instanceof RuleGroupMetadata) {
         image = isGroupUsed((RuleGroupMetadata) element)
-                ? CheckstyleUIPluginImages
-                        .getImage(CheckstyleUIPluginImages.MODULEGROUP_TICKED_ICON)
-                : CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.MODULEGROUP_ICON);
+                ? CheckstyleUIPluginImages.MODULEGROUP_TICKED_ICON.getImage()
+                : CheckstyleUIPluginImages.MODULEGROUP_ICON.getImage();
       } else if (element instanceof RuleMetadata) {
 
         image = isMetadataUsed((RuleMetadata) element)
-                ? CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.MODULE_TICKED_ICON)
-                : CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.MODULE_ICON);
+                ? CheckstyleUIPluginImages.MODULE_TICKED_ICON.getImage()
+                : CheckstyleUIPluginImages.MODULE_ICON.getImage();
       }
       return image;
     }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationPropertiesDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationPropertiesDialog.java
@@ -164,7 +164,7 @@ public class CheckConfigurationPropertiesDialog extends TitleAreaDialog {
   protected Control createDialogArea(Composite parent) {
 
     // set the logo
-    this.setTitleImage(CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.PLUGIN_LOGO));
+    this.setTitleImage(CheckstyleUIPluginImages.PLUGIN_LOGO.getImage());
 
     Composite composite = (Composite) super.createDialogArea(parent);
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationWorkingSetEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationWorkingSetEditor.java
@@ -692,7 +692,7 @@ public class CheckConfigurationWorkingSetEditor {
           if (mWorkingSet instanceof GlobalCheckConfigurationWorkingSet) {
 
             if (((GlobalCheckConfigurationWorkingSet) mWorkingSet).getDefaultCheckConfig() == cfg) {
-              image = CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.TICK_ICON);
+              image = CheckstyleUIPluginImages.TICK_ICON.getImage();
             }
           }
           break;

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/ResolvablePropertiesDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/ResolvablePropertiesDialog.java
@@ -157,7 +157,7 @@ public class ResolvablePropertiesDialog extends TitleAreaDialog {
   protected Control createDialogArea(Composite parent) {
 
     // set the logo
-    this.setTitleImage(CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.PLUGIN_LOGO));
+    this.setTitleImage(CheckstyleUIPluginImages.PLUGIN_LOGO.getImage());
     this.setTitle(Messages.ResolvablePropertiesDialog_titleMessageArea);
     this.setMessage(Messages.ResolvablePropertiesDialog_msgAdditionalProperties);
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/RuleConfigurationEditDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/RuleConfigurationEditDialog.java
@@ -392,7 +392,7 @@ public class RuleConfigurationEditDialog extends TitleAreaDialog {
     }
 
     // set the logo
-    this.setTitleImage(CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.PLUGIN_LOGO));
+    this.setTitleImage(CheckstyleUIPluginImages.PLUGIN_LOGO.getImage());
 
   }
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ConfigurationTypesUI.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ConfigurationTypesUI.java
@@ -27,12 +27,12 @@ import net.sf.eclipsecs.core.config.configtypes.IConfigurationType;
 import net.sf.eclipsecs.core.util.CheckstyleLog;
 import net.sf.eclipsecs.core.util.CheckstylePluginException;
 import net.sf.eclipsecs.ui.CheckstyleUIPlugin;
-import net.sf.eclipsecs.ui.CheckstyleUIPluginImages;
-
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.resource.ImageRegistry;
+import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 
@@ -65,7 +65,7 @@ public final class ConfigurationTypesUI {
   private static final Map<String, Class<? extends ICheckConfigurationEditor>> CONFIGURATION_TYPE_EDITORS;
 
   /** Map of icon paths for the configuration types. */
-  private static final Map<String, String> CONFIGATION_TYPE_ICONS;
+  private static final Map<String, String> CONFIGURATION_TYPE_ICONS;
 
   /**
    * Initialize the configured to the filter extension point.
@@ -73,7 +73,7 @@ public final class ConfigurationTypesUI {
   static {
 
     CONFIGURATION_TYPE_EDITORS = new HashMap<>();
-    CONFIGATION_TYPE_ICONS = new HashMap<>();
+    CONFIGURATION_TYPE_ICONS = new HashMap<>();
 
     IExtensionRegistry pluginRegistry = Platform.getExtensionRegistry();
 
@@ -92,7 +92,7 @@ public final class ConfigurationTypesUI {
         String iconPath = elements[i].getAttribute(ATTR_ICON);
 
         CONFIGURATION_TYPE_EDITORS.put(internalName, editor.getClass());
-        CONFIGATION_TYPE_ICONS.put(internalName, iconPath);
+        CONFIGURATION_TYPE_ICONS.put(internalName, iconPath);
       } catch (Exception e) {
         CheckstyleLog.log(e);
       }
@@ -142,12 +142,18 @@ public final class ConfigurationTypesUI {
    */
   public static Image getConfigurationTypeImage(IConfigurationType configType) {
 
-    String iconPath = CONFIGATION_TYPE_ICONS.get(configType.getInternalName());
+    String iconPath = CONFIGURATION_TYPE_ICONS.get(configType.getInternalName());
 
     if (iconPath != null) {
-      ImageDescriptor descriptor = AbstractUIPlugin
-              .imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID, iconPath);
-      return CheckstyleUIPluginImages.getImage(descriptor);
+      ImageRegistry imageRegistry = JFaceResources.getImageRegistry();
+      Image image = imageRegistry.get(iconPath);
+      if (image == null) {
+        ImageDescriptor descriptor = AbstractUIPlugin
+                .imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID, iconPath);
+        imageRegistry.put(iconPath, descriptor);
+        image = imageRegistry.get(iconPath);
+      }
+      return image;
     }
     return null;
   }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetAbstractBase.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetAbstractBase.java
@@ -71,7 +71,7 @@ public abstract class ConfigPropertyWidgetAbstractBase implements IConfigPropert
     gd = new GridData();
     gd.verticalAlignment = SWT.BEGINNING;
     lblPropertyInfo.setLayoutData(gd);
-    lblPropertyInfo.setImage(CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.HELP_ICON));
+    lblPropertyInfo.setImage(CheckstyleUIPluginImages.HELP_ICON.getImage());
     lblPropertyInfo.setToolTipText(mProp.getMetaData().getDescription());
     SWTUtil.addTooltipOnPressSupport(lblPropertyInfo);
   }
@@ -86,7 +86,7 @@ public abstract class ConfigPropertyWidgetAbstractBase implements IConfigPropert
 
   /**
    * Returns the widget containing the values.
-   * 
+   *
    * @return the widget containing the value
    */
   protected abstract Control getValueWidget(Composite parent);

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/preferences/CheckstylePreferencePage.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/preferences/CheckstylePreferencePage.java
@@ -201,7 +201,7 @@ public class CheckstylePreferencePage extends PreferencePage implements IWorkben
 
     mPurgeCacheButton = new Button(rebuildComposite, SWT.FLAT);
     mPurgeCacheButton
-            .setImage(CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.REFRESH_ICON));
+            .setImage(CheckstyleUIPluginImages.REFRESH_ICON.getImage());
     mPurgeCacheButton.setToolTipText(Messages.CheckstylePreferencePage_btnRefreshCheckerCache);
     mPurgeCacheButton.addSelectionListener(mController);
     GridData gd = new GridData();
@@ -234,7 +234,7 @@ public class CheckstylePreferencePage extends PreferencePage implements IWorkben
             CheckstylePluginPrefs.getBoolean(CheckstylePluginPrefs.PREF_INCLUDE_RULE_NAMES));
 
     Label lblRebuildNote = new Label(includeRuleNamesComposite, SWT.NULL);
-    lblRebuildNote.setImage(CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.HELP_ICON));
+    lblRebuildNote.setImage(CheckstyleUIPluginImages.HELP_ICON.getImage());
     lblRebuildNote.setToolTipText(Messages.CheckstylePreferencePage_txtSuggestRebuild);
     SWTUtil.addTooltipOnPressSupport(lblRebuildNote);
 
@@ -253,7 +253,7 @@ public class CheckstylePreferencePage extends PreferencePage implements IWorkben
             CheckstylePluginPrefs.getBoolean(CheckstylePluginPrefs.PREF_INCLUDE_MODULE_IDS));
 
     lblRebuildNote = new Label(includeModuleIdComposite, SWT.NULL);
-    lblRebuildNote.setImage(CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.HELP_ICON));
+    lblRebuildNote.setImage(CheckstyleUIPluginImages.HELP_ICON.getImage());
     lblRebuildNote.setToolTipText(Messages.CheckstylePreferencePage_txtSuggestRebuild);
     SWTUtil.addTooltipOnPressSupport(lblRebuildNote);
 
@@ -282,7 +282,7 @@ public class CheckstylePreferencePage extends PreferencePage implements IWorkben
     mTxtMarkerLimit.setLayoutData(gd);
 
     lblRebuildNote = new Label(limitMarkersComposite, SWT.NULL);
-    lblRebuildNote.setImage(CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.HELP_ICON));
+    lblRebuildNote.setImage(CheckstyleUIPluginImages.HELP_ICON.getImage());
     lblRebuildNote.setToolTipText(Messages.CheckstylePreferencePage_txtSuggestRebuild);
     SWTUtil.addTooltipOnPressSupport(lblRebuildNote);
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/FileMatchPatternEditDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/FileMatchPatternEditDialog.java
@@ -118,7 +118,7 @@ public class FileMatchPatternEditDialog extends TitleAreaDialog {
       mIncludeButton.setSelection(true);
     }
 
-    this.setTitleImage(CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.PLUGIN_LOGO));
+    this.setTitleImage(CheckstyleUIPluginImages.PLUGIN_LOGO.getImage());
     this.setTitle(Messages.FileMatchPatternEditDialog_title);
     this.setMessage(Messages.FileMatchPatternEditDialog_message);
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/FileSetEditDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/FileSetEditDialog.java
@@ -354,7 +354,7 @@ public class FileSetEditDialog extends TitleAreaDialog {
     // init the check configuration combo
     mComboViewer.setInput(mPropertyPage.getProjectConfigurationWorkingCopy());
 
-    this.setTitleImage(CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.PLUGIN_LOGO));
+    this.setTitleImage(CheckstyleUIPluginImages.PLUGIN_LOGO.getImage());
     this.setMessage(Messages.FileSetEditDialog_message);
 
     if (mIsCreatingNewFileset) {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/marker/MarkerPropertyPage.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/marker/MarkerPropertyPage.java
@@ -54,7 +54,7 @@ public class MarkerPropertyPage extends PropertyPage {
       labelMessage.setText(message);
 
       new Label(composite, SWT.NONE).setImage(
-              CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.MODULEGROUP_ICON));
+              CheckstyleUIPluginImages.MODULEGROUP_ICON.getImage());
       new Label(composite, SWT.NONE).setText(Messages.MarkerPropertyPage_Group);
 
       String moduleName = (String) getIssue().getAttribute(CheckstyleMarker.MODULE_NAME);
@@ -62,7 +62,7 @@ public class MarkerPropertyPage extends PropertyPage {
       new Label(composite, SWT.NONE).setText(metaData.getGroup().getGroupName());
 
       new Label(composite, SWT.NONE).setImage(
-              CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.MODULE_ICON));
+              CheckstyleUIPluginImages.MODULE_ICON.getImage());
       new Label(composite, SWT.NONE).setText(Messages.MarkerPropertyPage_Module);
 
       RowLayout rowLayout = new RowLayout(SWT.HORIZONTAL);
@@ -76,8 +76,7 @@ public class MarkerPropertyPage extends PropertyPage {
       new Label(nameComposite, SWT.NONE).setText(metaData.getRuleName());
 
       Label helpIcon = new Label(nameComposite, SWT.NONE);
-      helpIcon.setImage(
-              CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.HELP_ICON));
+      helpIcon.setImage(CheckstyleUIPluginImages.HELP_ICON.getImage());
       helpIcon.setToolTipText(NLS.bind(Messages.MarkerPropertyPage_SuppressionHint,
               metaData.getInternalName()));
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/blocks/AvoidNestedBlocksQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/blocks/AvoidNestedBlocksQuickfix.java
@@ -35,7 +35,7 @@ import org.eclipse.swt.graphics.Image;
 
 /**
  * Quickfix implementation that removes nested blocks.
- * 
+ *
  * @author Lars Ködderitzsch
  */
 public class AvoidNestedBlocksQuickfix extends AbstractASTResolution {
@@ -98,6 +98,6 @@ public class AvoidNestedBlocksQuickfix extends AbstractASTResolution {
    */
   @Override
   public Image getImage() {
-    return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_REMOVE);
+    return CheckstyleUIPluginImages.CORRECTION_REMOVE.getImage();
   }
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/blocks/NeedBracesQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/blocks/NeedBracesQuickfix.java
@@ -163,6 +163,6 @@ public class NeedBracesQuickfix extends AbstractASTResolution {
    */
   @Override
   public Image getImage() {
-    return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_ADD);
+    return CheckstyleUIPluginImages.CORRECTION_ADD.getImage();
   }
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/DefaultComesLastQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/DefaultComesLastQuickfix.java
@@ -37,7 +37,7 @@ import org.eclipse.swt.graphics.Image;
 /**
  * Quickfix implementation that moves the default case of a switch statement to
  * the last position.
- * 
+ *
  * @author Lars Ködderitzsch
  */
 public class DefaultComesLastQuickfix extends AbstractASTResolution {
@@ -122,6 +122,6 @@ public class DefaultComesLastQuickfix extends AbstractASTResolution {
    */
   @Override
   public Image getImage() {
-    return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_CHANGE);
+    return CheckstyleUIPluginImages.CORRECTION_CHANGE.getImage();
   }
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/EmptyStatementQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/EmptyStatementQuickfix.java
@@ -34,7 +34,7 @@ import org.eclipse.swt.graphics.Image;
 /**
  * Quickfix implementation that removes an empty statement (unneccessary
  * semicolon).
- * 
+ *
  * @author Lars Ködderitzsch
  */
 public class EmptyStatementQuickfix extends AbstractASTResolution {
@@ -86,7 +86,7 @@ public class EmptyStatementQuickfix extends AbstractASTResolution {
    */
   @Override
   public Image getImage() {
-    return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_REMOVE);
+    return CheckstyleUIPluginImages.CORRECTION_REMOVE.getImage();
   }
 
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/ExplicitInitializationQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/ExplicitInitializationQuickfix.java
@@ -119,7 +119,7 @@ public class ExplicitInitializationQuickfix extends AbstractASTResolution {
    */
   @Override
   public Image getImage() {
-    return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_REMOVE);
+    return CheckstyleUIPluginImages.CORRECTION_REMOVE.getImage();
   }
 
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/FinalLocalVariableQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/FinalLocalVariableQuickfix.java
@@ -35,7 +35,7 @@ import org.eclipse.swt.graphics.Image;
 /**
  * Quickfix implementation which adds final modifiers to parameters in method
  * declarations.
- * 
+ *
  * @author Levon Saldamli
  * @author Lars Ködderitzsch
  */
@@ -96,7 +96,7 @@ public class FinalLocalVariableQuickfix extends AbstractASTResolution {
    */
   @Override
   public Image getImage() {
-    return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_ADD);
+    return CheckstyleUIPluginImages.CORRECTION_ADD.getImage();
   }
 
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/MissingSwitchDefaultQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/MissingSwitchDefaultQuickfix.java
@@ -33,7 +33,7 @@ import org.eclipse.swt.graphics.Image;
 /**
  * Quickfix implementation that add a missing default statement to a switch
  * case.
- * 
+ *
  * @author Levon Saldamli
  */
 public class MissingSwitchDefaultQuickfix extends AbstractASTResolution {
@@ -82,6 +82,6 @@ public class MissingSwitchDefaultQuickfix extends AbstractASTResolution {
    */
   @Override
   public Image getImage() {
-    return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_ADD);
+    return CheckstyleUIPluginImages.CORRECTION_ADD.getImage();
   }
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/RequireThisQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/RequireThisQuickfix.java
@@ -163,7 +163,7 @@ public class RequireThisQuickfix extends AbstractASTResolution {
    */
   @Override
   public Image getImage() {
-    return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_ADD);
+    return CheckstyleUIPluginImages.CORRECTION_ADD.getImage();
   }
 
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnQuickfix.java
@@ -182,7 +182,7 @@ public class SimplifyBooleanReturnQuickfix extends AbstractASTResolution {
    */
   @Override
   public Image getImage() {
-    return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_CHANGE);
+    return CheckstyleUIPluginImages.CORRECTION_CHANGE.getImage();
   }
 
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityQuickfix.java
@@ -167,6 +167,6 @@ public class StringLiteralEqualityQuickfix extends AbstractASTResolution {
    */
   @Override
   public Image getImage() {
-    return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_CHANGE);
+    return CheckstyleUIPluginImages.CORRECTION_CHANGE.getImage();
   }
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/design/DesignForExtensionQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/design/DesignForExtensionQuickfix.java
@@ -37,7 +37,7 @@ import org.eclipse.swt.graphics.Image;
 
 /**
  * Quickfix implementation which adds the final modifiers a method declaration.
- * 
+ *
  * @author Levon Saldamli
  * @author Lars Ködderitzsch
  */
@@ -101,6 +101,6 @@ public class DesignForExtensionQuickfix extends AbstractASTResolution {
    */
   @Override
   public Image getImage() {
-    return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_ADD);
+    return CheckstyleUIPluginImages.CORRECTION_ADD.getImage();
   }
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/design/FinalClassQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/design/FinalClassQuickfix.java
@@ -36,7 +36,7 @@ import org.eclipse.swt.graphics.Image;
 
 /**
  * Quickfix implementation which adds the final modifiers a method declaration.
- * 
+ *
  * @author Levon Saldamli
  * @author Lars Ködderitzsch
  */
@@ -100,6 +100,6 @@ public class FinalClassQuickfix extends AbstractASTResolution {
    */
   @Override
   public Image getImage() {
-    return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_ADD);
+    return CheckstyleUIPluginImages.CORRECTION_ADD.getImage();
   }
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/ArrayTypeStyleQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/ArrayTypeStyleQuickfix.java
@@ -41,7 +41,7 @@ import org.eclipse.swt.graphics.Image;
 /**
  * Quickfix implementation which moves the array declaration (C-style to
  * Java-style and reverse).
- * 
+ *
  * @author Lars Ködderitzsch
  */
 public class ArrayTypeStyleQuickfix extends AbstractASTResolution {
@@ -208,7 +208,7 @@ public class ArrayTypeStyleQuickfix extends AbstractASTResolution {
    */
   @Override
   public Image getImage() {
-    return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_CHANGE);
+    return CheckstyleUIPluginImages.CORRECTION_CHANGE.getImage();
   }
 
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/FinalParametersQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/FinalParametersQuickfix.java
@@ -34,7 +34,7 @@ import org.eclipse.swt.graphics.Image;
 /**
  * Quickfix implementation which adds final modifiers to parameters in method
  * declarations.
- * 
+ *
  * @author Levon Saldamli
  * @author Lars Ködderitzsch
  */
@@ -83,7 +83,7 @@ public class FinalParametersQuickfix extends AbstractASTResolution {
    */
   @Override
   public Image getImage() {
-    return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_ADD);
+    return CheckstyleUIPluginImages.CORRECTION_ADD.getImage();
   }
 
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/UncommentedMainQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/UncommentedMainQuickfix.java
@@ -85,6 +85,6 @@ public class UncommentedMainQuickfix extends AbstractASTResolution {
    */
   @Override
   public Image getImage() {
-    return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_REMOVE);
+    return CheckstyleUIPluginImages.CORRECTION_REMOVE.getImage();
   }
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/UpperEllQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/UpperEllQuickfix.java
@@ -81,7 +81,7 @@ public class UpperEllQuickfix extends AbstractASTResolution {
    */
   @Override
   public Image getImage() {
-    return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_CHANGE);
+    return CheckstyleUIPluginImages.CORRECTION_CHANGE.getImage();
   }
 
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/modifier/ModifierOrderQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/modifier/ModifierOrderQuickfix.java
@@ -176,7 +176,7 @@ public class ModifierOrderQuickfix extends AbstractASTResolution {
    */
   @Override
   public Image getImage() {
-    return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_CHANGE);
+    return CheckstyleUIPluginImages.CORRECTION_CHANGE.getImage();
   }
 
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/modifier/RedundantModifierQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/modifier/RedundantModifierQuickfix.java
@@ -43,7 +43,7 @@ import org.eclipse.swt.graphics.Image;
 
 /**
  * Quickfix implementation that removes redundant modifiers.
- * 
+ *
  * @author Lars Ködderitzsch
  */
 public class RedundantModifierQuickfix extends AbstractASTResolution {
@@ -178,7 +178,7 @@ public class RedundantModifierQuickfix extends AbstractASTResolution {
    */
   @Override
   public Image getImage() {
-    return CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.CORRECTION_REMOVE);
+    return CheckstyleUIPluginImages.CORRECTION_REMOVE.getImage();
   }
 
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/GraphStatsView.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/GraphStatsView.java
@@ -354,7 +354,7 @@ public class GraphStatsView extends AbstractStatsView {
     };
     mListingAction.setText(Messages.GraphStatsView_displayListing);
     mListingAction.setToolTipText(Messages.GraphStatsView_displayListing);
-    mListingAction.setImageDescriptor(CheckstyleUIPluginImages.LIST_VIEW_ICON);
+    mListingAction.setImageDescriptor(CheckstyleUIPluginImages.LIST_VIEW_ICON.getImageDescriptor());
 
     mShowAllCategoriesAction = new Action(Messages.GraphStatsView_displayAllCategories,
             IAction.AS_CHECK_BOX) {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/MarkerStatsView.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/MarkerStatsView.java
@@ -380,7 +380,7 @@ public class MarkerStatsView extends AbstractStatsView {
     };
     mChartAction.setText(Messages.MarkerStatsView_displayChart);
     mChartAction.setToolTipText(Messages.MarkerStatsView_displayChartTooltip);
-    mChartAction.setImageDescriptor(CheckstyleUIPluginImages.GRAPH_VIEW_ICON);
+    mChartAction.setImageDescriptor(CheckstyleUIPluginImages.GRAPH_VIEW_ICON.getImageDescriptor());
 
     // action used to display the detail of a specific error type
     mDrillDownAction = new Action() {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilterDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilterDialog.java
@@ -267,7 +267,7 @@ public class CheckstyleMarkerFilterDialog extends TitleAreaDialog {
     // init the controls
     updateUIFromFilter();
 
-    this.setTitleImage(CheckstyleUIPluginImages.getImage(CheckstyleUIPluginImages.PLUGIN_LOGO));
+    this.setTitleImage(CheckstyleUIPluginImages.PLUGIN_LOGO.getImage());
     this.setTitle(Messages.CheckstyleMarkerFilterDialog_title);
     this.setMessage(Messages.CheckstyleMarkerFilterDialog_titleMessage);
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/FiltersAction.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/FiltersAction.java
@@ -28,7 +28,7 @@ import org.eclipse.jface.action.Action;
 
 /**
  * Action implementation for the filters action.
- * 
+ *
  * @author Lars Ködderitzsch
  */
 public class FiltersAction extends Action {
@@ -46,13 +46,13 @@ public class FiltersAction extends Action {
 
   /**
    * Creates the action.
-   * 
+   *
    * @param view
    *          the stats view
    */
   public FiltersAction(AbstractStatsView view) {
     super(Messages.FiltersAction_text);
-    setImageDescriptor(CheckstyleUIPluginImages.FILTER_ICON);
+    setImageDescriptor(CheckstyleUIPluginImages.FILTER_ICON.getImageDescriptor());
     setToolTipText(Messages.FiltersAction_tooltip);
     this.mStatsView = view;
     setEnabled(true);


### PR DESCRIPTION
Avoid a static block for creating the icon images, since we cannot really control when that static block is executed (it depends on the class loading time). Rather create the icons the first time they are accessed, since that is surely when the workbench is fully up and running.

Have tested configuration, execution, markers. Works as before, no more exception.