### PR TITLE
Ignore checkstyle dependency update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,13 @@
 version: 2
 updates:
   - package-ecosystem: maven
-    directory: "/"
+    directory: /
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: weekly
+    ignore:
+      - dependency-name: com.puppycrawl.tools:checkstyle
+        # we need to update the main Checkstyle dependency manually
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
* ignore the dependency to the main project in dependabot, because we have to do these changes manually
* remove quotes, gives better syntax highlighting in VS code
* also check the github actions