### PR TITLE
Have a Maven default goal configured

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     </dependencies>
 
     <build>
+        <defaultGoal>verify</defaultGoal>
         <finalName>${project.artifactId}_${unqualifiedVersion}.${buildQualifier}</finalName>
         <testSourceDirectory>test</testSourceDirectory>
         <testResources>


### PR DESCRIPTION
That way any contributor can easily build by invoking maven without any arguments, instead of going through the documentation to find the correct command line.
Also this serves as documentation of being a good Maven project, since it doesn't require "clean" to be used.

![grafik](https://github.com/checkstyle/eclipse-cs/assets/406876/83a27bfb-30fc-4833-8d52-ecc774174987)
