### PR TITLE
Infra: make documentation timestamp reproducible

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -4,20 +4,13 @@ set -e
 case $1 in
 
 git-diff)
-  printf "Changes to only docs/sitemap.xml:\n"
-  git diff docs/sitemap.xml
-
-  # file below is always modified on a run and updated with the current date
-  # such a change is ignored and must be verified manually instead
-  git checkout HEAD -- docs/sitemap.xml
-
   if [ "$(git status | grep 'Changes not staged\|Untracked files')" ]; then
     printf "Please clean up.\nGit status output:\n"
     printf "Top 300 lines of diff:\n"
     git status
     git diff | head -n 300
     false
-  fi 
+  fi
   ;;
 
 *)

--- a/docs/partials/index.html
+++ b/docs/partials/index.html
@@ -24,7 +24,7 @@
                     <small>
                         <sup>1 </sup>
                         Install via Eclipse Marketplace. Drag and drop this link into a running Eclipse
-                        (2020-09 or higher version) workspace. Latest release 10.6.0, based on Checkstyle 10.6, see
+                        (2020-09 or higher version) workspace. Latest release 10.6.0, based on Checkstyle 10.6.0, see
                         <a href="#!/releasenotes">release notes</a>
                     </small>
                 </div>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -4,85 +4,88 @@
             http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
   <!--
     The sitemap is used by the search indexers (google etc) to discover subpages
-    and check whether they have changed and need reindexing.
-    Since the eclipse-cs website are not static webpages but dynamically rendered in the browser
-    the indexers need a bit of help.
-    So effectively if you remove timestamps or keep them static,
-    indexers would think content hasn't changed.
+    and check whether they have changed and need reindexing. The indexers need a
+    bit of help because the eclipse-cs website doesn't contain static webpages,
+    but is dynamically rendered in the browser instead.
+    So effectively if you remove timestamps or keep them static, indexers would
+    think content hasn't changed.
+
+    The doctimestamp variable is replaced during maven resource-copy in the docs
+    project, and takes the last git timestamp of any change in the docs project.
   -->
   <url>
     <loc>https://checkstyle.org/eclipse-cs/</loc>
-    <lastmod>2023-04-08T00:49:40Z</lastmod>
+    <lastmod>2023-04-08</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/releasenotes</loc>
-    <lastmod>2023-04-08T00:49:40Z</lastmod>
+    <lastmod>2023-04-08</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/install</loc>
-    <lastmod>2023-04-08T00:49:40Z</lastmod>
+    <lastmod>2023-04-08</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/project-setup</loc>
-    <lastmod>2023-04-08T00:49:40Z</lastmod>
+    <lastmod>2023-04-08</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/custom-config</loc>
-    <lastmod>2023-04-08T00:49:40Z</lastmod>
+    <lastmod>2023-04-08</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/filters</loc>
-    <lastmod>2023-04-08T00:49:40Z</lastmod>
+    <lastmod>2023-04-08</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/configtypes</loc>
-    <lastmod>2023-04-08T00:49:40Z</lastmod>
+    <lastmod>2023-04-08</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/properties</loc>
-    <lastmod>2023-04-08T00:49:40Z</lastmod>
+    <lastmod>2023-04-08</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/filesets</loc>
-    <lastmod>2023-04-08T00:49:40Z</lastmod>
+    <lastmod>2023-04-08</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/preferences</loc>
-    <lastmod>2023-04-08T00:49:40Z</lastmod>
+    <lastmod>2023-04-08</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/extensions</loc>
-    <lastmod>2023-04-08T00:49:40Z</lastmod>
+    <lastmod>2023-04-08</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/custom-checks</loc>
-    <lastmod>2023-04-08T00:49:40Z</lastmod>
+    <lastmod>2023-04-08</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/builtin-config</loc>
-    <lastmod>2023-04-08T00:49:40Z</lastmod>
+    <lastmod>2023-04-08</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/custom-filters</loc>
-    <lastmod>2023-04-08T00:49:40Z</lastmod>
+    <lastmod>2023-04-08</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/faq</loc>
-    <lastmod>2023-04-08T00:49:40Z</lastmod>
+    <lastmod>2023-04-08</lastmod>
     <changefreq>weekly</changefreq>
   </url>
 </urlset>

--- a/net.sf.eclipsecs.doc/pom.xml
+++ b/net.sf.eclipsecs.doc/pom.xml
@@ -9,11 +9,31 @@
     <artifactId>net.sf.eclipsecs.doc</artifactId>
     <packaging>eclipse-plugin</packaging>
     <name>eclipse-cs Documentation Plugin</name>
-    <properties>
-        <timestamp>${maven.build.timestamp}</timestamp>
-    </properties>
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>calculate-website-timestamp</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <exec outputproperty="doctimestamp" executable="git">
+                                    <arg value="log"/>
+                                    <arg value="-1"/>
+                                    <arg value="--pretty=format:%cs"/>
+                                    <arg value="."/>
+                                </exec>
+                            </target>
+                            <exportAntProperties>true</exportAntProperties>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
                 <version>3.2.0</version>
