### PR TITLE
Issue #492: abort opening more module dialogs after cancel

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
@@ -658,39 +658,46 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
      *
      * @param selection
      *          the selection
+     * @return whether configuration was successful
      */
-    private void newModule(ISelection selection) {
-      if (mConfigurable) {
-        boolean openOnAdd = CheckstyleUIPluginPrefs
-                .getBoolean(CheckstyleUIPluginPrefs.PREF_OPEN_MODULE_EDITOR);
+    private boolean newModule(ISelection selection) {
+      if (!mConfigurable) {
+        return true;
+      }
+      boolean openOnAdd = CheckstyleUIPluginPrefs
+              .getBoolean(CheckstyleUIPluginPrefs.PREF_OPEN_MODULE_EDITOR);
 
-        Iterator<?> iter = ((IStructuredSelection) selection).iterator();
-        while (iter.hasNext()) {
-          Object selectedElement = iter.next();
-          if (selectedElement instanceof RuleGroupMetadata) {
-            // if group is selected add all modules from this group
-            List<RuleMetadata> rules = ((RuleGroupMetadata) selectedElement).getRuleMetadata();
+      Iterator<?> iter = ((IStructuredSelection) selection).iterator();
+      while (iter.hasNext()) {
+        Object selectedElement = iter.next();
+        if (selectedElement instanceof RuleGroupMetadata) {
+          // if group is selected add all modules from this group
+          List<RuleMetadata> rules = ((RuleGroupMetadata) selectedElement).getRuleMetadata();
 
-            IStructuredSelection allRulesOfGroupSelection = new StructuredSelection(rules);
-            newModule(allRulesOfGroupSelection);
-          } else if (selectedElement instanceof RuleMetadata) {
+          IStructuredSelection allRulesOfGroupSelection = new StructuredSelection(rules);
+          if (!newModule(allRulesOfGroupSelection)) {
+            return false;
+          }
+        } else if (selectedElement instanceof RuleMetadata) {
 
-            RuleMetadata metadata = (RuleMetadata) selectedElement;
+          RuleMetadata metadata = (RuleMetadata) selectedElement;
 
-            // check if the module is a singleton and already
-            // configured
-            if (metadata.isSingleton() && isAlreadyConfigured(metadata)) {
-              return;
-            }
+          // check if the module is a singleton and already
+          // configured
+          if (metadata.isSingleton() && isAlreadyConfigured(metadata)) {
+            return true;
+          }
 
-            Module workingCopy = new Module(metadata, false);
+          Module workingCopy = new Module(metadata, false);
 
-            if (openOnAdd) {
+          if (openOnAdd) {
 
-              RuleConfigurationEditDialog dialog = new RuleConfigurationEditDialog(getShell(),
-                      workingCopy, !mConfigurable,
-                      Messages.CheckConfigurationConfigureDialog_titleNewModule);
-              if (mConfigurable && Window.OK == dialog.open()) {
+            RuleConfigurationEditDialog dialog = new RuleConfigurationEditDialog(getShell(),
+                    workingCopy, !mConfigurable,
+                    Messages.CheckConfigurationConfigureDialog_titleNewModule);
+            if (mConfigurable) {
+              int dialogResult = dialog.open();
+              if (Window.OK == dialogResult) {
                 mModules.add(workingCopy);
                 mIsDirty = true;
                 mTableViewer.refresh(true);
@@ -698,17 +705,21 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
                 mTreeViewer.refresh();
                 mTreeViewer.getTree().forceFocus();
               }
-            } else {
-              mModules.add(workingCopy);
-              mIsDirty = true;
-              mTableViewer.refresh(true);
-              refreshTableViewerState();
-              mTreeViewer.refresh();
+              if (Window.CANCEL == dialogResult) {
+                // stop showing more dialogs and also don't add any further rules
+                return false;
+              }
             }
+          } else {
+            mModules.add(workingCopy);
+            mIsDirty = true;
+            mTableViewer.refresh(true);
+            refreshTableViewerState();
+            mTreeViewer.refresh();
           }
         }
       }
-
+      return true;
     }
 
     /**


### PR DESCRIPTION
When adding multiple modules to a configuration, the module configuration dialog is opened for each of them. If the user did that on accident, she had to go through as many dialogs as modules were selected.

With this change after the first cancellation of any dialog, no more dialogs are opened and no more rules are added.

Verified by manual testing. The implementation must use the return value (and not just cancel the iterator) because adding modules is implemented recursively, and we also want to cancel any previous levels of the recursion.