### PR TITLE
Right align table columns containing numbers

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/MarkerStatsView.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/MarkerStatsView.java
@@ -206,7 +206,7 @@ public class MarkerStatsView extends AbstractStatsView {
     idCol.setText(Messages.MarkerStatsView_kindOfErrorColumn);
     idCol.setWidth(400);
 
-    TableColumn countCol = new TableColumn(table, SWT.CENTER, 2);
+    TableColumn countCol = new TableColumn(table, SWT.RIGHT, 2);
     countCol.setText(Messages.MarkerStatsView_numberOfErrorsColumn);
     countCol.pack();
 
@@ -270,7 +270,7 @@ public class MarkerStatsView extends AbstractStatsView {
     folderCol.setText(Messages.MarkerStatsView_folderColumn);
     folderCol.setWidth(300);
 
-    TableColumn countCol = new TableColumn(table, SWT.CENTER, 3);
+    TableColumn countCol = new TableColumn(table, SWT.RIGHT, 3);
     countCol.setText(Messages.MarkerStatsView_lineColumn);
     countCol.pack();
 


### PR DESCRIPTION
Fixes #577.

![grafik](https://github.com/checkstyle/eclipse-cs/assets/406876/b6bb0245-e5c4-4041-9e0e-f44c47eed9a2)
