### PR TITLE
Issue #506: Available languages must be hard-coded

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/Messages.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/Messages.java
@@ -176,8 +176,6 @@ public final class Messages extends NLS {
 
   public static String CheckstylePreferencePage_lblLocaleLanguage;
 
-  public static String CheckstylePreferencePage_lblLocaleLanguages;
-
   public static String CheckstylePreferencePage_version;
 
   public static String CheckstylePropertyPage_btnActivateCheckstyle;

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/messages.properties
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/messages.properties
@@ -62,7 +62,6 @@ CheckstylePreferencePage_lblIncludeModuleIds=Include module id (if available) in
 CheckstylePreferencePage_lblIncludeRulenames = Include rule names in violation messages
 CheckstylePreferencePage_lblLimitMarker = Limit Checkstyle markers per resource to
 CheckstylePreferencePage_lblLocaleLanguage= Rule message language
-CheckstylePreferencePage_lblLocaleLanguages= default,de,en,es,fi,fr,ja,pt,tr,zh
 CheckstylePreferencePage_lblProjectUsage = Used in projects:
 CheckstylePreferencePage_lblRebuild = Rebuild projects if needed:
 CheckstylePreferencePage_lblWarnFilesets = Warn before losing configured file sets


### PR DESCRIPTION
Don't have the language list in the properties, but rather in code. Also add a localized version of the language name to the dropdown list.

![grafik](https://user-images.githubusercontent.com/406876/230771764-e8bad649-e4a6-4cca-a6e5-f722b38e12e8.png)
