### PR TITLE
Clean up tests and convert to AssertJ

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -347,36 +347,36 @@
             <property name="checks" value="IllegalCatch"/>
         </module>
         <module name="SuppressionXpathSingleFilter">
-            <property name="files" value=".*[\\/]src[\\/]test[\\/]"/>
+            <property name="files" value=".*[\\/]test[\\/]"/>
             <property name="checks" value="EmptyBlock"/>
         </module>
         <module name="SuppressionXpathSingleFilter">
-            <property name="files" value=".*[\\/]src[\\/](test|it)[\\/]"/>
+            <property name="files" value=".*[\\/](test|it)[\\/]"/>
             <property name="checks" value="JavadocVariable"/>
         </module>
         <module name="SuppressionXpathSingleFilter">
-            <property name="files" value=".*[\\/]src[\\/](test|it)[\\/]"/>
+            <property name="files" value=".*[\\/](test|it)[\\/]"/>
             <property name="checks" value="JavadocType"/>
         </module>
         <module name="SuppressionXpathSingleFilter">
-            <property name="files" value=".*[\\/]src[\\/](test|it)[\\/]"/>
+            <property name="files" value=".*[\\/](test|it)[\\/]"/>
             <property name="checks" value="MagicNumber"/>
         </module>
         <module name="SuppressionXpathSingleFilter">
-            <property name="files" value=".*[\\/]src[\\/](test|it)[\\/]"/>
+            <property name="files" value=".*[\\/](test|it)[\\/]"/>
             <property name="checks" value="AvoidStaticImport"/>
         </module>
         <module name="SuppressionXpathSingleFilter">
-            <property name="files" value=".*[\\/]src[\\/](test|it)[\\/]"/>
+            <property name="files" value=".*[\\/](test|it)[\\/]"/>
             <property name="checks" value="WriteTag"/>
         </module>
         <module name="SuppressionXpathSingleFilter">
-            <property name="files" value=".*[\\/]src[\\/](test|it)[\\/]"/>
+            <property name="files" value=".*[\\/](test|it)[\\/]"/>
             <property name="checks" value="MethodCount"/>
         </module>
         <!-- Fixing these cases will decrease code readability -->
         <module name="SuppressionXpathSingleFilter">
-            <property name="files" value=".*[\\/]src[\\/](test|it)[\\/]"/>
+            <property name="files" value=".*[\\/](test|it)[\\/]"/>
             <property name="checks" value="MultipleStringLiterals"/>
         </module>
         <module name="SuppressWithNearbyCommentFilter">

--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -389,7 +389,12 @@
         <!-- Imports -->
         <module name="AvoidStarImport"/>
         <module name="AvoidStaticImport"/>
-        <module name="IllegalImport"/>
+        <module name="IllegalImport">
+            <property name="illegalClasses"
+                      value="org.junit.jupiter.api.Assertions"/>
+            <message key="import.illegal"
+                     value="Use org.assertj.core.api.Assertions instead."/>
+        </module>
         <module name="ImportControl">
             <property name="id" value="ImportControlMain"/>
             <property name="file" value="${checkstyle.importcontrol.file}"/>

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -234,8 +234,4 @@
     <suppress id="JavadocPackage"
              files=".*"
              />
-    <!-- exclude test code, see also /net.sf.eclipsecs.ui/.checkstyle -->
-    <suppress checks=".*"
-             files="test[/\\].*"
-             />
 </suppressions>

--- a/net.sf.eclipsecs.checkstyle/build.properties
+++ b/net.sf.eclipsecs.checkstyle/build.properties
@@ -6,3 +6,5 @@ bin.includes = META-INF/,\
 jars.compile.order = .
 source.. = metadata/
 javacDefaultEncoding.. = UTF-8
+additional.bundles = assertj-core,\
+                     net.bytebuddy.byte-buddy

--- a/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/ChecksTest.java
+++ b/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/ChecksTest.java
@@ -1,3 +1,23 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
+
 package net.sf.eclipsecs.checkstyle;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/utils/CheckUtil.java
+++ b/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/utils/CheckUtil.java
@@ -1,3 +1,23 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
+
 package net.sf.eclipsecs.checkstyle.utils;
 
 import com.puppycrawl.tools.checkstyle.PackageNamesLoader;

--- a/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/utils/XmlUtil.java
+++ b/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/utils/XmlUtil.java
@@ -20,7 +20,7 @@
 
 package net.sf.eclipsecs.checkstyle.utils;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.StringReader;

--- a/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/utils/XmlUtil.java
+++ b/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/utils/XmlUtil.java
@@ -1,3 +1,23 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
+
 package net.sf.eclipsecs.checkstyle.utils;
 
 import static org.junit.jupiter.api.Assertions.fail;

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Eclipse Checkstyle" sequenceNumber="1695316836">
+<target name="Eclipse Checkstyle" sequenceNumber="1695470918">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.jdt.feature.group" version="3.18.800.v20210611-1600"/>
@@ -26,7 +26,27 @@
       <unit id="org.junit.platform.suite.api" version="1.7.1.v20210222-1948"/>
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository"/>
     </location>
