### PR TITLE
Have hyperlinks in preference page title

### DIFF
--- a/net.sf.eclipsecs.ui/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.ui/META-INF/MANIFEST.MF
@@ -7,7 +7,9 @@ Bundle-Vendor: Eclipse Checkstyle Project
 Bundle-Activator: net.sf.eclipsecs.ui.CheckstyleUIPlugin
 Bundle-ActivationPolicy: lazy
 Require-Bundle: net.sf.eclipsecs.core,
- org.eclipse.core.expressions
+ org.eclipse.core.expressions,
+ org.eclipse.ui.workbench,
+ org.eclipse.jface
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Localization: plugin
 Export-Package: net.sf.eclipsecs.ui,


### PR DESCRIPTION
Make the project name and version number clickable hyperlinks. They open the homepage respectively release notes, using the default browser settings of Eclipse.

![grafik](https://user-images.githubusercontent.com/406876/230656728-4d0f00fe-0e96-4c4a-a11c-e41dff5eac45.png)

For reviewers: It depends on your Eclipse preferences whether this opens in an internal browser in an editor tab or in an external browser as separate process.