### PR TITLE
limit Java EE version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,6 +390,9 @@
                                 <rules>
                                     <banDuplicatePomDependencyVersions/>
                                     <requireExplicitDependencyScope/>
+                                    <requireJavaVersion>
+                                        <version>[11,18)</version>
+                                    </requireJavaVersion>
                                     <requireMavenVersion>
                                         <version>${maven-version}</version>
                                     </requireMavenVersion>


### PR DESCRIPTION
The Tycho build cannot be run on a Java 21 EE. Document that by means of a Maven enforcer rule (even though Tycho will fail earlier than the rule would be applied).

Can be reverted with the upgrade to a new Tycho major version.