### PR TITLE
Fix build order

### DIFF
--- a/net.sf.eclipsecs.checkstyle/pom.xml
+++ b/net.sf.eclipsecs.checkstyle/pom.xml
@@ -9,40 +9,28 @@
     <artifactId>net.sf.eclipsecs.checkstyle</artifactId>
     <packaging>eclipse-plugin</packaging>
     <name>Checkstyle Core Library Plugin</name>
-    
+
     <properties>
         <checkstyle.version>10.10.0</checkstyle.version>
     </properties>
     <build>
         <plugins>
             <plugin>
-                <groupId>com.googlecode.maven-download-plugin</groupId>
-                <artifactId>download-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>download-checkstyle-src</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>wget</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>.</outputDirectory>
-                            <url>https://github.com/checkstyle/checkstyle/archive/checkstyle-${checkstyle.version}.zip</url>
-                            <outputFileName>checkstyle-checkstyle-${checkstyle.version}.zip</outputFileName>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>        
-            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>prepare-package</phase>
+                        <id>repackage-checkstyle-source</id>
+                        <phase>generate-sources</phase>
                         <configuration>
                             <target>
+                                <get src="https://github.com/checkstyle/checkstyle/archive/checkstyle-${checkstyle.version}.zip"
+                                     dest="${basedir}/checkstyle-${checkstyle.version}.zip"
+                                     verbose="false"
+                                     usetimestamp="true"/>
                                 <delete dir="${project.build.directory}/checkstyle-src-unpack" />
                                 <delete dir="${project.build.directory}/checkstyle-src" />
-                                <unzip src="checkstyle-checkstyle-${checkstyle.version}.zip" dest="${project.build.directory}/checkstyle-src-unpack">
+                                <unzip src="checkstyle-${checkstyle.version}.zip" dest="${project.build.directory}/checkstyle-src-unpack">
                                     <patternset>
                                         <include name="**/src/main/java/**" />
                                         <include name="**/src/main/resources/**" />

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,6 @@
 
     <properties>
         <build-helper-maven-plugin-version>3.4.0</build-helper-maven-plugin-version>
-        <download-maven-plugin-version>1.7.1</download-maven-plugin-version>
         <exec-maven-plugin-version>3.1.0</exec-maven-plugin-version>
 
         <!-- Maven JUnit version must fit the JUnit version used in the target platform, otherwise Surefire may produce exceptions -->


### PR DESCRIPTION
The unpacking previously happened in the prepage-package lifecycle phase of maven. That's far too late, since other compilation steps require those sources. I had multiple failing local builds because of this.

Until now this only worked correctly because either
* the eclipse builder would compile the depending sources again when the maven build unpacked everything
* the maven build was not fast enough in parallel processing
* the sources were still available locally from the last download, when not using clean in between

Also ensure the order of download and unpack is correct by converting the download to an Ant task and moving it into the same execution. As a side effect, this avoids the download progress messages of the previous download-maven-plugin.