### PR TITLE
WIP: use checkstyle core cachefile

### DIFF
--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
@@ -162,7 +162,21 @@ public class Auditor {
       // Cleanup listener and filter
       if (checker != null) {
         checker.removeListener(listener);
+        persistCacheFile(checker);
       }
+    }
+  }
+
+  private void persistCacheFile(Checker checker) throws CheckstylePluginException {
+    try {
+      // TODO use new API in checkstyle core once it might be available
+      var field = checker.getClass().getDeclaredField("cacheFile");
+      field.setAccessible(true);
+      var cacheFile = field.get(checker);
+      var persistMethod = cacheFile.getClass().getDeclaredMethod("persist");
+      persistMethod.invoke(cacheFile);
+    } catch (ReflectiveOperationException | SecurityException | IllegalArgumentException ex) {
+      CheckstylePluginException.rethrow(ex);
     }
   }
 


### PR DESCRIPTION
This is a proof of concept only and needs further discussion.
When running checkstyle via maven plugin, it's really easy to use the cacheFile mechanism for more speed. In the eclipse plugin, there is no caching enabled for checkstyle core (the plugin only caches some of its own configuration files and similar). This leads to very long runtime in case of clean builds (because all files will be scanned again then, independent of whether there are actual changes). I have some workspace where checkstyle consumes 20 minutes of CPU time on clean builds.
This change enables the cacheFile mechanism in checkstyle core. It uses a single cachefile for all checkers, which is stored in the ".metadata" folder belonging to a workspace. That way the cachefile is not visible in the workspace itself, and every workspace has its own persistent cachefile, without using any global temp directories or similar.
The cache is not configurable and always enabled. It can be invalidated with the already existing "Purge checkstyle caches" action (hit Ctrl-3, start typing "purge").
The effect of the cache can be seen best when using the context menu on a large project to invoke checkstyle on it. Without the cache that always takes the same time, with a visible job in the progress view. With the cache the first invocation takes that same long time, every additional invocation on an already checked project is super-fast (in fact, I don't see a job anymore in the progress view in most cases because the job is finished more quickly then the progress view updates).

Open issues:
* The existing lifecycle of the cachefile in checkers doesn't really fit for the plugin, therefore it currently calls the persist method via reflection. This method should be made public API in the checkstyle project. Right now it's only called from within the Checker.destroy() method, and that is not called at all from the Eclipse plugin.
* Are there any hidden assumptions about the cachefile on the checkstyle core side? Is it okay to have the same checkfile for many checkers? The plugin creates one checker per eclipse project to be checked, and all share the identical cachefile right now.