### PR TITLE
Avoid wrong checkstyle library being unpacked

### DIFF
--- a/net.sf.eclipsecs.checkstyle/pom.xml
+++ b/net.sf.eclipsecs.checkstyle/pom.xml
@@ -42,10 +42,7 @@
                             <target>
                                 <delete dir="${project.build.directory}/checkstyle-src-unpack" />
                                 <delete dir="${project.build.directory}/checkstyle-src" />
-                                <first id="cssrc">
-                                    <fileset dir="." includes="checkstyle-checkstyle-*.zip" />
-                                </first>
-                                <unzip src="${toString:cssrc}" dest="${project.build.directory}/checkstyle-src-unpack">
+                                <unzip src="checkstyle-checkstyle-${checkstyle.version}.zip" dest="${project.build.directory}/checkstyle-src-unpack">
                                     <patternset>
                                         <include name="**/src/main/java/**" />
                                         <include name="**/src/main/resources/**" />


### PR DESCRIPTION
If multiple zip files are available in the local directory (from previous builds of older releases), the previous code might choose a wrong outdated version. Just use the known file name from the download to avoid that.