### PR TITLE
infra: increase minimum required Eclipse version to 2021-06

### DIFF
--- a/docs/partials/index.html
+++ b/docs/partials/index.html
@@ -8,7 +8,7 @@
                     <p style="margin-bottom: 5px;">
                         <a class="btn btn-primary btn-outline-inverse btn-lg" target="_blank"
                             href="http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=150"
-                            title="Drag and drop this link into a running Eclipse (2020-09 or higher version) workspace to install the Eclipse Checkstyle Plugin">
+                            title="Drag and drop this link into a running Eclipse (2021-06 or higher version) workspace to install the Eclipse Checkstyle Plugin">
                             <i class="fa fa-plug">
                             </i>
                             Install
@@ -24,7 +24,7 @@
                     <small>
                         <sup>1 </sup>
                         Install via Eclipse Marketplace. Drag and drop this link into a running Eclipse
-                        (2020-09 or higher version) workspace. Latest release 10.7.0, based on Checkstyle 10.7.0, see
+                        (2021-06 or higher version) workspace. Latest release 10.7.0, based on Checkstyle 10.7.0, see
                         <a href="#!/releasenotes">release notes</a>
                     </small>
                 </div>

--- a/docs/partials/install.html
+++ b/docs/partials/install.html
@@ -10,11 +10,11 @@
             <p>
                 <a class="btn btn-primary btn-outline-inverse btn-lg" target="_blank"
                     href="http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=150"
-                    title="Drag and drop this link into a running Eclipse (2020-09 or higher version) workspace to install Checkstyle Plugin"
+                    title="Drag and drop this link into a running Eclipse (2021-06 or higher version) workspace to install Checkstyle Plugin"
                         ><i class="fa fa-plug"> </i> Install </a>
             </p>
             <ol>
-                <li>Drag&amp;Drop the link above to a running Eclipse instance (2020-09 or higher version). This will trigger the
+                <li>Drag&amp;Drop the link above to a running Eclipse instance (2021-06 or higher version). This will trigger the
                     Eclipse Marketplace client with the Eclipse Checkstyle Plugin being pre-selected for
                     installation.</li>
                 <li>Confirm the selection of features to install</li>

--- a/net.sf.eclipsecs-feature/feature.xml
+++ b/net.sf.eclipsecs-feature/feature.xml
@@ -22,7 +22,7 @@
    </url>
 
    <requires>
-      <import plugin="org.eclipse.core.runtime" version="3.19.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.core.runtime" version="3.22.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.core.resources"/>
       <import plugin="org.eclipse.jdt.core"/>
       <import plugin="org.eclipse.team.core"/>

--- a/net.sf.eclipsecs-updatesite/pom.xml
+++ b/net.sf.eclipsecs-updatesite/pom.xml
@@ -135,9 +135,9 @@
                         <configuration>
                             <repositories>
                                 <repository>
-                                    <id>2020-09</id>
+                                    <id>2021-06</id>
                                     <layout>p2</layout>
-                                    <url>https://download.eclipse.org/releases/2020-09</url>
+                                    <url>https://download.eclipse.org/releases/2021-06</url>
                                 </repository>
                             </repositories>
                             <dependencies>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/index.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/index.html
@@ -8,7 +8,7 @@
                     <p style="margin-bottom: 5px;">
                         <a class="btn btn-primary btn-outline-inverse btn-lg" target="_blank"
                             href="http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=150"
-                            title="Drag and drop this link into a running Eclipse (2020-09 or higher version) workspace to install the Eclipse Checkstyle Plugin">
+                            title="Drag and drop this link into a running Eclipse (2021-06 or higher version) workspace to install the Eclipse Checkstyle Plugin">
                             <i class="fa fa-plug">
                             </i>
                             Install
@@ -24,7 +24,7 @@
                     <small>
                         <sup>1 </sup>
                         Install via Eclipse Marketplace. Drag and drop this link into a running Eclipse
-                        (2020-09 or higher version) workspace. Latest release 10.7.0, based on Checkstyle 10.7.0, see
+                        (2021-06 or higher version) workspace. Latest release 10.7.0, based on Checkstyle 10.7.0, see
                         <a href="#!/releasenotes">release notes</a>
                     </small>
                 </div>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/install.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/install.html
@@ -10,11 +10,11 @@
             <p>
                 <a class="btn btn-primary btn-outline-inverse btn-lg" target="_blank"
                     href="http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=150"
-                    title="Drag and drop this link into a running Eclipse (2020-09 or higher version) workspace to install Checkstyle Plugin"
+                    title="Drag and drop this link into a running Eclipse (2021-06 or higher version) workspace to install Checkstyle Plugin"
                         ><i class="fa fa-plug"> </i> Install </a>
             </p>
             <ol>
