### PR TITLE
normalize feature.xml to current format

### DIFF
--- a/net.sf.eclipsecs-feature/feature.xml
+++ b/net.sf.eclipsecs-feature/feature.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feature version="10.12.3.qualifier"
+<feature
       id="net.sf.eclipsecs"
       label="%feature.label"
+      version="10.12.3.qualifier"
       provider-name="%feature.provider_name"
       plugin="net.sf.eclipsecs.branding">
 
@@ -37,35 +38,22 @@
 
    <plugin
          id="net.sf.eclipsecs.branding"
-         download-size="0"
-         install-size="0"
-         version="10.12.3.qualifier"
-         unpack="false"/>
+         version="10.12.3.qualifier"/>
 
    <plugin
          id="net.sf.eclipsecs.core"
-         download-size="0"
-         install-size="0"
-         version="10.12.3.qualifier"
-         unpack="true"/>
+         version="10.12.3.qualifier"/>
 
    <plugin
          id="net.sf.eclipsecs.doc"
-         download-size="0"
-         install-size="0"
-         version="10.12.3.qualifier"
-         unpack="false"/>
+         version="10.12.3.qualifier"/>
 
    <plugin
          id="net.sf.eclipsecs.checkstyle"
-         download-size="0"
-         install-size="0"
          version="10.12.3.qualifier"/>
 
    <plugin
          id="net.sf.eclipsecs.ui"
-         download-size="0"
-         install-size="0"
          version="10.12.3.qualifier"/>
 
 </feature>


### PR DESCRIPTION
The feature.xml serialization was changed in Eclipse 4.30: https://eclipse.dev/eclipse/news/4.30/pde.php#unnecessary-attributes-removal

This change just stores the feature.xml without any changes, to avoid confusion in the future by other editors when doing actual changes.