-    <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="MavenDependencies">
+    <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="SnakeYaml">
+    <dependencies>
+    	<dependency>
+    		<groupId>org.yaml</groupId>
+    		<artifactId>snakeyaml</artifactId>
+    		<version>1.33</version>
+    		<type>jar</type>
+    	</dependency>
+    </dependencies>
+    </location>
+    <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="Javassist">
+    <dependencies>
+    	<dependency>
+    		<groupId>org.javassist</groupId>
+    		<artifactId>javassist</artifactId>
+    		<version>3.29.2-GA</version>
+    		<type>jar</type>
+    	</dependency>
+    </dependencies>
+    </location>
+    <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="DOM4J">
     <dependencies>
     	<dependency>
     		<groupId>org.dom4j</groupId>
@@ -34,18 +54,10 @@
     		<version>2.1.3</version>
     		<type>jar</type>
     	</dependency>
-    	<dependency>
-    		<groupId>org.javassist</groupId>
-    		<artifactId>javassist</artifactId>
-    		<version>3.29.2-GA</version>
-    		<type>jar</type>
-    	</dependency>
-    	<dependency>
-    		<groupId>org.yaml</groupId>
-    		<artifactId>snakeyaml</artifactId>
-    		<version>1.33</version>
-    		<type>jar</type>
-    	</dependency>
+    </dependencies>
+    </location>
+    <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="JFreeCharts">
+    <dependencies>
     	<dependency>
     		<groupId>org.jfree</groupId>
     		<artifactId>jcommon</artifactId>
@@ -70,6 +82,20 @@
     		<version>1.1.0</version>
     		<type>jar</type>
     	</dependency>
+    </dependencies>
+    </location>
+    <location includeDependencyDepth="direct" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="AssertJ">
+    <dependencies>
+    	<dependency>
+    		<groupId>org.assertj</groupId>
+    		<artifactId>assertj-core</artifactId>
+    		<version>3.24.2</version>
+    		<type>jar</type>
+    	</dependency>
+    </dependencies>
+    </location>
+    <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="ApacheCommons">
+    <dependencies>
     	<dependency>
     		<groupId>org.apache.commons</groupId>
     		<artifactId>commons-lang3</artifactId>

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
@@ -35,27 +35,36 @@ location "https://download.eclipse.org/tools/orbit/downloads/drops/R202106020316
 
 // If the following part has errors and no syntax highlighting, then please use Help>About>Installation>Installed Software>Target Platform DSL>Uninstall.
 // After restarting please install the current version from the URL in line 1.
-maven MavenDependencies
+maven ApacheCommons
 	scope=compile
 	dependencyDepth=none
 	missingManifest=generate
 	includeSources
 {
 	dependency {
-		groupId="org.dom4j"
-		artifactId="dom4j"
-		version="2.1.3"
+		groupId="org.apache.commons"
+		artifactId="commons-lang3"
+		version="3.12.0"
 	}
+}
+maven AssertJ
+	scope=compile
+	dependencyDepth=direct
+	missingManifest=generate
+	includeSources
+{
 	dependency {
-		groupId="org.javassist"
-		artifactId="javassist"
-		version="3.29.2-GA"
+		groupId="org.assertj"
+		artifactId="assertj-core"
+		version="3.24.2"
 	}
-	dependency {
-		groupId="org.yaml"
-		artifactId="snakeyaml"
-		version="1.33"
-	}
+}
+maven JFreeCharts
+	scope=compile
+	dependencyDepth=none
+	missingManifest=generate
+	includeSources
+{
 	dependency {
 		groupId="org.jfree"
 		artifactId="jcommon"
@@ -76,9 +85,40 @@ maven MavenDependencies
 		artifactId="swtgraphics2d"
 		version="1.1.0"
 	}
+}
+maven DOM4J
+	scope=compile
+	dependencyDepth=none
+	missingManifest=generate
+	includeSources
+{
 	dependency {
-		groupId="org.apache.commons"
-		artifactId="commons-lang3"
-		version="3.12.0"
+		groupId="org.dom4j"
+		artifactId="dom4j"
+		version="2.1.3"
+	}
+}
+maven Javassist
+	scope=compile
+	dependencyDepth=none
+	missingManifest=generate
+	includeSources
+{
+	dependency {
+		groupId="org.javassist"
+		artifactId="javassist"
+		version="3.29.2-GA"
+	}
+}
+maven SnakeYaml
+	scope=compile
+	dependencyDepth=none
+	missingManifest=generate
+	includeSources
+{
+	dependency {
+		groupId="org.yaml"
+		artifactId="snakeyaml"
+		version="1.33"
 	}
 }