-                <li>Drag&amp;Drop the link above to a running Eclipse instance (2020-09 or higher version). This will trigger the
+                <li>Drag&amp;Drop the link above to a running Eclipse instance (2021-06 or higher version). This will trigger the
                     Eclipse Marketplace client with the Eclipse Checkstyle Plugin being pre-selected for
                     installation.</li>
                 <li>Confirm the selection of features to install</li>

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Eclipse Checkstyle" sequenceNumber="1683469992">
+<target name="Eclipse Checkstyle" sequenceNumber="1685003741">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
-      <unit id="org.eclipse.jdt.feature.group" version="3.18.500.v20200902-1800"/>
-      <unit id="org.eclipse.sdk.ide" version="4.17.0.I20200902-1800"/>
-      <unit id="org.eclipse.emf.feature.group" version="2.23.0.v20200822-0801"/>
-      <unit id="org.eclipse.ecf" version="3.9.100.v20200611-2221"/>
-      <unit id="org.eclipse.ecf.filetransfer" version="5.1.100.v20200611-2221"/>
-      <unit id="org.eclipse.ecf.identity" version="3.9.400.v20200611-2221"/>
-      <unit id="org.eclipse.ecf.provider.filetransfer" version="3.2.600.v20200611-2221"/>
-      <repository location="https://download.eclipse.org/releases/2020-09/202009161000/"/>
+      <unit id="org.eclipse.jdt.feature.group" version="3.18.800.v20210611-1600"/>
+      <unit id="org.eclipse.sdk.ide" version="4.20.0.I20210611-1600"/>
+      <unit id="org.eclipse.emf.feature.group" version="2.26.0.v20210506-1425"/>
+      <unit id="org.eclipse.ecf" version="3.9.102.v20210409-2301"/>
+      <unit id="org.eclipse.ecf.filetransfer" version="5.1.102.v20210409-2301"/>
+      <unit id="org.eclipse.ecf.identity" version="3.9.402.v20210409-2301"/>
+      <unit id="org.eclipse.ecf.provider.filetransfer" version="3.2.601.v20201025-0700"/>
+      <repository location="https://download.eclipse.org/releases/2021-06/202106161001/"/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
-      <unit id="org.junit.jupiter.api" version="5.6.0.v20200203-2009"/>
-      <unit id="org.junit.jupiter.engine" version="5.6.0.v20200203-2009"/>
-      <unit id="org.junit.jupiter.params" version="5.6.0.v20200203-2009"/>
-      <unit id="org.junit.platform.commons" version="1.6.0.v20200203-2009"/>
-      <unit id="org.junit.platform.engine" version="1.6.0.v20200203-2009"/>
-      <unit id="org.junit.platform.launcher" version="1.6.0.v20200203-2009"/>
-      <unit id="org.junit.platform.runner" version="1.6.0.v20200203-2009"/>
-      <unit id="org.junit.platform.suite.api" version="1.6.0.v20200203-2009"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200831200620/repository"/>
+      <unit id="org.junit.jupiter.api" version="5.7.1.v20210222-1948"/>
+      <unit id="org.junit.jupiter.engine" version="5.7.1.v20210222-1948"/>
+      <unit id="org.junit.jupiter.params" version="5.7.1.v20210222-1948"/>
+      <unit id="org.junit.platform.commons" version="1.7.1.v20210222-1948"/>
+      <unit id="org.junit.platform.engine" version="1.7.1.v20210222-1948"/>
+      <unit id="org.junit.platform.launcher" version="1.7.1.v20210222-1948"/>
+      <unit id="org.junit.platform.runner" version="1.7.1.v20210222-1948"/>
+      <unit id="org.junit.platform.suite.api" version="1.7.1.v20210222-1948"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository"/>
     </location>
     <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="MavenDependencies">
     <dependencies>

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
@@ -4,7 +4,7 @@ target "Eclipse Checkstyle"
 with source configurePhase
 environment JavaSE-11
 
-location "https://download.eclipse.org/releases/2020-09/202009161000/" {
+location "https://download.eclipse.org/releases/2021-06/202106161001/" {
 	org.eclipse.jdt.feature.group
 	org.eclipse.sdk.ide
 
@@ -18,7 +18,7 @@ location "https://download.eclipse.org/releases/2020-09/202009161000/" {
 }
 
 // matching release of JUnit 5 from Eclipse Orbit
-location "https://download.eclipse.org/tools/orbit/downloads/drops/R20200831200620/repository" {
+location "https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository" {
 	org.junit.jupiter.api
 	org.junit.jupiter.engine
 	org.junit.jupiter.params

--- a/net.sf.eclipsecs.target/readme.md
+++ b/net.sf.eclipsecs.target/readme.md
@@ -1,7 +1,7 @@
 ## What's this?
 
 The `.target` file describes the minimum Eclipse environment that eclipse-cs runs in.
-Right now that is 2020-09 (since that is the first version officially running on Java 11).
+Right now that is 2021-06.
 
 
 ## Preconditions for development


### PR DESCRIPTION
Fixes #461 