### PR TITLE
Issue #510: Open description hyperlinks in external browser

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
@@ -39,6 +39,7 @@ import net.sf.eclipsecs.ui.CheckstyleUIPlugin;
 import net.sf.eclipsecs.ui.CheckstyleUIPluginImages;
 import net.sf.eclipsecs.ui.CheckstyleUIPluginPrefs;
 import net.sf.eclipsecs.ui.Messages;
+import net.sf.eclipsecs.ui.util.InternalBrowser;
 import net.sf.eclipsecs.ui.util.SWTUtil;
 import net.sf.eclipsecs.ui.util.table.EnhancedCheckBoxTableViewer;
 import net.sf.eclipsecs.ui.util.table.ITableComparableProvider;
@@ -73,6 +74,8 @@ import org.eclipse.jface.window.Window;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
+import org.eclipse.swt.browser.LocationAdapter;
+import org.eclipse.swt.browser.LocationEvent;
 import org.eclipse.swt.custom.SashForm;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.KeyListener;
@@ -213,6 +216,17 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
     gridData = new GridData(GridData.FILL_BOTH);
     gridData.heightHint = 100;
     mBrowserDescription.setLayoutData(gridData);
+    mBrowserDescription.addLocationListener(new LocationAdapter() {
+      @Override
+      public void changing(LocationEvent event) {
+        String url = event.location;
+        if (url == null || !url.startsWith("http")) {
+          return;
+        }
+        InternalBrowser.openLinkInExternalBrowser(url);
+        event.doit = false;
+      }
+    });
 
     // initialize the data
     initialize();

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/preferences/CheckstylePreferencePage.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/preferences/CheckstylePreferencePage.java
@@ -20,8 +20,6 @@
 
 package net.sf.eclipsecs.ui.preferences;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Collection;
 
 import org.eclipse.core.resources.IProject;
@@ -49,9 +47,6 @@ import org.eclipse.swt.widgets.Link;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
-import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.browser.IWebBrowser;
 import org.osgi.service.prefs.BackingStoreException;
 
 import com.puppycrawl.tools.checkstyle.Main;
@@ -61,13 +56,13 @@ import net.sf.eclipsecs.core.builder.CheckerFactory;
 import net.sf.eclipsecs.core.builder.CheckstyleBuilder;
 import net.sf.eclipsecs.core.config.CheckConfigurationFactory;
 import net.sf.eclipsecs.core.config.ICheckConfigurationWorkingSet;
-import net.sf.eclipsecs.core.util.CheckstyleLog;
 import net.sf.eclipsecs.core.util.CheckstylePluginException;
 import net.sf.eclipsecs.ui.CheckstyleUIPlugin;
 import net.sf.eclipsecs.ui.CheckstyleUIPluginImages;
 import net.sf.eclipsecs.ui.CheckstyleUIPluginPrefs;
 import net.sf.eclipsecs.ui.Messages;
 import net.sf.eclipsecs.ui.config.CheckConfigurationWorkingSetEditor;
+import net.sf.eclipsecs.ui.util.InternalBrowser;
 import net.sf.eclipsecs.ui.util.SWTUtil;
 
 /**
@@ -176,12 +171,7 @@ public class CheckstylePreferencePage extends PreferencePage implements IWorkben
     if (Character.isDigit(event.text.charAt(0))) {
       url = url + "/releasenotes.html#Release_" + getCheckstyleVersion();
     }
-    try {
-      final IWebBrowser browser = PlatformUI.getWorkbench().getBrowserSupport().createBrowser(null);
-      browser.openURL(new URL(url));
-    } catch (PartInitException | MalformedURLException ex) {
-      CheckstyleLog.log(ex);
-    }
+    InternalBrowser.openLinkInExternalBrowser(url);
   }
 
   /**

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/InternalBrowser.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/InternalBrowser.java
@@ -1,0 +1,53 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+//============================================================================
+
+package net.sf.eclipsecs.ui.util;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.browser.IWebBrowser;
+import org.eclipse.ui.browser.IWorkbenchBrowserSupport;
+
+import net.sf.eclipsecs.core.util.CheckstyleLog;
+
+/**
+ * Wrapper of the Eclipse internal browser.
+ */
+public final class InternalBrowser {
+
+  private InternalBrowser() {
+    // utility class
+  }
+
+  /**
+   * Open a link in an external browser, independent of the Eclipse browser settings.
+   */
+  public static final void openLinkInExternalBrowser(String url) {
+    try {
+      final IWebBrowser browser = PlatformUI.getWorkbench().getBrowserSupport().createBrowser(IWorkbenchBrowserSupport.AS_EXTERNAL, null, null, null);
+      browser.openURL(new URL(url));
+    } catch (PartInitException | MalformedURLException ex) {
+      CheckstyleLog.log(ex);
+    }
+  }
+}


### PR DESCRIPTION
Also change the new hyperlinks in the preference page to always use the external browser, because people might not even notice the browser tab _behind_ the preference dialog.

Tested from runtime, opens browser in external process now.