### PR TITLE
Fix rendering of inline code tags

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
@@ -101,6 +101,8 @@ import org.osgi.service.prefs.BackingStoreException;
  */
 public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
 
+  private static final Pattern PATTERN_INLINE_CODE = Pattern.compile(Pattern.quote("{@code ") + "([^}]*?)" + Pattern.quote("}"));
+
   /** The current check configuration. */
   private final CheckConfigurationWorkingCopy mConfiguration;
 
@@ -469,10 +471,14 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
     StringBuilder buf = new StringBuilder();
     buf.append("<html><body style=\"margin: 3px; font-size: 11px; ");
     buf.append("font-family: verdana, 'trebuchet MS', helvetica, sans-serif;\">");
-    buf.append(description != null ? description
+    buf.append(description != null ? convertInlineCodeTags(description)
             : Messages.CheckConfigurationConfigureDialog_txtNoDescription);
     buf.append("</body></html>");
     return buf.toString();
+  }
+
+  private static String convertInlineCodeTags(String html) {
+    return PATTERN_INLINE_CODE.matcher(html).replaceAll("<code>$1</code>");
   }
 
   /**


### PR DESCRIPTION
Rule descriptions with inline code tags (from Javadoc) rendered those tags verbatim. Replace them by HTML code tags for correct rendering.

before:
![grafik](https://user-images.githubusercontent.com/406876/230790199-19a275e2-c55d-4d13-96cc-eace9df45c08.png)

after:
![grafik](https://user-images.githubusercontent.com/406876/230790191-5d4f4165-62f5-498f-84cb-425caf9fee9c.png)
