### PR TITLE
Add project configuration menu contribution

### DIFF
--- a/net.sf.eclipsecs.ui/OSGI-INF/l10n/bundle.properties
+++ b/net.sf.eclipsecs.ui/OSGI-INF/l10n/bundle.properties
@@ -56,3 +56,5 @@ actionSet.label = Checkstyle
 extension-point.quickfix-provider.name = Checkstyle Quickfix provider
 extension-point.filter-editor.name = Checkstyle filter editors
 extension-point.config-types-ui.name = Checkstyle configuration type editors
+addnature.label = Add Checkstyle Nature
+removenature.label = Remove Checkstyle Nature

--- a/net.sf.eclipsecs.ui/plugin.xml
+++ b/net.sf.eclipsecs.ui/plugin.xml
@@ -31,8 +31,8 @@
             filter="FilesFromPackage"/>
     </extension>
 
-	<!-- Configuration type editors -->
-	<extension
+    <!-- Configuration type editors -->
+    <extension
         point="net.sf.eclipsecs.ui.configtypesui">
         <configtypeui
             configtypename="builtin"
@@ -54,7 +54,7 @@
             configtypename="project"
             editorclass="net.sf.eclipsecs.ui.config.configtypes.ProjectConfigurationEditor"
             icon="icons/configtype_project.gif"/>
-	</extension>
+    </extension>
 
     <extension
         point="org.eclipse.ui.startup">
@@ -128,8 +128,8 @@
     </extension>
 
     <!--
-	Provide marker resolutions
-	-->
+    Provide marker resolutions
+    -->
     <extension
         point="org.eclipse.ui.ide.markerResolution">
         <markerResolutionGenerator
@@ -463,6 +463,51 @@
                   label="%CheckSelectedFilesAction.label"
                   menubarPath="Checkstyle.menu/ondemand"
                   tooltip="%CheckSelectedFilesAction.tooltip"/>
+        </objectContribution>
+
+        <objectContribution adaptable="true"
+            id="checkstyle.addNature"
+            objectClass="org.eclipse.core.resources.IProject">
+            <action class="net.sf.eclipsecs.ui.actions.ActivateProjectsAction"
+                enablesFor="+"
+                icon="icons/checkstyle_command.png"
+                id="checkstyle.addNature.action"
+                label="%addnature.label"
+                menubarPath="org.eclipse.ui.projectConfigure/additions"
+                style="push">
+            </action>
+            <visibility>
+                <and>
+                    <objectState name="open" value="true"/>
+                    <objectState name="projectNature"
+                        value="org.eclipse.jdt.core.javanature">
+                    </objectState>
+                    <not>
+                        <objectState name="projectNature"
+                            value="net.sf.eclipsecs.core.CheckstyleNature">
+                        </objectState>
+                    </not>
+                </and>
+            </visibility>
+        </objectContribution>
+        <objectContribution adaptable="true"
+            id="checkstyle.removeNature"
+            objectClass="org.eclipse.core.resources.IProject">
+            <action class="net.sf.eclipsecs.ui.actions.DeactivateProjectsAction"
+                enablesFor="1"
+                id="checkstyle.removeNature.action"
+                label="%removenature.label"
+                menubarPath="org.eclipse.ui.projectConfigure/additions"
+                style="push">
+            </action>
+            <visibility>
+                <and>
+                    <objectState name="open" value="true"/>
+                    <objectState name="projectNature"
+                        value="net.sf.eclipsecs.core.CheckstyleNature">
+                    </objectState>
+                </and>
+            </visibility>
         </objectContribution>
     </extension>
 


### PR DESCRIPTION
That's the place where all project conversion and configuration contributions of different plugins should appear.
While that's basically a duplication of the sub menus in the Checkstyle command, it's the place where Eclipse developers might look first when trying to enable/disable checkstyle for a project.
The menu items are only visible if all selected projects do/don't have the checkstyle nature and are currently open.

The other menu items in this menu depend on what you have installed, e.g. you might see Xtext, Gradle, Groovy, Maven and other items appear there.
![grafik](https://github.com/checkstyle/eclipse-cs/assets/406876/a0c18a46-9426-4ea7-b4ce-e8ecee9aa91b)
