### PR TITLE
infra: downgrade JUnit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,9 @@
         <build-helper-maven-plugin-version>3.4.0</build-helper-maven-plugin-version>
         <download-maven-plugin-version>1.7.1</download-maven-plugin-version>
         <exec-maven-plugin-version>3.1.0</exec-maven-plugin-version>
-        <junit-jupiter-version>5.10.0</junit-jupiter-version>
+
+        <!-- Maven JUnit version must fit the JUnit version used in the target platform, otherwise Surefire may produce exceptions -->
+        <junit-jupiter-version>5.7.2</junit-jupiter-version>
         <maven-antrun-plugin-version>3.1.0</maven-antrun-plugin-version>
         <maven-checkstyle-plugin-version>3.3.0</maven-checkstyle-plugin-version>
         <maven-clean-plugin-version>3.3.1</maven-clean-plugin-version>
@@ -33,7 +35,7 @@
         <maven-install-plugin-version>3.1.1</maven-install-plugin-version>
         <maven-resources-plugin-version>3.3.1</maven-resources-plugin-version>
         <maven-site-plugin-version>3.12.1</maven-site-plugin-version>
-        <maven-surefire-plugin-version>2.22.2</maven-surefire-plugin-version>
+        <maven-surefire-plugin-version>3.1.2</maven-surefire-plugin-version>
         <maven-version>3.6.3</maven-version>
         <tycho-version>2.7.5</tycho-version>
         <versions-maven-plugin-version>2.16.1</versions-maven-plugin-version>
@@ -377,11 +379,6 @@
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin-version}</version>
-                    <configuration>
-                        <includes>
-                            <include>**/*Test.java</include>
-                        </includes>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Upgrading Maven Surefire to a recent version fails with exceptions in the process launching the test process. That's because we have 2 versions of JUnit: 5.10 from Maven and 5.7.1 from the Eclipse target platform. Surefire seems to be confused by that and tries to use the junit-platform-launcher 5.7 from the target platform to launch the 5.10 JUnit during the Maven run.

To avoid this, downgrade the Maven JUnit version to the latest 5.7.x, such that both Maven and Eclipse use the same JUnit version.

Also remove some superfluous configuration.