### PR TITLE
fix #430: set unused button invisible

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationWorkingSetEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationWorkingSetEditor.java
@@ -356,6 +356,9 @@ public class CheckConfigurationWorkingSetEditor {
       formData.right = new FormAttachment(100);
       mDefaultButton.setLayoutData(formData);
     }
+    else {
+      mDefaultButton.setVisible(false);
+    }
 
     mExportButton = new Button(rightButtons, SWT.PUSH);
     mExportButton.setText(Messages.CheckstylePreferencePage_btnExport);


### PR DESCRIPTION
https://github.com/checkstyle/eclipse-cs/issues/430

Previously that button was just not layouted in the container widget, but it was actually usable. Now set the widget to invisible, thereby removing it from the tab key cycling and from the button click listener.