### PR TITLE
infra: filter duplicated resources

### DIFF
--- a/.derived
+++ b/.derived
@@ -1,6 +1,18 @@
 # AutoDeriv plugin configuration.
 # To make this work, you need to install the plugin from https://nodj.github.io/AutoDeriv/
 
-# target folders of eclipse and maven
+# target folders of Eclipse and Maven
 target
 bin
+
+# The nested Maven modules are all shown as folders of this project, leading to duplicate search results etc.
+# Set them derived in this project only (doesn't have any effect on the Eclipse projects for the same Maven modules).
+net.sf.eclipsecs.branding
+net.sf.eclipsecs.checkstyle
+net.sf.eclipsecs.core
+net.sf.eclipsecs.doc
+net.sf.eclipsecs.sample
+net.sf.eclipsecs.target
+net.sf.eclipsecs.ui
+net.sf.eclipsecs-feature
+net.sf.eclipsecs-updatesite


### PR DESCRIPTION
When importing all projects in Eclipse, the Maven modules are imported as standalone projects, but also appear as child folders of the root module. That in turn leads to always having each file appear twice when opening the resource selection dialog, running a file search etc.
Mark the child folders in the root module project as derived, which will hide them in most file related operations afterwards.

trying to open a manifest file before and after the change (in the before screenshot all the below ones are unwanted duplicates or temporary files):

![grafik](https://github.com/checkstyle/eclipse-cs/assets/406876/ef8d4dc7-0375-4877-9a5d-a20320a4cc54)

![grafik](https://github.com/checkstyle/eclipse-cs/assets/406876/c8469cc4-c131-490b-906e-88aaf17874a5)
