### PR TITLE
infra: clean up build goals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,27 +138,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                      <phase>verify</phase>
-                      <goals>
-                        <goal>exec</goal>
-                      </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <executable>git</executable>
-                    <arguments>
-                      <argument>diff</argument>
-                      <argument>HEAD~1</argument>
-                      <argument>HEAD</argument>
-                    </arguments>
-                    <outputFile>${maven.multiModuleProjectDirectory}/show.patch</outputFile>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <executions>
                     <execution>
@@ -294,6 +273,13 @@
                             <generate>true</generate>
                         </sourceReferences>
                     </configuration>
+                    <executions>
+                        <!-- disable default goal for consumer POMs, we don't need that -->
+                        <execution>
+                            <id>default-update-consumer-pom</id>
+                            <phase>none</phase>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.eclipse.tycho</groupId>
@@ -513,4 +499,44 @@
             </plugins>
         </pluginManagement>
     </build>
+    <profiles>
+        <profile>
+            <id>git-patch</id>
+            <!-- This POM is both parent and reactor, therefore all plugins in the build section will be executed for all modules.
+            By checking for the existence of the README, we limit the execution of this profile to the parent only, thereby creating the patch only once.
+            TODO: In the long run, we should probably split parent and reactor into 2 POM files instead. -->
+            <activation>
+                <file>
+                    <exists>README.md</exists>
+                </file>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>create-git-patch-file</id>
+                                <!-- must be earlier than the phase we bind the checkstyle goal to -->
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <executable>git</executable>
+                            <arguments>
+                                <argument>diff</argument>
+                                <argument>HEAD~1</argument>
+                                <argument>HEAD</argument>
+                            </arguments>
+                            <outputFile>${maven.multiModuleProjectDirectory}/show.patch</outputFile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
* disable a tycho goal which we don't need
* execute the patch creation only once overall, not for each module

Fixes #616 