### PR TITLE
Infra: Filter derived files from own checks

### DIFF
--- a/net.sf.eclipsecs-updatesite/.checkstyle
+++ b/net.sf.eclipsecs-updatesite/.checkstyle
@@ -14,4 +14,5 @@
   <fileset name="all" enabled="true" check-config-name="Eclipse CS configuration" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
   </fileset>
+  <filter name="DerivedFiles" enabled="true"/>
 </fileset-config>

--- a/net.sf.eclipsecs.branding/.checkstyle
+++ b/net.sf.eclipsecs.branding/.checkstyle
@@ -14,4 +14,5 @@
   <fileset name="all" enabled="true" check-config-name="Eclipse CS configuration" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
   </fileset>
+  <filter name="DerivedFiles" enabled="true"/>
 </fileset-config>

--- a/net.sf.eclipsecs.checkstyle/.checkstyle
+++ b/net.sf.eclipsecs.checkstyle/.checkstyle
@@ -14,4 +14,5 @@
   <fileset name="all" enabled="true" check-config-name="Eclipse CS configuration" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
   </fileset>
+  <filter name="DerivedFiles" enabled="true"/>
 </fileset-config>

--- a/net.sf.eclipsecs.core/.checkstyle
+++ b/net.sf.eclipsecs.core/.checkstyle
@@ -14,4 +14,5 @@
   <fileset name="all" enabled="true" check-config-name="Eclipse CS configuration" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
   </fileset>
+  <filter name="DerivedFiles" enabled="true"/>
 </fileset-config>

--- a/net.sf.eclipsecs.doc/.checkstyle
+++ b/net.sf.eclipsecs.doc/.checkstyle
@@ -14,4 +14,5 @@
   <fileset name="all" enabled="true" check-config-name="Eclipse CS configuration" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
   </fileset>
+  <filter name="DerivedFiles" enabled="true"/>
 </fileset-config>

--- a/net.sf.eclipsecs.sample/.checkstyle
+++ b/net.sf.eclipsecs.sample/.checkstyle
@@ -14,4 +14,5 @@
   <fileset name="all" enabled="true" check-config-name="Eclipse CS configuration" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
   </fileset>
+  <filter name="DerivedFiles" enabled="true"/>
 </fileset-config>

--- a/net.sf.eclipsecs.ui/.checkstyle
+++ b/net.sf.eclipsecs.ui/.checkstyle
@@ -14,4 +14,5 @@
   <fileset name="all" enabled="true" check-config-name="Eclipse CS configuration" local="true">
     <file-match-pattern match-pattern="." include-pattern="true"/>
   </fileset>
+  <filter name="DerivedFiles" enabled="true"/>
 </fileset-config>


### PR DESCRIPTION
I just had some derived files (in the Eclipse bin directory) showing checkstyle issues. That's not useful, therefore enable the derived files filter for all projects.