### PR TITLE
infra: add development support plugins to target platform

### DIFF
--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Eclipse Checkstyle" sequenceNumber="1685003741">
+<target name="Eclipse Checkstyle" sequenceNumber="1695316836">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.jdt.feature.group" version="3.18.800.v20210611-1600"/>
@@ -11,6 +11,8 @@
       <unit id="org.eclipse.ecf.filetransfer" version="5.1.102.v20210409-2301"/>
       <unit id="org.eclipse.ecf.identity" version="3.9.402.v20210409-2301"/>
       <unit id="org.eclipse.ecf.provider.filetransfer" version="3.2.601.v20201025-0700"/>
+      <unit id="org.eclipse.tools.layout.spy" version="1.1.0.v20210110-1247"/>
+      <unit id="org.eclipse.ui.trace" version="1.2.0.v20210110-1242"/>
       <repository location="https://download.eclipse.org/releases/2021-06/202106161001/"/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
@@ -15,6 +15,10 @@ location "https://download.eclipse.org/releases/2021-06/202106161001/" {
 	org.eclipse.ecf.filetransfer
 	org.eclipse.ecf.identity
 	org.eclipse.ecf.provider.filetransfer
+
+	// additional support plugins which are useful during development, but will not be part of the product
+	org.eclipse.tools.layout.spy
+	org.eclipse.ui.trace
 }
 
 // matching release of JUnit 5 from Eclipse Orbit


### PR DESCRIPTION
These plugins don't affect the released product, but they are useful when running a development runtime. For instance the layout spy can be used to visually debug the layout of all dialogs etc.