### PR TITLE
Fix configuration transformation jobs

### DIFF
--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/Messages.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/Messages.java
@@ -110,5 +110,9 @@ public final class Messages extends NLS {
 
   public static String PartsOpenedJob_title;
 
+  public static String TransformCheckstyleRulesJob_name;
+
+  public static String TransformFormatterRulesJob_name;
+
   // CHECKSTYLE:ON
 }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/TransformCheckstyleRulesJob.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/TransformCheckstyleRulesJob.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.sf.eclipsecs.core.CheckstylePlugin;
+import net.sf.eclipsecs.core.Messages;
 import net.sf.eclipsecs.core.config.CheckstyleConfigurationFile;
 import net.sf.eclipsecs.core.config.ICheckConfiguration;
 import net.sf.eclipsecs.core.config.configtypes.IContextAware;
@@ -46,6 +47,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.SubMonitor;
 import org.xml.sax.InputSource;
 
 /**
@@ -66,14 +68,15 @@ public class TransformCheckstyleRulesJob extends WorkspaceJob {
    *          The current selected project in the workspace.
    */
   public TransformCheckstyleRulesJob(final IProject project) {
-    super("transformCheckstyle");
+    super(Messages.TransformCheckstyleRulesJob_name);
 
     this.mProject = project;
   }
 
   @Override
-  public IStatus runInWorkspace(final IProgressMonitor arg0) throws CoreException {
-
+  public IStatus runInWorkspace(final IProgressMonitor monitor) throws CoreException {
+    SubMonitor subMonitor = SubMonitor.convert(monitor);
+    subMonitor.setWorkRemaining(IProgressMonitor.UNKNOWN);
     try {
       final IProjectConfiguration conf = ProjectConfigurationFactory.getConfiguration(mProject);
 
@@ -135,4 +138,10 @@ public class TransformCheckstyleRulesJob extends WorkspaceJob {
       }
     }
   }
+
+  @Override
+  public boolean belongsTo(Object family) {
+    return AbstractCheckJob.CHECKSTYLE_JOB_FAMILY.equals(family) || super.belongsTo(family);
+  }
+
 }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/TransformFormatterRulesJob.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/TransformFormatterRulesJob.java
@@ -23,6 +23,7 @@ package net.sf.eclipsecs.core.jobs;
 import java.io.FileNotFoundException;
 
 import net.sf.eclipsecs.core.CheckstylePlugin;
+import net.sf.eclipsecs.core.Messages;
 import net.sf.eclipsecs.core.transformer.FormatterConfigParser;
 import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
 import net.sf.eclipsecs.core.transformer.FormatterTransformer;
@@ -34,6 +35,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.SubMonitor;
 
 /**
  * Job who starts transforming the formatter-rules to checkstyle-settings.
@@ -47,18 +49,20 @@ public class TransformFormatterRulesJob extends WorkspaceJob {
    * Job for transforming formatter-rules to checkstyle-settings.
    */
   public TransformFormatterRulesJob() {
-    super("transformFormatter");
+    super(Messages.TransformFormatterRulesJob_name);
   }
 
   @Override
-  public IStatus runInWorkspace(final IProgressMonitor arg0) throws CoreException {
+  public IStatus runInWorkspace(final IProgressMonitor monitor) throws CoreException {
+    SubMonitor subMonitor = SubMonitor.convert(monitor);
+    subMonitor.setWorkRemaining(IProgressMonitor.UNKNOWN);
 
     // TODO this way of loading formatter profiles is very dubious, to say
     // the least, refer to FormatterConfigWriter for a better API
     final String workspace = ResourcesPlugin.getWorkspace().getRoot().getLocation().toString();
 
     final String configLocation = workspace
-            + "/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.core.prefs";
+            + "/.metadata/.plugins/org.eclipse.core.runtime/.settings/org.eclipse.jdt.core.prefs"; //$NON-NLS-1$
 
     FormatterConfigParser parser = null;
 
@@ -75,7 +79,7 @@ public class TransformFormatterRulesJob extends WorkspaceJob {
 
     try {
       FormatterTransformer transformer = new FormatterTransformer(rules);
-      transformer.transformRules(workspace + "/test-checkstyle.xml");
+      transformer.transformRules(workspace + "/test-checkstyle.xml"); //$NON-NLS-1$
     } catch (CheckstylePluginException ex) {
       Status status = new Status(IStatus.ERROR, CheckstylePlugin.PLUGIN_ID, IStatus.ERROR,
               ex.getMessage(), ex);
@@ -84,4 +88,10 @@ public class TransformFormatterRulesJob extends WorkspaceJob {
 
     return Status.OK_STATUS;
   }
+
+  @Override
+  public boolean belongsTo(Object family) {
+    return AbstractCheckJob.CHECKSTYLE_JOB_FAMILY.equals(family) || super.belongsTo(family);
+  }
+
 }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/messages.properties
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/messages.properties
@@ -33,3 +33,5 @@ RemoteConfigurationType_msgRemoteCachingFailed = Could not cache remote configur
 RemoteConfigurationType_msgUnAuthorized = 401: Authentication failed
 RunCheckstyleOnFilesJob_title = Checkstyle
 SimpleFileSetsEditor_nameAllFileset = all
+TransformCheckstyleRulesJob_name=Convert Checkstyle rules
+TransformFormatterRulesJob_name=Convert formatter settings


### PR DESCRIPTION
* Job names are end user visible in the Eclipse UI, therefore just taking some unique identifier without meaning is not correct.
* Always initialize the progress reporting, even if there is nothing to count.
* add icon via job family registration