### PR TITLE
Infra: Avoid exception when launching runtime

### DIFF
--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
@@ -3,6 +3,10 @@
 <target name="Eclipse Checkstyle" sequenceNumber="1653761205">
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/cbi/updates/license/"/>
+			<unit id="org.eclipse.license.feature.group" version="0.0.0"/>
+		</location>
 		<location type="Target" uri="file:${project_loc:/net.sf.eclipsecs.core}/../net.sf.eclipsecs.target/net.sf.eclipsecs.partial.maven.target"/>
 		<location type="Target" uri="file:${project_loc:/net.sf.eclipsecs.core}/../net.sf.eclipsecs.target/net.sf.eclipsecs.partial.eclipse.target"/>
 	</locations>

--- a/net.sf.eclipsecs.target/readme.md
+++ b/net.sf.eclipsecs.target/readme.md
@@ -70,6 +70,14 @@ Meanwhile Eclipse PDE and Tycho can also use Maven libraries directly in the tar
 Those libraries are contained in `net.sf.eclipsecs.partial.maven.target`.
 You can open that with a text editor and edit the Maven coordinates like in a `pom.xml`.
 
+### Eclipse license entry
+
+Unfortunately there is a [bug in Eclipse PDE when resolving target files](https://github.com/eclipse-pde/eclipse.pde/issues/558) that contain only nested target files.
+The issue leads to logging a (harmless) exception in the console when launching Eclipse-CS from the IDE.
+This is only relevant for Eclipse-CS developers, not Eclipse-CS users.
+The workaround is to simply add another (not nested) target location in the first position.
+Therefore this target contains a reference to the Eclipse license feature in the target platform.
+That license feature is not used anywhere.
 
 ## Committing changes
 


### PR DESCRIPTION
This is a workaround to avoid the below exception when launching a runtime from the Eclipse IDE. See readme.md for more details. This change does not affect the functionality of the plugin itself at all.

java.nio.file.InvalidPathException: Illegal char <:> at index 4: file:C:\dev\eclipse-cs\git\eclipse-cs\net.sf.eclipsecs.target\net.sf.eclipsecs.partial.maven.target\eclipse.exe
	at java.base/sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
	at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
	at java.base/sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
	at java.base/sun.nio.fs.WindowsPath.parse(WindowsPath.java:92)
	at java.base/sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:229)
	at java.base/java.nio.file.Path.of(Path.java:147)
	at java.base/java.nio.file.Paths.get(Paths.java:69)
	at org.eclipse.urischeme.internal.registration.FileProvider.fileExists(FileProvider.java:56)
	at org.eclipse.urischeme.internal.registration.RegistrationWindows.getLauncherFromLauncherProperty(RegistrationWindows.java:125)
	at org.eclipse.urischeme.internal.registration.RegistrationWindows.getEclipseLauncher(RegistrationWindows.java:103)
	at org.eclipse.urischeme.internal.registration.RegistrationWindows.getSchemesInformation(RegistrationWindows.java:83)
	at org.eclipse.urischeme.AutoRegisterSchemeHandlersJob.run(AutoRegisterSchemeHandlersJob.java:71)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)