### PR TITLE
Infra: re-enable tycho jgit timestamp provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,11 +211,13 @@
                     <artifactId>tycho-packaging-plugin</artifactId>
                     <version>${tycho-version}</version>
                     <dependencies>
+                        <!-- generate timestamps from last git change of any file in this module -->
                         <dependency>
                             <groupId>org.eclipse.tycho.extras</groupId>
                             <artifactId>tycho-buildtimestamp-jgit</artifactId>
                             <version>${tycho-version}</version>
                         </dependency>
+                        <!-- automatically add a source references header to the manifest -->
                         <dependency>
                             <groupId>org.eclipse.tycho.extras</groupId>
                             <artifactId>tycho-sourceref-jgit</artifactId>
@@ -223,10 +225,7 @@
                         </dependency>
                     </dependencies>
                     <configuration>
-                        <!-- <timestampProvider>jgit</timestampProvider> -->
-                        <jgit.ignore>
-                            pom.xml
-                        </jgit.ignore>
+                        <timestampProvider>jgit</timestampProvider>
                         <jgit.dirtyWorkingTree>ignore</jgit.dirtyWorkingTree>
                         <sourceReferences>
                             <generate>true</generate>


### PR DESCRIPTION
The Tycho JGit timestamp provider calculates the timestamp based on the last change of any file in the module. It's therefore okay to be different for different child modules, so it was wrong to disable it in the first place.

The benefit of this timestamp provider is that it leads to the exact same version number each time we re-build the same commit (since that commit defines the timestamp). Without this, rebuilding the same commit leads to the _current_ timestamp (build time) being used, leading to different file names for the same commit.

See https://wiki.eclipse.org/Tycho/Reproducible_Version_Qualifiers for more details.

Tested via local maven build.