### PR TITLE
Fix #475: include transitive dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,15 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>tycho-p2-repository-plugin</artifactId>
+                    <version>${tycho-version}</version>
+                    <configuration>
+                        <!-- make the update site self-contained by including all transitive dependencies -->
+                        <includeAllDependencies>true</includeAllDependencies>
+                    </configuration>
+                </plugin>
                 <!-- Disable default deployer. -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fix #475

This way Tycho automatically includes direct _and_ transitive dependencies in the update site. That is more than just the missing libraries, it includes every plugin needed when installing Eclipse-CS (that is, down to the actual Eclipse workbench and similar plugins).

The amount of data used during an installation does not change. The main change is that during installation all _needed_ plugins are found in the Eclipse-CS update site _as such_ while previously other known Eclipse repositories would be contacted to look for the missing transitively required bundles. This setting should have been used before, as it is generally good practice to have self-contained update sites.

Users can now also uncheck the checkbox "Contact all update sites to find required software", which will shorten the time drastically.

Below is just the beginning of the plugin list now contained in the update site:
![grafik](https://user-images.githubusercontent.com/406876/217061028-452e2f64-dfe7-411c-bfd3-3f219b688781.png)
