### PR TITLE
Replace confusing type conversion

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationPropertiesDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationPropertiesDialog.java
@@ -309,7 +309,7 @@ public class CheckConfigurationPropertiesDialog extends TitleAreaDialog {
         MessageDialog dialog = new MessageDialog(getShell(),
                 Messages.CheckConfigurationPropertiesDialog_titleUnresolvedProps, null,
                 NLS.bind(Messages.CheckConfigurationPropertiesDialog_msgUnresolvedProps,
-                        "" + unresolvedProps.size()), //$NON-NLS-1$
+                        Integer.toString(unresolvedProps.size())),
                 MessageDialog.WARNING,
                 new String[] { Messages.CheckConfigurationPropertiesDialog_btnEditProps,
                     Messages.CheckConfigurationPropertiesDialog_btnContinue,

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ExternalFileConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ExternalFileConfigurationEditor.java
@@ -201,7 +201,7 @@ public class ExternalFileConfigurationEditor implements ICheckConfigurationEdito
     mWorkingCopy.setName(mConfigName.getText());
     mWorkingCopy.setDescription(mDescription.getText());
     mWorkingCopy.getAdditionalData().put(ExternalFileConfigurationType.KEY_PROTECT_CONFIG,
-            "" + mChkProtectConfig.getSelection()); //$NON-NLS-1$
+            Boolean.toString(mChkProtectConfig.getSelection()));
 
     try {
       mWorkingCopy.setLocation(mLocation.getText());

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ProjectConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ProjectConfigurationEditor.java
@@ -239,7 +239,7 @@ public class ProjectConfigurationEditor implements ICheckConfigurationEditor {
     mWorkingCopy.setDescription(mDescription.getText());
 
     mWorkingCopy.getAdditionalData().put(ExternalFileConfigurationType.KEY_PROTECT_CONFIG,
-            "" + mChkProtectConfig.getSelection()); //$NON-NLS-1$
+            Boolean.toString(mChkProtectConfig.getSelection()));
 
     try {
       mWorkingCopy.setLocation(mLocation.getText());

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/RemoteConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/RemoteConfigurationEditor.java
@@ -233,7 +233,7 @@ public class RemoteConfigurationEditor implements ICheckConfigurationEditor {
     mWorkingCopy.setDescription(mDescription.getText());
 
     mWorkingCopy.getAdditionalData().put(RemoteConfigurationType.KEY_CACHE_CONFIG,
-            "" + mChkCacheConfig.getSelection()); //$NON-NLS-1$
+            Boolean.toString(mChkCacheConfig.getSelection()));
 
     return mWorkingCopy;
   }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetBoolean.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetBoolean.java
@@ -68,7 +68,7 @@ public class ConfigPropertyWidgetBoolean extends ConfigPropertyWidgetAbstractBas
 
   @Override
   public String getValue() {
-    return "" + mCheckbox.getSelection(); //$NON-NLS-1$
+    return Boolean.toString(mCheckbox.getSelection());
   }
 
   @Override

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetMultiCheck.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetMultiCheck.java
@@ -196,10 +196,10 @@ public class ConfigPropertyWidgetMultiCheck extends ConfigPropertyWidgetAbstract
         try {
           translation = TOKEN_BUNDLE.getString((String) element);
         } catch (MissingResourceException ex) {
-          translation = "" + element; //$NON-NLS-1$
+          translation = element.toString();
         }
       } else {
-        translation = "" + element; //$NON-NLS-1$
+        translation = element.toString();
       }
       return translation;
     }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/FileSetEditDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/FileSetEditDialog.java
@@ -391,8 +391,8 @@ public class FileSetEditDialog extends TitleAreaDialog {
   private void updateMatchView() {
     mMatchesViewer.refresh();
     mMatchGroup.setText(NLS.bind(Messages.FileSetEditDialog_titleTestResult,
-            new String[] { mProject.getName(), "" + mMatchesViewer.getTable().getItemCount(), //$NON-NLS-1$
-                "" + mProjectFiles.size() })); //$NON-NLS-1$
+            new String[] { mProject.getName(), Integer.toString(mMatchesViewer.getTable().getItemCount()),
+                Integer.toString(mProjectFiles.size()) }));
   }
 
   @Override

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/MarkerStatsView.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/MarkerStatsView.java
@@ -603,7 +603,7 @@ public class MarkerStatsView extends AbstractStatsView {
           text = stat.getIdentifiant();
           break;
         case 2:
-          text = stat.getCount() + ""; //$NON-NLS-1$
+          text = Integer.toString(stat.getCount());
           break;
 
         default:


### PR DESCRIPTION
Explicitly convert to String instead of relying on implicit string concatenation done by the compiler. This would even be worth a checkstyle check.