### PR TITLE
fix #411: broken online help

### DIFF
--- a/net.sf.eclipsecs.doc/pom.xml
+++ b/net.sf.eclipsecs.doc/pom.xml
@@ -81,7 +81,7 @@
                             <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${project.basedir}/../docs</outputDirectory>
+                            <outputDirectory>${project.basedir}/docs</outputDirectory>
                             <resources>
                                 <resource>
                                     <directory>src/main/resources</directory>


### PR DESCRIPTION
The documentation generation has 2 different target directories:
* root/docs for the website
* root/net.sf.eclipsecs.docs/docs for the online help

Care must be taken to not confuse them in scripts.

![grafik](https://user-images.githubusercontent.com/406876/202809172-769c406a-ee00-4c8e-9046-412359b8bd92.png)