### PR TITLE
Infra: declare all DTDs with checkstyle.org

### DIFF
--- a/docs/dtds/checkstyle-metadata_1_0.dtd
+++ b/docs/dtds/checkstyle-metadata_1_0.dtd
@@ -4,7 +4,7 @@
 
 <!DOCTYPE checkstyle-metadata PUBLIC
     "-//eclipse-cs//DTD Check Metadata 1.0//EN"
-    "http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_0.dtd">
+    "https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_0.dtd">
 -->
 
 <!--

--- a/docs/dtds/checkstyle-metadata_1_1.dtd
+++ b/docs/dtds/checkstyle-metadata_1_1.dtd
@@ -4,7 +4,7 @@
 
 <!DOCTYPE checkstyle-metadata PUBLIC
     "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-    "http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+    "https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 -->
 
 <!--

--- a/docs/partials/custom-checks.html
+++ b/docs/partials/custom-checks.html
@@ -47,12 +47,12 @@
                 <strong> In order to let the plug-in find your metadata you need to declare the package within your
                         <code>checkstyle_packages.xml</code> file (see point 2). </strong>
                 <br/> The metadata file must adhere to this dtd: <a target="_blank"
-                    href="http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd"
-                    >http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd</a> . <br/> So it would be a
+                    href="https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd"
+                    >https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd</a> . <br/> So it would be a
                 good idea to include this document type declaration to your metadata file: </p>
             <pre><code>&lt;!DOCTYPE checkstyle-metadata
     PUBLIC &quot;-//eclipse-cs//DTD Check Metadata 1.1//EN&quot;
-    &quot;http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd&quot;&gt;</code></pre>
+    &quot;https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd&quot;&gt;</code></pre>
             <p>This way you can validate your metadata file against the dtd using your preferred XML editor.</p>
             <p> The dtd file itself contains an abundance of documentation on the tags and their attributes, further
                 further practical reference you may want to peek into the <code>net.sf.eclipsecs.checkstyle</code>

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/annotation/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/annotation/checkstyle-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE checkstyle-metadata PUBLIC
 "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-"http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+"https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 <checkstyle-metadata>
     <rule-group-metadata name="%Annotation.group" priority="100">
     </rule-group-metadata>

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/blocks/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/blocks/checkstyle-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE checkstyle-metadata PUBLIC
 "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-"http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+"https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 <checkstyle-metadata>
     <rule-group-metadata name="%Blocks.group" priority="800">
     </rule-group-metadata>

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/checkstyle-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE checkstyle-metadata PUBLIC
 "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-"http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+"https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 <checkstyle-metadata>
     <rule-group-metadata name="%Miscellaneous.group" priority="1300">
     </rule-group-metadata>

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/coding/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/coding/checkstyle-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE checkstyle-metadata PUBLIC
 "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-"http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+"https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 <checkstyle-metadata>
     <rule-group-metadata name="%Coding.group" priority="900">
     </rule-group-metadata>

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/design/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/design/checkstyle-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE checkstyle-metadata PUBLIC
 "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-"http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+"https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 <checkstyle-metadata>
     <rule-group-metadata name="%Design.group" priority="1000">
     </rule-group-metadata>

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/header/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/header/checkstyle-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE checkstyle-metadata PUBLIC
 "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-"http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+"https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 <checkstyle-metadata>
     <rule-group-metadata name="%Headers.group" priority="300">
     </rule-group-metadata>

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/imports/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/imports/checkstyle-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE checkstyle-metadata PUBLIC
 "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-"http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+"https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 <checkstyle-metadata>
     <rule-group-metadata name="%Imports.group" priority="400">
     </rule-group-metadata>

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/indentation/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/indentation/checkstyle-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE checkstyle-metadata PUBLIC
 "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-"http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+"https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 <checkstyle-metadata>
     <rule-group-metadata name="%Indentation.group" priority="500">
     </rule-group-metadata>

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/javadoc/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/javadoc/checkstyle-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE checkstyle-metadata PUBLIC
 "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-"http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+"https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 <checkstyle-metadata>
     <rule-group-metadata name="%Javadoc.group" priority="100">
     </rule-group-metadata>

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/metrics/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/metrics/checkstyle-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE checkstyle-metadata PUBLIC
 "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-"http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+"https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 <checkstyle-metadata>
     <rule-group-metadata name="%Metrics.group" priority="1200">
     </rule-group-metadata>

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/modifier/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/modifier/checkstyle-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE checkstyle-metadata PUBLIC
 "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-"http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+"https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 <checkstyle-metadata>
     <rule-group-metadata name="%Modifiers.group" priority="700">
     </rule-group-metadata>

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/naming/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/naming/checkstyle-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE checkstyle-metadata PUBLIC
 "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-"http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+"https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 <checkstyle-metadata>
     <rule-group-metadata name="%Naming.group" priority="200">
     </rule-group-metadata>

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/regexp/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/regexp/checkstyle-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE checkstyle-metadata PUBLIC
 "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-"http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+"https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 <checkstyle-metadata>
     <rule-group-metadata name="%Regexp.group" priority="650">
     </rule-group-metadata>

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/sizes/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/sizes/checkstyle-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE checkstyle-metadata PUBLIC
 "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-"http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+"https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 <checkstyle-metadata>
     <rule-group-metadata name="%Sizes.group" priority="500">
     </rule-group-metadata>

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/whitespace/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checks/whitespace/checkstyle-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE checkstyle-metadata PUBLIC
 "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-"http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+"https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 <checkstyle-metadata>
     <rule-group-metadata name="%Whitespace.group" priority="600">
     </rule-group-metadata>

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checkstyle-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE checkstyle-metadata PUBLIC
 "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-"http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+"https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 <checkstyle-metadata>
     <rule-group-metadata name="%Other.group" priority="1500">
 

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checkstyle-metadata_1_0.dtd
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checkstyle-metadata_1_0.dtd
@@ -4,7 +4,7 @@
 
 <!DOCTYPE checkstyle-metadata PUBLIC
     "-//eclipse-cs//DTD Check Metadata 1.0//EN"
