### PR TITLE
config: removes custom arch to avoid credit usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ jobs:
 
     # JDK 17 (most recent Java LTS version)
     - jdk: openjdk17
-      arch: amd64
       env:
         - DESC="install (openjdk17)"
         - CMD="mvn --errors --no-transfer-progress install"


### PR DESCRIPTION
Travis can only use arch `ppc64le` otherwise we get charged. Travis will shutdown when we use up all our credits.

We won't know if this will continue working once travis returns, but we need this removed regardless.