### PR TITLE
remove reexports of checkstyle core library

### DIFF
--- a/net.sf.eclipsecs.checkstyle/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.checkstyle/META-INF/MANIFEST.MF
@@ -7,10 +7,6 @@ Bundle-Vendor: Eclipse Checkstyle Project
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: .,
- com.google.common.base;version="10.5.0",
- com.google.common.cache;version="10.5.0",
- com.google.common.collect;version="10.5.0",
- com.google.common.io;version="10.5.0",
  com.puppycrawl.tools.checkstyle,
  com.puppycrawl.tools.checkstyle.api;
   uses:="org.xml.sax.helpers,
@@ -35,8 +31,7 @@ Export-Package: .,
  com.puppycrawl.tools.checkstyle.checks.whitespace,
  com.puppycrawl.tools.checkstyle.filefilters,
  com.puppycrawl.tools.checkstyle.filters,
- com.puppycrawl.tools.checkstyle.utils,
- org.apache.commons.beanutils;version="10.5.0"
+ com.puppycrawl.tools.checkstyle.utils
 Bundle-ClassPath: .,
  checkstyle-10.5.0-all.jar
 Automatic-Module-Name: net.sf.eclipsecs.checkstyle

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.partial.maven.target
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.partial.maven.target
@@ -43,6 +43,11 @@
 					<artifactId>swtgraphics2d</artifactId>
 					<version>1.1.0</version>
 				</dependency>
+				<dependency>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-lang3</artifactId>
+					<version>3.12.0</version>
+				</dependency>
 			</dependencies>
 		</location>
 	</locations>

--- a/net.sf.eclipsecs.ui/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.ui/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Export-Package: net.sf.eclipsecs.ui,
  net.sf.eclipsecs.ui.properties.filter,
  net.sf.eclipsecs.ui.quickfixes
 Eclipse-BuddyPolicy: registered
-Import-Package: org.eclipse.core.commands,
+Import-Package: org.apache.commons.lang3;version="3.12.0",
+ org.eclipse.core.commands,
  org.eclipse.core.filebuffers,
  org.eclipse.core.resources,
  org.eclipse.core.runtime,

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
@@ -20,8 +20,6 @@
 
 package net.sf.eclipsecs.ui.config;
 
