### PR TITLE
normalize array properties

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetFactory.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetFactory.java
@@ -54,27 +54,37 @@ public final class ConfigPropertyWidgetFactory {
 
     if (prop.isPropertyReference()) {
       widget = new ConfigPropertyWidgetString(parent, prop);
-    } else if (type.equals(ConfigPropertyType.String)) {
-      widget = new ConfigPropertyWidgetString(parent, prop);
-    } else if (type.equals(ConfigPropertyType.StringArray)) {
-      widget = new ConfigPropertyWidgetString(parent, prop);
-    } else if (type.equals(ConfigPropertyType.Integer)) {
-      widget = new ConfigPropertyWidgetInteger(parent, prop);
-    } else if (type.equals(ConfigPropertyType.SingleSelect)) {
-      widget = new ConfigPropertyWidgetSingleSelect(parent, prop);
-    } else if (type.equals(ConfigPropertyType.Boolean)) {
-      widget = new ConfigPropertyWidgetBoolean(parent, prop);
-    } else if (type.equals(ConfigPropertyType.MultiCheck)) {
-      widget = new ConfigPropertyWidgetMultiCheck(parent, prop);
-    } else if (type.equals(ConfigPropertyType.Hidden)) {
-      widget = new ConfigPropertyWidgetHidden(parent, prop);
-    } else if (type.equals(ConfigPropertyType.File)) {
-      widget = new ConfigPropertyWidgetFile(parent, prop);
-    } else if (type.equals(ConfigPropertyType.Regex)) {
-      widget = new ConfigPropertyWidgetRegex(parent, prop);
+    } else {
+      widget = getWidgetForConfigPropertyType(parent, prop, type);
     }
 
     widget.initialize();
     return widget;
+  }
+
+  private static IConfigPropertyWidget getWidgetForConfigPropertyType(Composite parent,
+          ConfigProperty prop, ConfigPropertyType type) {
+    switch (type) {
+    case String:
+      return new ConfigPropertyWidgetString(parent, prop);
+    case StringArray:
+      return new ConfigPropertyWidgetStringArray(parent, prop);
+    case Integer:
+      return new ConfigPropertyWidgetInteger(parent, prop);
+    case SingleSelect:
+      return new ConfigPropertyWidgetSingleSelect(parent, prop);
+    case Boolean:
+      return new ConfigPropertyWidgetBoolean(parent, prop);
+    case MultiCheck:
+      return new ConfigPropertyWidgetMultiCheck(parent, prop);
+    case Hidden:
+      return new ConfigPropertyWidgetHidden(parent, prop);
+    case File:
+      return new ConfigPropertyWidgetFile(parent, prop);
+    case Regex:
+      return new ConfigPropertyWidgetRegex(parent, prop);
+    default:
+      return new ConfigPropertyWidgetString(parent, prop);
+    }
   }
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetMultiCheck.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetMultiCheck.java
@@ -22,12 +22,14 @@ package net.sf.eclipsecs.ui.config.widgets;
 
 import java.text.Collator;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.MissingResourceException;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 import java.util.StringTokenizer;
+import java.util.stream.Collectors;
 
 import net.sf.eclipsecs.core.config.ConfigProperty;
 import net.sf.eclipsecs.core.config.meta.ConfigPropertyMetadata;
@@ -123,18 +125,9 @@ public class ConfigPropertyWidgetMultiCheck extends ConfigPropertyWidgetAbstract
 
   @Override
   public String getValue() {
-    StringBuilder buffer = new StringBuilder(""); //$NON-NLS-1$
-
-    Object[] checkedElements = mTable.getCheckedElements();
-
-    for (int i = 0; i < checkedElements.length; i++) {
-
-      if (i > 0) {
-        buffer.append(","); //$NON-NLS-1$
-      }
-      buffer.append(checkedElements[i]);
-    }
-    return buffer.toString();
+    return Arrays.stream(mTable.getCheckedElements())
+            .map(Object::toString)
+            .collect(Collectors.joining(", "));
   }
 
   private List<String> getInitialValues() {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetStringArray.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetStringArray.java
@@ -1,0 +1,59 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
+
+package net.sf.eclipsecs.ui.config.widgets;
+
+import net.sf.eclipsecs.core.config.ConfigProperty;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.eclipse.swt.widgets.Composite;
+
+/**
+ * Property configuration widget for string arrays.
+ */
+public class ConfigPropertyWidgetStringArray extends ConfigPropertyWidgetString {
+
+  public ConfigPropertyWidgetStringArray(Composite parent, ConfigProperty prop) {
+    super(parent, prop);
+  }
+
+  @Override
+  protected String getInitValue() {
+    return normalizeSeparator(super.getInitValue());
+  }
+
+  @Override
+  public String getValue() {
+    return normalizeSeparator(super.getValue());
+  }
+
+  /**
+   * normalize array properties to be separated by a comma and a blank for better readability of the plain config file
+   * @param text
+   * @return text with normalized separators
+   */
+  private String normalizeSeparator(String text) {
+    return Arrays.stream(text.split(","))
+            .map(String::strip)
+            .collect(Collectors.joining(", "));
+  }
+}


### PR DESCRIPTION
Ensure that array properties and multi value properties are stored with a normalized ", " separator (comma plus blank) in the config file, independent of how they have been edited in the UI.
That improves readability and comparison of configuration files in the long run.

Example with a bad config file. Opening the editor has the values already normalized and saving would then also fix the config file:
![grafik](https://github.com/checkstyle/eclipse-cs/assets/406876/35e5614b-9c96-4cbd-8eec-b9dc80659a81)
