### PR TITLE
Infra: more strict/reproducible Maven builds

### DIFF
--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -15,77 +15,77 @@
   -->
   <url>
     <loc>https://checkstyle.org/eclipse-cs/</loc>
-    <lastmod>2023-04-15</lastmod>
+    <lastmod>2023-04-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/releasenotes</loc>
-    <lastmod>2023-04-15</lastmod>
+    <lastmod>2023-04-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/install</loc>
-    <lastmod>2023-04-15</lastmod>
+    <lastmod>2023-04-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/project-setup</loc>
-    <lastmod>2023-04-15</lastmod>
+    <lastmod>2023-04-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/custom-config</loc>
-    <lastmod>2023-04-15</lastmod>
+    <lastmod>2023-04-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/filters</loc>
-    <lastmod>2023-04-15</lastmod>
+    <lastmod>2023-04-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/configtypes</loc>
-    <lastmod>2023-04-15</lastmod>
+    <lastmod>2023-04-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/properties</loc>
-    <lastmod>2023-04-15</lastmod>
+    <lastmod>2023-04-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/filesets</loc>
-    <lastmod>2023-04-15</lastmod>
+    <lastmod>2023-04-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/preferences</loc>
-    <lastmod>2023-04-15</lastmod>
+    <lastmod>2023-04-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/extensions</loc>
-    <lastmod>2023-04-15</lastmod>
+    <lastmod>2023-04-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/custom-checks</loc>
-    <lastmod>2023-04-15</lastmod>
+    <lastmod>2023-04-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/builtin-config</loc>
-    <lastmod>2023-04-15</lastmod>
+    <lastmod>2023-04-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/custom-filters</loc>
-    <lastmod>2023-04-15</lastmod>
+    <lastmod>2023-04-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://checkstyle.org/eclipse-cs/#!/faq</loc>
-    <lastmod>2023-04-15</lastmod>
+    <lastmod>2023-04-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
 </urlset>

--- a/net.sf.eclipsecs-updatesite/pom.xml
+++ b/net.sf.eclipsecs-updatesite/pom.xml
@@ -132,7 +132,6 @@
                     <plugin>
                         <groupId>org.eclipse.tycho.extras</groupId>
                         <artifactId>tycho-eclipserun-plugin</artifactId>
-                        <version>${tycho-version}</version>
                         <configuration>
                             <repositories>
                                 <repository>

--- a/net.sf.eclipsecs.doc/pom.xml
+++ b/net.sf.eclipsecs.doc/pom.xml
@@ -120,36 +120,5 @@
                 </executions>
             </plugin>
         </plugins>
-
-        <pluginManagement>
-            <plugins>
-                <!-- Exclude the "copy-resources" goal from m2e execution, as it interferes with resource filtering
-                (i.e. ${buildQualifier} in update site resources is not properly expanded).-->
-                <plugin>
-                    <groupId>org.eclipse.m2e</groupId>
-                    <artifactId>lifecycle-mapping</artifactId>
-                    <version>1.0.0</version>
-                    <configuration>
-                        <lifecycleMappingMetadata>
-                            <pluginExecutions>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.apache.maven.plugins</groupId>
-                                        <artifactId>maven-resources-plugin</artifactId>
-                                        <versionRange>[1.0.0,)</versionRange>
-                                        <goals>
-                                            <goal>copy-resources</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore />
-                                    </action>
-                                </pluginExecution>
-                            </pluginExecutions>
-                        </lifecycleMappingMetadata>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -207,9 +207,53 @@
                     <version>3.1.0</version>
                 </plugin>
                 <plugin>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.22.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.12.0</version>
+                </plugin>
+                <plugin>
                     <groupId>com.googlecode.maven-download-plugin</groupId>
                     <artifactId>download-maven-plugin</artifactId>
                     <version>1.6.8</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>tycho-compiler-plugin</artifactId>
+                    <version>${tycho-version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>tycho-ds-plugin</artifactId>
+                    <version>${tycho-version}</version>
+                    <executions>
+                        <execution>
+                            <id>default-declarative-services</id>
+                            <!-- disable goal execution which is bound to default lifecycle -->
+                            <phase>none</phase>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.eclipse.tycho.extras</groupId>
+                    <artifactId>tycho-eclipserun-plugin</artifactId>
+                    <version>${tycho-version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>tycho-p2-publisher-plugin</artifactId>
+                    <version>${tycho-version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>tycho-surefire-plugin</artifactId>
+                    <version>${tycho-version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.eclipse.tycho</groupId>
@@ -349,9 +393,12 @@
                             </goals>
                             <configuration>
                                 <rules>
+                                    <banDuplicatePomDependencyVersions/>
+                                    <requireExplicitDependencyScope/>
                                     <requireMavenVersion>
                                         <version>3.6.3</version>
                                     </requireMavenVersion>
+                                    <requirePluginVersions/>
                                     <requireReleaseDeps>
                                         <excludes>
                                             <exclude>net.sf.eclipsecs:*</exclude>
@@ -380,7 +427,9 @@
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>3.3.0</version>
                 </plugin>
-                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+                <!-- This plugin's configuration is used to silence Eclipse M2E warnings for
+                Maven goals that cannot be mapped to the Eclipse build lifecycle.
+                It has no influence on the Maven build itself. -->
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>
                     <artifactId>lifecycle-mapping</artifactId>
@@ -391,28 +440,42 @@
                                 <pluginExecution>
                                     <pluginExecutionFilter>
                                         <groupId>org.apache.maven.plugins</groupId>
-                                        <artifactId>maven-resources-plugin</artifactId>
-                                        <versionRange>[2.4.3,)</versionRange>
-                                        <goals>
-                                            <goal>resources</goal>
-                                            <goal>testResources</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore></ignore>
-                                    </action>
-                                </pluginExecution>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>org.apache.maven.plugins</groupId>
                                         <artifactId>maven-clean-plugin</artifactId>
-                                        <versionRange>[2.5,)</versionRange>
+                                        <versionRange>[1.0.0,)</versionRange>
                                         <goals>
                                             <goal>clean</goal>
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <ignore></ignore>
+                                        <ignore/>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-enforcer-plugin</artifactId>
+                                        <versionRange>[1.0.0,)</versionRange>
+                                        <goals>
+                                            <goal>enforce</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore/>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-resources-plugin</artifactId>
+                                        <versionRange>[1.0.0,)</versionRange>
+                                        <goals>
+                                            <goal>copy-resources</goal>
+                                            <goal>resources</goal>
+                                            <goal>testResources</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore/>
                                     </action>
                                 </pluginExecution>
                                 <pluginExecution>
@@ -431,6 +494,12 @@
                             </pluginExecutions>
                         </lifecycleMappingMetadata>
                     </configuration>
+                </plugin>
+                <!-- used to automatically find updates of maven plugins and dependencies -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>2.15.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
* add more Maven enforcer rules
* pin versions of all required default Maven plugins instead of relying on Maven super POM
* add maven-versions-plugin to plugin management, because that is used to verify and upgrade all these versions
* exclude more maven plugins from m2e execution, they are not needed for the eclipse build
* have all m2e lifecycle mappings in the parent pom, not in child modules

This PR also showcases the previous documentation timestamp changes: The first maven build with all the above changes committed produced new timestamps (because of docs/pom.xml being modified). The sitemap was then amended and will not change any further when building this commit again.