@@ -60,7 +80,7 @@
                                 </resource>
                                 <resource>
                                     <directory>src/main/resources</directory>
-                                    <!-- Copy all the rest except update site files (see above) -->
+                                    <!-- Copy remaining except update site files (see above) -->
                                     <includes>
                                         <include>**/*</include>
                                     </includes>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/index.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/index.html
@@ -24,7 +24,7 @@
                     <small>
                         <sup>1 </sup>
                         Install via Eclipse Marketplace. Drag and drop this link into a running Eclipse
-                        (2020-09 or higher version) workspace. Latest release 10.6.0, based on Checkstyle 10.6, see
+                        (2020-09 or higher version) workspace. Latest release 10.6.0, based on Checkstyle 10.6.0, see
                         <a href="#!/releasenotes">release notes</a>
                     </small>
                 </div>

--- a/net.sf.eclipsecs.doc/src/main/resources/sitemap.xml
+++ b/net.sf.eclipsecs.doc/src/main/resources/sitemap.xml
@@ -4,85 +4,88 @@
             http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
   <!--
     The sitemap is used by the search indexers (google etc) to discover subpages
-    and check whether they have changed and need reindexing.
-    Since the eclipse-cs website are not static webpages but dynamically rendered in the browser
-    the indexers need a bit of help.
-    So effectively if you remove timestamps or keep them static,
-    indexers would think content hasn't changed.
+    and check whether they have changed and need reindexing. The indexers need a
+    bit of help because the eclipse-cs website doesn't contain static webpages,
+    but is dynamically rendered in the browser instead.
+    So effectively if you remove timestamps or keep them static, indexers would
+    think content hasn't changed.
+
+    The doctimestamp variable is replaced during maven resource-copy in the docs
+    project, and takes the last git timestamp of any change in the docs project.
   -->
   <url>
     <loc>https://checkstyle.org/eclipse-cs/</loc>
-    <lastmod>${timestamp}</lastmod>
+    <lastmod>${doctimestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/releasenotes</loc>
-    <lastmod>${timestamp}</lastmod>
+    <lastmod>${doctimestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/install</loc>
-    <lastmod>${timestamp}</lastmod>
+    <lastmod>${doctimestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/project-setup</loc>
-    <lastmod>${timestamp}</lastmod>
+    <lastmod>${doctimestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/custom-config</loc>
-    <lastmod>${timestamp}</lastmod>
+    <lastmod>${doctimestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/filters</loc>
-    <lastmod>${timestamp}</lastmod>
+    <lastmod>${doctimestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/configtypes</loc>
-    <lastmod>${timestamp}</lastmod>
+    <lastmod>${doctimestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/properties</loc>
-    <lastmod>${timestamp}</lastmod>
+    <lastmod>${doctimestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/filesets</loc>
-    <lastmod>${timestamp}</lastmod>
+    <lastmod>${doctimestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/preferences</loc>
-    <lastmod>${timestamp}</lastmod>
+    <lastmod>${doctimestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/extensions</loc>
-    <lastmod>${timestamp}</lastmod>
+    <lastmod>${doctimestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/custom-checks</loc>
-    <lastmod>${timestamp}</lastmod>
+    <lastmod>${doctimestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/builtin-config</loc>
-    <lastmod>${timestamp}</lastmod>
+    <lastmod>${doctimestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/custom-filters</loc>
-    <lastmod>${timestamp}</lastmod>
+    <lastmod>${doctimestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/faq</loc>
-    <lastmod>${timestamp}</lastmod>
+    <lastmod>${doctimestamp}</lastmod>
     <changefreq>weekly</changefreq>
   </url>
 </urlset>

--- a/pom.xml
+++ b/pom.xml
@@ -387,6 +387,19 @@
                                         <ignore></ignore>
                                     </action>
                                 </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-antrun-plugin</artifactId>
+                                        <versionRange>[1.0,)</versionRange>
+                                        <goals>
+                                            <goal>clean</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
                             </pluginExecutions>
                         </lifecycleMappingMetadata>
                     </configuration>


### PR DESCRIPTION
Instead of adding the current time into the documentation sitemap, use the last change in any file of the docs project. Also use only the date part of the timestamp, not the full second resolution timestamp (using only the date is a valid W3C date format, which is used in sitemaps). That trick avoids vicious circle between committing documentation changes, updating the sitemap, amending to the last commit, updating the sitemap again etc.

That way rebuilding with maven from an existing git commit will no longer lead to unwanted changes in general.

@Calixte @rnveach When this has been merged and you see a locally modified sitemap.xml appearing in the future, then you should commit it, and no longer ignore/replace it, because then there have been changes in the documentation.