--- a/net.sf.eclipsecs.ui/build.properties
+++ b/net.sf.eclipsecs.ui/build.properties
@@ -8,5 +8,6 @@ bin.includes = icons/,\
 jars.compile.order = .
 source.. = src/
 additional.bundles = org.eclipse.jdt.core,\
-                     org.eclipse.core.runtime
+                     org.eclipse.core.runtime,\
+                     assertj-core
 javacDefaultEncoding.. = UTF-8

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/AbstractQuickfixTestCase.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/AbstractQuickfixTestCase.java
@@ -20,8 +20,7 @@
 
 package net.sf.eclipsecs.ui.quickfixes;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -50,13 +49,10 @@ public abstract class AbstractQuickfixTestCase {
 
   protected void testQuickfix(final String testDataXml, final AbstractASTResolution quickfix)
           throws Exception {
-    InputStream stream = getClass().getResourceAsStream(testDataXml);
-    assertNotNull(stream, "Cannot find resource " + testDataXml + " in package "
-            + getClass().getPackage().getName());
-    try {
+    try (InputStream stream = getClass().getResourceAsStream(testDataXml)) {
+      assertThat(stream).withFailMessage(() -> "Cannot find resource " + testDataXml + " in package "
+            + getClass().getPackage().getName()).isNotNull();
       testQuickfix(stream, quickfix);
-    } finally {
-      stream.close();
     }
   }
 
@@ -88,7 +84,8 @@ public abstract class AbstractQuickfixTestCase {
       TextEdit edit = compUnit.rewrite(doc, options);
       edit.apply(doc);
 
-      assertEquals(testdata[i].result, doc.get().lines().map(String::stripTrailing).collect(Collectors.joining("\n")));
+      String trailingSpaceRemoved = doc.get().lines().map(String::stripTrailing).collect(Collectors.joining("\n"));
+      assertThat(trailingSpaceRemoved).isEqualTo(testdata[i].result);
     }
 
   }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/AvoidNestedBlocksInput.xml
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/AvoidNestedBlocksInput.xml
@@ -37,7 +37,7 @@ public class A {
 public class A {
     public void foo(int a, int b) {
         switch(0) {
-        case 0: 
+        case 0:
         System.out.println("test");
                 break;
             default:

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/AvoidNestedBlocksTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/AvoidNestedBlocksTest.java
@@ -1,3 +1,22 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
 
 package net.sf.eclipsecs.ui.quickfixes.blocks;
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/NeedBracesTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/NeedBracesTest.java
@@ -1,3 +1,22 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
 
 package net.sf.eclipsecs.ui.quickfixes.blocks;
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/DefaultComesLastTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/DefaultComesLastTest.java
@@ -1,3 +1,22 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
 
 package net.sf.eclipsecs.ui.quickfixes.coding;
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/EmptyStatementTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/EmptyStatementTest.java
@@ -1,3 +1,22 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
 
 package net.sf.eclipsecs.ui.quickfixes.coding;
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/ExplicitInitializationTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/ExplicitInitializationTest.java
@@ -1,3 +1,23 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
+
 package net.sf.eclipsecs.ui.quickfixes.coding;
 
 import org.junit.jupiter.api.Test;

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/FinalLocalVariableTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/FinalLocalVariableTest.java
@@ -1,3 +1,22 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
 
 package net.sf.eclipsecs.ui.quickfixes.coding;
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/MissingSwitchDefaultTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/MissingSwitchDefaultTest.java
@@ -1,3 +1,22 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
 
 package net.sf.eclipsecs.ui.quickfixes.coding;
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/RequireThisTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/RequireThisTest.java
@@ -1,3 +1,23 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
+
 package net.sf.eclipsecs.ui.quickfixes.coding;
 
 import org.junit.jupiter.api.Test;

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnTest.java
@@ -1,3 +1,23 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
+
 package net.sf.eclipsecs.ui.quickfixes.coding;
 
 import org.junit.jupiter.api.Test;

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithBooleanLiteralCondition.xml
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithBooleanLiteralCondition.xml
@@ -6,7 +6,7 @@ public class A {
     public boolean foo() {
         if (true) {
             return true;
-        } else { 
+        } else {
             return false;
         }
     }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithCurlyBraces.xml
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithCurlyBraces.xml
@@ -6,7 +6,7 @@ public class A {
     public boolean foo() {
         if (1 > 2) {
             return true;
-        } else { 
+        } else {
             return false;
         }
     }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithFieldAccessCondition.xml
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithFieldAccessCondition.xml
@@ -7,7 +7,7 @@ public class A {
     public boolean foo() {
         if (this.b) {
             return true;
-        } else { 
+        } else {
             return false;
         }
     }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithMethodInvocationCondition.xml
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithMethodInvocationCondition.xml
@@ -7,7 +7,7 @@ public class A {
     public boolean foo() {
         if (foo()) {
             return true;
-        } else { 
+        } else {
             return false;
         }
     }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithNotCondition.xml
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithNotCondition.xml
@@ -6,7 +6,7 @@ public class Boolean {
     public boolean foo() {
         if (!true) {
             return true;
-        } else { 
+        } else {
             return false;
         }
     }
@@ -26,7 +26,7 @@ public class Boolean {
     public boolean foo() {
         if (!true) {
             return false;
-        } else { 
+        } else {
             return true;
         }
     }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithParanthesizedExpressionCondition.xml
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithParanthesizedExpressionCondition.xml
@@ -7,7 +7,7 @@ public class A {
     public boolean foo() {
         if (b) {
             return true;
-        } else { 
+        } else {
             return false;
         }
     }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithQualifiedNameCondition.xml
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithQualifiedNameCondition.xml
@@ -6,7 +6,7 @@ public class A {
     public boolean foo() {
         if (B.b) {
             return true;
-        } else { 
+        } else {
             return false;
         }
     }
@@ -32,7 +32,7 @@ public class A {
     public boolean foo() {
         if (B.b) {
             return false;
-        } else { 
+        } else {
             return true;
         }
     }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithSimpleNameCondition.xml
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithSimpleNameCondition.xml
@@ -7,7 +7,7 @@ public class A {
     public boolean foo() {
         if ((a | b)) {
             return true;
-        } else { 
+        } else {
             return false;
         }
     }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithSuperFieldAccessCondition.xml
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithSuperFieldAccessCondition.xml
@@ -6,7 +6,7 @@ public class A extends B {
     public boolean foo() {
         if (super.b) {
             return true;
-        } else { 
+        } else {
             return false;
         }
     }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithSuperMethodInvocationCondition.xml
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithSuperMethodInvocationCondition.xml
@@ -6,7 +6,7 @@ public class A extends B {
     public boolean foo() {
         if (super.bar()) {
             return true;
-        } else { 
+        } else {
             return false;
         }
     }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithThisExpressionCondition.xml
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithThisExpressionCondition.xml
@@ -6,7 +6,7 @@ public class Boolean {
     public boolean foo() {
         if (Boolean.this) {
             return true;
-        } else { 
+        } else {
             return false;
         }
     }
@@ -26,7 +26,7 @@ public class Boolean {
     public boolean foo() {
         if (Boolean.this) {
             return false;
-        } else { 
+        } else {
             return true;
         }
     }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithoutCurlyBraces.xml
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnWithoutCurlyBraces.xml
@@ -6,7 +6,7 @@ public class A {
     public boolean foo() {
         if (1 > 2)
             return true;
-        else 
+        else
             return false;
     }
 }
@@ -25,7 +25,7 @@ public class A {
     public boolean foo() {
         if (1 > 2)
             return false;
-        else 
+        else
             return true;
     }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityTest.java
@@ -1,3 +1,22 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
 
 package net.sf.eclipsecs.ui.quickfixes.coding;
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/DesignForExtensionTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/DesignForExtensionTest.java
@@ -1,3 +1,22 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
 
 package net.sf.eclipsecs.ui.quickfixes.design;
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/FinalClassTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/FinalClassTest.java
@@ -1,3 +1,22 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
 
 package net.sf.eclipsecs.ui.quickfixes.design;
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/ArrayTypeStyleTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/ArrayTypeStyleTest.java
@@ -1,3 +1,22 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
 
 package net.sf.eclipsecs.ui.quickfixes.misc;
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/FinalParametersTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/FinalParametersTest.java
@@ -1,3 +1,22 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
 
 package net.sf.eclipsecs.ui.quickfixes.misc;
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UncommentedMainTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UncommentedMainTest.java
@@ -1,3 +1,22 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
 
 package net.sf.eclipsecs.ui.quickfixes.misc;
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UpperEllTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UpperEllTest.java
@@ -1,3 +1,22 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
 
 package net.sf.eclipsecs.ui.quickfixes.misc;
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/ModifierOrderTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/ModifierOrderTest.java
@@ -1,3 +1,22 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
 
 package net.sf.eclipsecs.ui.quickfixes.modifier;
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/RedundantModifierTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/RedundantModifierTest.java
@@ -1,3 +1,22 @@
+//============================================================================
+//
+// Copyright (C) 2003-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+//============================================================================
 
 package net.sf.eclipsecs.ui.quickfixes.modifier;
 


### PR DESCRIPTION
Reenable checkstyle checks on test code, and convert JUnit assertions to AssertJ. See commit messages for more details.