-    "http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_0.dtd">
+    "https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_0.dtd">
 -->
 
 <!--

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checkstyle-metadata_1_1.dtd
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/checkstyle-metadata_1_1.dtd
@@ -4,7 +4,7 @@
 
 <!DOCTYPE checkstyle-metadata PUBLIC
     "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-    "http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+    "https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 -->
 
 <!--

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/filefilters/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/filefilters/checkstyle-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE checkstyle-metadata PUBLIC
 "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-"http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+"https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 <checkstyle-metadata>
     <rule-group-metadata name="%FileFilters.group" priority="1700">
     </rule-group-metadata>

--- a/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/filters/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.checkstyle/metadata/com/puppycrawl/tools/checkstyle/filters/checkstyle-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE checkstyle-metadata PUBLIC
 "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-"http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+"https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 <checkstyle-metadata>
     <rule-group-metadata name="%Filters.group" priority="1700">
     </rule-group-metadata>

--- a/net.sf.eclipsecs.doc/src/main/resources/dtds/checkstyle-metadata_1_0.dtd
+++ b/net.sf.eclipsecs.doc/src/main/resources/dtds/checkstyle-metadata_1_0.dtd
@@ -4,7 +4,7 @@
 
 <!DOCTYPE checkstyle-metadata PUBLIC
     "-//eclipse-cs//DTD Check Metadata 1.0//EN"
-    "http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_0.dtd">
+    "https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_0.dtd">
 -->
 
 <!--

--- a/net.sf.eclipsecs.doc/src/main/resources/dtds/checkstyle-metadata_1_1.dtd
+++ b/net.sf.eclipsecs.doc/src/main/resources/dtds/checkstyle-metadata_1_1.dtd
@@ -4,7 +4,7 @@
 
 <!DOCTYPE checkstyle-metadata PUBLIC
     "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-    "http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+    "https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 -->
 
 <!--

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/custom-checks.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/custom-checks.html
@@ -47,12 +47,12 @@
                 <strong> In order to let the plug-in find your metadata you need to declare the package within your
                         <code>checkstyle_packages.xml</code> file (see point 2). </strong>
                 <br/> The metadata file must adhere to this dtd: <a target="_blank"
-                    href="http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd"
-                    >http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd</a> . <br/> So it would be a
+                    href="https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd"
+                    >https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd</a> . <br/> So it would be a
                 good idea to include this document type declaration to your metadata file: </p>
             <pre><code>&lt;!DOCTYPE checkstyle-metadata
     PUBLIC &quot;-//eclipse-cs//DTD Check Metadata 1.1//EN&quot;
-    &quot;http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd&quot;&gt;</code></pre>
+    &quot;https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd&quot;&gt;</code></pre>
             <p>This way you can validate your metadata file against the dtd using your preferred XML editor.</p>
             <p> The dtd file itself contains an abundance of documentation on the tags and their attributes, further
                 further practical reference you may want to peek into the <code>net.sf.eclipsecs.checkstyle</code>

--- a/net.sf.eclipsecs.sample/src/net/sf/eclipsecs/sample/checks/checkstyle-metadata.xml
+++ b/net.sf.eclipsecs.sample/src/net/sf/eclipsecs/sample/checks/checkstyle-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE checkstyle-metadata PUBLIC
 "-//eclipse-cs//DTD Check Metadata 1.1//EN"
-"http://eclipse-cs.sourceforge.net/dtds/checkstyle-metadata_1_1.dtd">
+"https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd">
 <checkstyle-metadata>
     <rule-group-metadata name="My custom checks"  priority="1600">
         <description>%MyCustomChecks.desc</description>


### PR DESCRIPTION
Let all DTDs point to the current host instead of the old sourceforge host.

Verified download from a changed URL works as before.