-import com.google.common.base.Strings;
-
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,6 +44,7 @@ import net.sf.eclipsecs.ui.util.table.EnhancedCheckBoxTableViewer;
 import net.sf.eclipsecs.ui.util.table.ITableComparableProvider;
 import net.sf.eclipsecs.ui.util.table.ITableSettingsProvider;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -537,7 +536,7 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
     public void modifyText(ModifyEvent e) {
       mTreeViewer.getControl().setRedraw(false);
       try {
-        if (!Strings.isNullOrEmpty(mTxtTreeFilter.getText())) {
+        if (StringUtils.isNotBlank(mTxtTreeFilter.getText())) {
 
           if (!Arrays.asList(mTableViewer.getFilters()).contains(mTreeFilter)) {
             mTreeViewer.addFilter(mTreeFilter);

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/ResolvablePropertiesDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/ResolvablePropertiesDialog.java
@@ -20,8 +20,6 @@
 
 package net.sf.eclipsecs.ui.config;
 
-import com.google.common.base.Strings;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -38,6 +36,7 @@ import net.sf.eclipsecs.ui.util.table.EnhancedTableViewer;
 import net.sf.eclipsecs.ui.util.table.ITableComparableProvider;
 import net.sf.eclipsecs.ui.util.table.ITableSettingsProvider;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.dialogs.TitleAreaDialog;
@@ -265,7 +264,7 @@ public class ResolvablePropertiesDialog extends TitleAreaDialog {
     // OK'ing
     for (ResolvableProperty prop : mResolvableProperties) {
 
-      if (Strings.emptyToNull(prop.getValue()) == null) {
+      if (StringUtils.isBlank(prop.getValue())) {
         this.setErrorMessage(NLS.bind(Messages.ResolvablePropertiesDialog_msgMissingPropertyValue,
                 prop.getPropertyName()));
         return;

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/ResolvablePropertyEditDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/ResolvablePropertyEditDialog.java
@@ -20,13 +20,12 @@
 
 package net.sf.eclipsecs.ui.config;
 
-import com.google.common.base.Strings;
-
 import net.sf.eclipsecs.core.config.ResolvableProperty;
 import net.sf.eclipsecs.ui.CheckstyleUIPlugin;
 import net.sf.eclipsecs.ui.Messages;
 import net.sf.eclipsecs.ui.util.SWTUtil;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jface.contentassist.SubjectControlContentAssistant;
 import org.eclipse.jface.dialogs.TitleAreaDialog;
 import org.eclipse.jface.text.DefaultInformationControl;
@@ -110,11 +109,11 @@ public class ResolvablePropertyEditDialog extends TitleAreaDialog {
   @Override
   protected void okPressed() {
 
-    if (Strings.emptyToNull(mTxtName.getText()) == null) {
+    if (StringUtils.isBlank(mTxtName.getText())) {
       this.setErrorMessage(Messages.ResolvablePropertyEditDialog_msgMissingName);
       return;
     }
-    if (Strings.emptyToNull(mTxtValue.getText()) == null) {
+    if (StringUtils.isBlank(mTxtValue.getText())) {
       this.setErrorMessage(Messages.ResolvablePropertyEditDialog_msgMissingValue);
       return;
     }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/RuleConfigurationEditDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/RuleConfigurationEditDialog.java
@@ -20,8 +20,6 @@
 
 package net.sf.eclipsecs.ui.config;
 
-import com.google.common.base.Strings;
-
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -43,6 +41,7 @@ import net.sf.eclipsecs.ui.config.widgets.ConfigPropertyWidgetFactory;
 import net.sf.eclipsecs.ui.config.widgets.IConfigPropertyWidget;
 import net.sf.eclipsecs.ui.util.SWTUtil;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.dialogs.TitleAreaDialog;
@@ -226,7 +225,7 @@ public class RuleConfigurationEditDialog extends TitleAreaDialog {
       }
 
       String message = mRule.getCustomMessages().get(msgKey);
-      if (Strings.emptyToNull(message) != null) {
+      if (StringUtils.isNotBlank(message)) {
         msgText.setText(message);
       }
       msgText.setEnabled(!mReadonly);
@@ -405,10 +404,10 @@ public class RuleConfigurationEditDialog extends TitleAreaDialog {
     }
 
     // Get the comment.
-    final  String comment = Strings.emptyToNull(mCommentText.getText());
+    final  String comment = StringUtils.trimToNull(mCommentText.getText());
 
     // Get the id
-    final String id = Strings.emptyToNull(mIdText.getText());
+    final String id = StringUtils.trimToNull(mIdText.getText());
 
     // Get the custom message
     for (Map.Entry<String, Text> entry : mCustomMessages.entrySet()) {
@@ -421,7 +420,7 @@ public class RuleConfigurationEditDialog extends TitleAreaDialog {
         standardMessage = ""; //$NON-NLS-1$
       }
 
-      String message = Strings.emptyToNull(entry.getValue().getText());
+      String message = StringUtils.trimToNull(entry.getValue().getText());
       if (message != null && !message.equals(standardMessage)) {
         mRule.getCustomMessages().put(msgKey, message);
       } else {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ExternalFileConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ExternalFileConfigurationEditor.java
@@ -20,8 +20,6 @@
 
 package net.sf.eclipsecs.ui.config.configtypes;
 
-import com.google.common.base.Strings;
-
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -35,6 +33,7 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
 import net.sf.eclipsecs.ui.Messages;
 import net.sf.eclipsecs.ui.config.CheckConfigurationPropertiesDialog;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
@@ -209,7 +208,7 @@ public class ExternalFileConfigurationEditor implements ICheckConfigurationEdito
     } catch (CheckstylePluginException ex) {
       String location = mLocation.getText();
 
-      if (Strings.emptyToNull(location) != null && ensureFileExists(location)) {
+      if (StringUtils.isNotBlank(location) && ensureFileExists(location)) {
         mWorkingCopy.setLocation(mLocation.getText());
       } else {
         throw ex;

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/InternalConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/InternalConfigurationEditor.java
@@ -20,8 +20,6 @@
 
 package net.sf.eclipsecs.ui.config.configtypes;
 
-import com.google.common.base.Strings;
-
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -39,6 +37,7 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
 import net.sf.eclipsecs.ui.Messages;
 import net.sf.eclipsecs.ui.config.CheckConfigurationPropertiesDialog;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
@@ -197,7 +196,7 @@ public class InternalConfigurationEditor implements ICheckConfigurationEditor {
       try {
         mWorkingCopy.setLocation(location);
       } catch (CheckstylePluginException ex) {
-        if (Strings.emptyToNull(location) != null && ensureFileExists(location)) {
+        if (StringUtils.isNotBlank(location) && ensureFileExists(location)) {
           mWorkingCopy.setLocation(location);
         } else {
           throw ex;

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ProjectConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ProjectConfigurationEditor.java
@@ -20,8 +20,6 @@
 
 package net.sf.eclipsecs.ui.config.configtypes;
 
-import com.google.common.base.Strings;
-
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -38,6 +36,7 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
 import net.sf.eclipsecs.ui.Messages;
 import net.sf.eclipsecs.ui.config.CheckConfigurationPropertiesDialog;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -247,7 +246,7 @@ public class ProjectConfigurationEditor implements ICheckConfigurationEditor {
     } catch (CheckstylePluginException ex) {
       String location = mLocation.getText();
 
-      if (Strings.emptyToNull(location) == null) {
+      if (StringUtils.isBlank(location)) {
         throw ex;
       }
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/RemoteConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/RemoteConfigurationEditor.java
@@ -23,8 +23,6 @@ package net.sf.eclipsecs.ui.config.configtypes;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import com.google.common.base.Strings;
-
 import net.sf.eclipsecs.core.config.CheckConfigurationWorkingCopy;
 import net.sf.eclipsecs.core.config.configtypes.RemoteConfigurationType;
 import net.sf.eclipsecs.core.config.configtypes.RemoteConfigurationType.RemoteConfigAuthenticator;
@@ -33,6 +31,7 @@ import net.sf.eclipsecs.ui.CheckstyleUIPlugin;
 import net.sf.eclipsecs.ui.Messages;
 import net.sf.eclipsecs.ui.config.CheckConfigurationPropertiesDialog;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -217,8 +216,8 @@ public class RemoteConfigurationEditor implements ICheckConfigurationEditor {
 
     // store credentials if necessary
     try {
-      if (Strings.emptyToNull(mUserName.getText()) != null
-              || Strings.emptyToNull(mPassword.getText()) != null) {
+      if (StringUtils.isNotBlank(mUserName.getText())
+              || StringUtils.isNotBlank(mPassword.getText())) {
         RemoteConfigurationType.RemoteConfigAuthenticator.storeCredentials(
                 new URL(mLocation.getText()), mUserName.getText(), mPassword.getText());
       } else {

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/AbstractQuickfixTestCase.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/AbstractQuickfixTestCase.java
@@ -1,7 +1,5 @@
 package net.sf.eclipsecs.ui.quickfixes;
 
-import com.google.common.base.Strings;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -11,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.dom.AST;
@@ -96,7 +95,7 @@ public abstract class AbstractQuickfixTestCase {
       int line = Integer.parseInt(input.getAttribute("fix-line"));
 
       int position = 0;
-      if (!Strings.isNullOrEmpty(input.getAttribute("position"))) {
+      if (StringUtils.isNotBlank(input.getAttribute("position"))) {
         position = Integer.parseInt(input.getAttribute("position"));
       }
 


### PR DESCRIPTION
Before this change eclipse-cs used the Google Guava packages exported by the checkstyle core library, and even reexported them for other bundles. Since those re-exports were using the checkstyle library version, they might lead to version confusion in other bundles importing the same packages (since Guava has completely different version numbers than the checkstyle core library). Also updating the Guava version in the checkstyle library could easily lead to eclipse-cs breaking on next update due to this coupling.

Remove those re-exports from eclipse-cs and make every bundle manage its own package imports instead.

Remove the Guava dependency in eclipsecs.ui. It was only used for Guava Strings, and that can be replaced with the much smaller Apache Commons Lang3, therefore also getting rid of Guava transitive dependencies.

Tested by installing the update site into another IDE and configuring and running everything as normal.