### PR TITLE
minor: updates travis ci link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ Open a command line in project root directory and run `mvn clean package`.
 
 Find the installable bundle update site archive `net.sf.eclipsecs-updatesite/target/net.sf.eclipsecs-updatesite_X.X.X.YYYYmmDDHHMM.zip`.
 
-[travis]:https://travis-ci.org/checkstyle/eclipse-cs
-[travis img]:https://travis-ci.org/checkstyle/eclipse-cs.svg?branch=master
+[travis]:https://travis-ci.com/github/checkstyle/eclipse-cs/builds
+[travis img]:https://api.travis-ci.com/checkstyle/eclipse-cs.svg


### PR DESCRIPTION
Updates the travis CI link in the readme as it doesn't work for me. It takes me to a page that says "This repository was migrated and is now building on travis-ci.com".

Used similar links to main repo.