### PR TITLE
Module configuration editor does not open

### DIFF
--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -182,7 +182,13 @@
                    ### InnerInterface(.*)
                    ### InnerClass(.*)"/>
     </module>
-    <module name="LogicConditionNeedOptimizationCheck"/>
+    <module name="LogicConditionNeedOptimizationCheck">
+      <!-- This rule is wrong. You cannot optimize "return executeEmergencyBrake() && someCondition"
+      to "return someCondition && executeEmergencyBrake()". The short circuit evaluation of boolean
+      expressions will lead to the method not being called, even if it has a wanted side effect
+      (something that changes global state). -->
+      <property name="severity" value="ignore"/>
+    </module>
     <module name="AvoidConditionInversionCheck"/>
     <module name="SingleBreakOrContinueCheck"/>
     <module name="NumericLiteralNeedsUnderscoreCheck"/>

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
@@ -139,7 +139,7 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
   /** Button to remove a module. */
   private Button mRemoveButton;
 
-  /** Button to remove a module. */
+  /** Button to edit a module. */
   private Button mEditButton;
 
   /** Group containing the table viewer. */
@@ -663,7 +663,7 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
         RuleConfigurationEditDialog dialog = new RuleConfigurationEditDialog(getShell(),
                 workingCopy, !mConfigurable,
                 Messages.CheckConfigurationConfigureDialog_titleModuleConfigEditor);
-        if (mConfigurable && Window.OK == dialog.open()) {
+        if (Window.OK == dialog.open() && mConfigurable) {
           mModules.set(mModules.indexOf(module), workingCopy);
           mIsDirty = true;
           mTableViewer.refresh(true);


### PR DESCRIPTION
This partially reverts 3e27bdc0e329e719140539c70b87f1dbc76c57a5. Boolean expressions with side effects MUST NOT be modified in such a way that short circuit evaluation will remove the side effect. That's a ground rule for all kinds of code optimizations and transformations.

I had to disable one of the sevntu rules, because it's wrong. You cannot move methods to the right of boolean expressions, if those methods have a side effect that changes any global state of the application.

Fixes #559.

Raised https://github.com/sevntu-checkstyle/sevntu.checkstyle/issues/1025