### PR TITLE
have progress icon for checkstyle jobs

### DIFF
--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/AbstractCheckJob.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/AbstractCheckJob.java
@@ -1,0 +1,54 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+//============================================================================
+
+package net.sf.eclipsecs.core.jobs;
+
+import org.eclipse.core.resources.WorkspaceJob;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
+
+/**
+ * Super class of all jobs that invoke Checkstyle. Avoids concurrent invocations and styles the progress UI.
+ *
+ */
+public abstract class AbstractCheckJob extends WorkspaceJob implements ISchedulingRule {
+  /**
+   * The job family marker is used by the progress service to provide different icons.
+   */
+  public static final Object CHECKSTYLE_JOB_FAMILY = new Object();
+
+  public AbstractCheckJob(String name) {
+    super(name);
+  }
+
+  @Override
+  public final boolean isConflicting(ISchedulingRule rule) {
+    return rule instanceof AuditorJob || rule instanceof RunCheckstyleOnFilesJob;
+  }
+
+  @Override
+  public boolean belongsTo(Object family) {
+    if (CHECKSTYLE_JOB_FAMILY.equals(family)) {
+      return true;
+    }
+
+    return super.belongsTo(family);
+  }
+
+}

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/AuditorJob.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/AuditorJob.java
@@ -26,7 +26,6 @@ import net.sf.eclipsecs.core.builder.Auditor;
 import net.sf.eclipsecs.core.util.CheckstylePluginException;
 
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -40,7 +39,7 @@ import org.eclipse.osgi.util.NLS;
  *
  * @author Lars Ködderitzsch
  */
-public class AuditorJob extends WorkspaceJob implements ISchedulingRule {
+public class AuditorJob extends AbstractCheckJob {
 
   private IProject mProject;
 
@@ -64,11 +63,6 @@ public class AuditorJob extends WorkspaceJob implements ISchedulingRule {
   @Override
   public boolean contains(ISchedulingRule arg0) {
     return arg0 instanceof AuditorJob;
-  }
-
-  @Override
-  public boolean isConflicting(ISchedulingRule arg0) {
-    return arg0 instanceof AuditorJob || arg0 instanceof RunCheckstyleOnFilesJob;
   }
 
   @Override

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/RunCheckstyleOnFilesJob.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/RunCheckstyleOnFilesJob.java
@@ -37,7 +37,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
-import org.eclipse.core.resources.WorkspaceJob;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -49,7 +48,7 @@ import org.eclipse.core.runtime.jobs.ISchedulingRule;
  *
  * @author Lars Ködderitzsch
  */
-public class RunCheckstyleOnFilesJob extends WorkspaceJob implements ISchedulingRule {
+public class RunCheckstyleOnFilesJob extends AbstractCheckJob {
 
   private List<IFile> mFilesToCheck;
 
@@ -83,11 +82,6 @@ public class RunCheckstyleOnFilesJob extends WorkspaceJob implements IScheduling
   @Override
   public boolean contains(ISchedulingRule arg0) {
     return arg0 instanceof RunCheckstyleOnFilesJob;
-  }
-
-  @Override
-  public boolean isConflicting(ISchedulingRule arg0) {
-    return arg0 instanceof RunCheckstyleOnFilesJob || arg0 instanceof AuditorJob;
   }
 
   @Override

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/CheckstyleUIPlugin.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/CheckstyleUIPlugin.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 
+import net.sf.eclipsecs.core.jobs.AbstractCheckJob;
 import net.sf.eclipsecs.core.util.CheckstyleLog;
 import net.sf.eclipsecs.core.util.ExtensionClassLoader;
 import net.sf.eclipsecs.ui.properties.filter.CheckFileOnOpenPartListener;
@@ -45,6 +46,7 @@ import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.eclipse.ui.progress.IProgressService;
 import org.osgi.framework.BundleContext;
 
 /**
@@ -140,9 +142,19 @@ public class CheckstyleUIPlugin extends AbstractUIPlugin {
         }
 
         workbench.addWindowListener(mWindowListener);
+        registerProgressIcon();
       }
     });
 
+  }
+
+  protected void registerProgressIcon() {
+    IProgressService service = PlatformUI.getWorkbench().getProgressService();
+    if (service == null) {
+      return;
+    }
+    service.registerIconForFamily(CheckstyleUIPluginImages.CHECKSTYLE_ICON.getImageDescriptor(),
+            AbstractCheckJob.CHECKSTYLE_JOB_FAMILY);
   }
 
   @Override

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/CheckstyleUIPluginImages.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/CheckstyleUIPluginImages.java
@@ -93,7 +93,10 @@ public enum CheckstyleUIPluginImages {
   /** Image descriptor for the refresh icon. */
   REFRESH_ICON(() -> ResourceLocator.imageDescriptorFromBundle("org.eclipse.search",
           "platform:/plugin/org.eclipse.search/icons/full/elcl16/refresh.png")
-          .orElse(MARKER_ERROR.getImageDescriptor()));
+          .orElse(MARKER_ERROR.getImageDescriptor())),
+  /** Image descriptor for the checkstyle project icon. */
+  CHECKSTYLE_ICON(() -> AbstractUIPlugin.imageDescriptorFromPlugin(CheckstyleUIPlugin.PLUGIN_ID,
+          "icons/checkstyle_command.png"));
 
   /**
    * lazy creation factory


### PR DESCRIPTION
Jobs being shown in the progress view can style the icon next to the progress bar. The git plugin uses that to show an icon matching the current git operation, spotbugs and some others show their specific icon. Let's also have the checkstyle icon next to the running checkstyle jobs so that it can be recognized more easily in a mix of running jobs.
Looks like this: 
![image](https://user-images.githubusercontent.com/406876/229339984-9b16cc82-14f0-4b99-b619-fa18658728e1.png)
