### PR TITLE
Ignore sitemap changes again

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -4,13 +4,20 @@ set -e
 case $1 in
 
 git-diff)
+  printf "Changes to only docs/sitemap.xml:\n"
+  git diff docs/sitemap.xml
+
+  # file below is always modified on a run and updated with the current date
+  # such a change is ignored and must be verified manually instead
+  git checkout HEAD -- docs/sitemap.xml
+
   if [ "$(git status | grep 'Changes not staged\|Untracked files')" ]; then
     printf "Please clean up.\nGit status output:\n"
     printf "Top 300 lines of diff:\n"
     git status
     git diff | head -n 300
     false
-  fi
+  fi 
   ;;
 
 *)


### PR DESCRIPTION
Completely removing the special handling of the sitemap timestamps was wrong. While the other changes in the build avoided that timestamps change with _every_ build, they will still change after real documentation updates (like version number changes).

Therefore re-introduce the special handling, but try it with native git diff arguments.