### PR TITLE
don't use input text for filter hints

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
@@ -72,8 +72,6 @@ import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.custom.SashForm;
-import org.eclipse.swt.events.FocusEvent;
-import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.events.ModifyEvent;
@@ -266,30 +264,10 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
     knownModules.setText(Messages.CheckConfigurationConfigureDialog_lblAvailableModules);
 
     mTxtTreeFilter = new Text(knownModules, SWT.SINGLE | SWT.BORDER);
-    mTxtTreeFilter.setText(mDefaultFilterText);
+    mTxtTreeFilter.setMessage(mDefaultFilterText);
     mTxtTreeFilter.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
     mTxtTreeFilter.addModifyListener(mController);
     mTxtTreeFilter.addKeyListener(mController);
-
-    // select all of the default text on focus gain
-    mTxtTreeFilter.addFocusListener(new FocusListener() {
-      @Override
-      public void focusGained(FocusEvent e) {
-        if (mDefaultFilterText.equals(mTxtTreeFilter.getText())) {
-          getShell().getDisplay().asyncExec(new Runnable() {
-
-            @Override
-            public void run() {
-              mTxtTreeFilter.selectAll();
-            }
-          });
-        }
-      }
-
-      @Override
-      public void focusLost(FocusEvent e) {
-      }
-    });
 
     mTreeViewer = new TreeViewer(knownModules,
             SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL | SWT.BORDER);
@@ -551,8 +529,7 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
     public void modifyText(ModifyEvent e) {
       mTreeViewer.getControl().setRedraw(false);
       try {
-        if (!mDefaultFilterText.equals(mTxtTreeFilter.getText())
-                && !Strings.isNullOrEmpty(mTxtTreeFilter.getText())) {
+        if (!Strings.isNullOrEmpty(mTxtTreeFilter.getText())) {
 
           if (!Arrays.asList(mTableViewer.getFilters()).contains(mTreeFilter)) {
             mTreeViewer.addFilter(mTreeFilter);

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/RuleConfigurationEditDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/RuleConfigurationEditDialog.java
@@ -53,8 +53,6 @@ import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.FocusEvent;
-import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridData;
@@ -62,7 +60,6 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
@@ -230,33 +227,9 @@ public class RuleConfigurationEditDialog extends TitleAreaDialog {
       final String standardMessage = MetadataFactory.getStandardMessage(msgKey,
               mRule.getMetaData().getInternalName());
 
-      // msgText.setMessage(standardMessage); //a nice solution, sadly only for
-      // Eclipse 3.3+
-
-      // alternative for above
       if (standardMessage != null) {
-        msgText.setText(standardMessage);
+        msgText.setMessage(standardMessage);
       }
-      msgText.addFocusListener(new FocusListener() {
-
-        @Override
-        public void focusGained(FocusEvent e) {
-          Display.getCurrent().asyncExec(new Runnable() {
-
-            @Override
-            public void run() {
-              if (msgText.getText().equals(standardMessage)) {
-                msgText.selectAll();
-              }
-            }
-          });
-        }
-
-        @Override
-        public void focusLost(FocusEvent e) {
-          // NOOP
-        }
-      });
 
       String message = mRule.getCustomMessages().get(msgKey);
       if (Strings.emptyToNull(message) != null) {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetRegex.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetRegex.java
@@ -31,8 +31,6 @@ import net.sf.eclipsecs.ui.Messages;
 import net.sf.eclipsecs.ui.util.regex.RegexCompletionProposalFactory;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.FocusEvent;
-import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.graphics.Color;
@@ -40,7 +38,6 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Text;
 
 /**
@@ -110,28 +107,8 @@ public class ConfigPropertyWidgetRegex extends ConfigPropertyWidgetAbstractBase 
 
       mRegexTestWidget = new Text(mContents, SWT.SINGLE | SWT.BORDER);
       mRegexTestWidget.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-      mRegexTestWidget.setText(mDefaultMessage);
+      mRegexTestWidget.setMessage(mDefaultMessage);
       mRegexTestWidget.addKeyListener(new RegexTestListener());
-      mRegexTestWidget.addFocusListener(new FocusListener() {
-
-        @Override
-        public void focusGained(FocusEvent e) {
-          Display.getCurrent().asyncExec(new Runnable() {
-
-            @Override
-            public void run() {
-              if (mRegexTestWidget.getText().equals(mDefaultMessage)) {
-                mRegexTestWidget.selectAll();
-              }
-            }
-          });
-        }
-
-        @Override
-        public void focusLost(FocusEvent e) {
-          // NOOP
-        }
-      });
 
     }
 
@@ -177,10 +154,6 @@ public class ConfigPropertyWidgetRegex extends ConfigPropertyWidgetAbstractBase 
   }
 
   private void testRegex() {
-    if (mDefaultMessage.equals(mRegexTestWidget.getText())) {
-      return;
-    }
-
     try {
       Pattern pattern = Pattern.compile(mTextWidget.getText());
       Matcher matcher = pattern.matcher(mRegexTestWidget.getText());


### PR DESCRIPTION
JFace text controls have a separate message property to give hints for the expected input into a text field. Programmatically setting the actual control text instead is a bad idea since it can lead to the user actually editing that hint.

before the change its possible to edit the hint, since it's the actual widget text:
![grafik](https://user-images.githubusercontent.com/406876/206918906-3596cc3e-0b06-42d6-a3d9-12de373c7b7e.png)

after the change the widget itself shows the hint only if the input is empty:
![grafik](https://user-images.githubusercontent.com/406876/206918929-941c7e65-042e-4051-8c04-de559569ce61.png)
