### PR TITLE
Infra: Avoid repeated target file resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,9 @@
                 <version>${tycho-version}</version>
                 <configuration>
                     <target>
-                        <file>${basedir}/../net.sf.eclipsecs.target/net.sf.eclipsecs.target.target</file>
+                        <!-- Replace multi module dir by basedir after Tycho 3.0+ can be used.
+                        see https://github.com/eclipse-tycho/tycho/issues/1660 -->
+                        <file>${maven.multiModuleProjectDirectory}/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target</file>
                     </target>
                     <resolver>p2</resolver>
                     <environments>


### PR DESCRIPTION
Due to a bug in Tycho the path towards target platform files is not normalized. Therefore a/../target and b/../target are considered different files, even though they are in fact the same.

As a workaround use a path relative to the directory where the maven build was started in, which is identical for all maven modules. This is typically not recommended, because it would not work when building a single module only, but that doesn't work anyway in this project (due to the checkstyle maven config properties resolution).