### PR TITLE
Issue #512: Focus config name of internal config editor

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/InternalConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/InternalConfigurationEditor.java
@@ -110,6 +110,7 @@ public class InternalConfigurationEditor implements ICheckConfigurationEditor {
     mConfigName = new Text(contents, SWT.LEFT | SWT.SINGLE | SWT.BORDER);
     gridData = new GridData(GridData.FILL_HORIZONTAL);
     mConfigName.setLayoutData(gridData);
+    mConfigName.setFocus();
 
     Label lblConfigLocation = new Label(contents, SWT.NULL);
     lblConfigLocation.setText(Messages.CheckConfigurationPropertiesDialog_lblLocation);


### PR DESCRIPTION
Was missing only in 1 of 5 implementation classes.

![grafik](https://user-images.githubusercontent.com/406876/231285385-66e3f5bb-18fa-459b-9ef0-fd898463ffc0.png)
