### PR TITLE
Issue #391: disable dialog context help

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/ConfigureProjectFromBluePrintAction.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/ConfigureProjectFromBluePrintAction.java
@@ -53,7 +53,7 @@ import org.eclipse.ui.model.WorkbenchLabelProvider;
 /**
  * Action to configure one ore more projects at once by using another project as
  * blueprint.
- * 
+ *
  * @author Lars Ködderitzsch
  */
 public class ConfigureProjectFromBluePrintAction implements IObjectActionDelegate {
@@ -96,6 +96,7 @@ public class ConfigureProjectFromBluePrintAction implements IObjectActionDelegat
     filteredProjects.removeAll(mSelectedProjects);
 
     ListDialog dialog = new ListDialog(mPart.getSite().getShell());
+    dialog.setHelpAvailable(false);
     dialog.setInput(filteredProjects);
     dialog.setContentProvider(new ArrayContentProvider());
     dialog.setLabelProvider(new WorkbenchLabelProvider());
@@ -117,7 +118,7 @@ public class ConfigureProjectFromBluePrintAction implements IObjectActionDelegat
   /**
    * Job implementation that configures several projects from a blueprint
    * project.
-   * 
+   *
    * @author Lars Ködderitzsch
    */
   private static class BulkConfigureJob extends WorkspaceJob {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ProjectConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ProjectConfigurationEditor.java
@@ -167,6 +167,7 @@ public class ProjectConfigurationEditor implements ICheckConfigurationEditor {
       public void widgetSelected(SelectionEvent e) {
         ElementTreeSelectionDialog dialog = new ElementTreeSelectionDialog(shell,
                 new WorkbenchLabelProvider(), new WorkbenchContentProvider());
+        dialog.setHelpAvailable(false);
         dialog.setTitle(Messages.ProjectConfigurationLocationEditor_titleSelectConfigFile);
         dialog.setMessage(Messages.ProjectConfigurationLocationEditor_msgSelectConfigFile);
         dialog.setBlockOnOpen(true);

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/PackageFilterEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/PackageFilterEditor.java
@@ -367,6 +367,7 @@ public class PackageFilterEditor implements IFilterEditor {
     public CheckedTreeSelectionDialog(Shell parent, ILabelProvider labelProvider,
             ITreeContentProvider contentProvider) {
       super(parent);
+      setHelpAvailable(false);
       mLabelProvider = labelProvider;
       mContentProvider = contentProvider;
       setResult(new ArrayList<>(0));


### PR DESCRIPTION
The previous PR linked to the issue was not complete. I found 3 more dialogs with context help enabled, and disabled it the same way as before.