### PR TITLE
improve documentation

### DIFF
--- a/docs/googlea9a1beab32866ee0.html
+++ b/docs/googlea9a1beab32866ee0.html
@@ -1,1 +1,0 @@
-google-site-verification: googlea9a1beab32866ee0.html

--- a/docs/index.html
+++ b/docs/index.html
@@ -78,7 +78,6 @@
       <div id="main" role="main" data-ng-view=""> </div>
     </div>
     <!--  javascript -->
-    <!-- script src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script> -->
     <script src="3rd-party/angular-1.2.26/angular.min.js" data-semver="1.2.26" data-require="angular.js@1.2.x"></script>
     <script src="3rd-party/angular-1.2.26/angular-animate.min.js" data-semver="1.2.26" data-require="angular.js@1.2.x"></script>
     <script src="3rd-party/angular-1.2.26/angular-route.min.js" data-semver="1.2.26" data-require="angular.js@1.2.x"></script>

--- a/docs/partials/builtin-config.html
+++ b/docs/partials/builtin-config.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Provide a custom built-in configuration</h1>
     <p>By providing an <a href="#!/extensions">extension plugin</a> Eclipse Checkstyle enables you to roll out an immutable
         Checkstyle configuration to your team members.<br/> This is especially powerful if you distribute your plugin

--- a/docs/partials/builtin-config.html
+++ b/docs/partials/builtin-config.html
@@ -2,10 +2,10 @@
     <!-- <div data-google-ad=""/> -->
 
     <h1>Provide a custom built-in configuration</h1>
-    <p>By providing a <a href="#!/extensions">extension plugin</a> the eclipse-cs enables you to roll out a immutable
+    <p>By providing an <a href="#!/extensions">extension plugin</a> Eclipse Checkstyle enables you to roll out an immutable
         Checkstyle configuration to your team members.<br/> This is especially powerful if you distribute your plugin
-        via a corporate update site</p>
-    <p>You can provide such a built-in configuration by the use of the <code>net.sf.eclipsecs.core.configurations</code>
+        via a corporate update site.</p>
+    <p>You can provide such a built-in configuration by extending the <code>net.sf.eclipsecs.core.configurations</code>
         extension point.</p>
     <p>Simply put your configuration file into the root of the extension plugin project and add a similar entry (see
         example below) to your <code>plugin.xml</code>. <br/>

--- a/docs/partials/configtypes.html
+++ b/docs/partials/configtypes.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Configuration types</h1>
     <p>The Eclipse Checkstyle Plugin uses plain standard Checkstyle configuration files. For easier reuse of existing
         Checkstyle configurations and to support some common use cases different Configuration types were introduced

--- a/docs/partials/custom-checks.html
+++ b/docs/partials/custom-checks.html
@@ -4,7 +4,7 @@
     <h1>Providing custom Checkstyle checks</h1>
     <p> One great feature of Checkstyle is its extensibility. You can easily write own checks as explained <a
             target="_blank" href="https://checkstyle.org/writingchecks.html">here <i
-                class="fa fa-external-link"> </i></a> . <br/> To hook your checks into the eclipse-cs plugin you need to
+                class="fa fa-external-link"> </i></a>. <br/> To hook your checks into the eclipse-cs plugin you need to
         provide them as a extension plugin. </p>
     <p> In the further steps I am - for the sake of simplicity - assuming that you start off with the <a
             href="#!/extensions">sample plugin</a> the eclipse-cs project provides. <br/> If not then you are supposedly
@@ -48,7 +48,7 @@
                         <code>checkstyle_packages.xml</code> file (see point 2). </strong>
                 <br/> The metadata file must adhere to this dtd: <a target="_blank"
                     href="https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd"
-                    >https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd</a> . <br/> So it would be a
+                    >https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd</a>. <br/> So it would be a
                 good idea to include this document type declaration to your metadata file: </p>
             <pre><code>&lt;!DOCTYPE checkstyle-metadata
     PUBLIC &quot;-//eclipse-cs//DTD Check Metadata 1.1//EN&quot;

--- a/docs/partials/custom-checks.html
+++ b/docs/partials/custom-checks.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Providing custom Checkstyle checks</h1>
     <p> One great feature of Checkstyle is its extensibility. You can easily write own checks as explained <a
             target="_blank" href="https://checkstyle.org/writingchecks.html">here <i

--- a/docs/partials/custom-config.html
+++ b/docs/partials/custom-config.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Creating a custom Checkstyle configuration</h1>
 
     <p>The built-in configurations that ship with the plugin will only get you so far. Chances are that you will require

--- a/docs/partials/custom-filters.html
+++ b/docs/partials/custom-filters.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Custom plugin filters</h1>
     <p>As you surely know by now, the Eclipse Checkstyle Plug-in sports filters to exclude files from the checks.<br/>
         These filters are available on the plug-ins project properties page.</p>

--- a/docs/partials/extensions.html
+++ b/docs/partials/extensions.html
@@ -1,7 +1,7 @@
 <div class="container">
     <!-- <div data-google-ad=""/> -->
 
-    <h1>Extending the Eclipse Checkstyle Plugin</h1>
+    <h1>Extending Eclipse Checkstyle</h1>
     <p>The Checkstyle core and the eclipse-cs plugin can be extended to add one or more of the following artifacts: </p>
     <ul>
         <li>
@@ -18,7 +18,7 @@
         not as complicated as it sounds.</p>
     <p> The easiest way is to check out the sample eclipse-cs extension plugin from the Git repository, this sample
         plugin provides an example for each documented extension hook.</p>
-    <p>The repository location is: <code>https://github.com/checkstyle/eclipse-cs.git</code><br/>The project to check out is:
+    <p>The repository location is: <code>https://github.com/checkstyle/eclipse-cs.git</code>.<br/>The project to check out is:
             <code>net.sf.eclipsecs.sample</code></p>
     <p>After you got the project in your workspace you can just disconnect it from the Git and rename the project and
         the plugins symbolic bundle name in <code>META-INF/MANIFEST.MF</code> to your liking.</p>

--- a/docs/partials/extensions.html
+++ b/docs/partials/extensions.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Extending Eclipse Checkstyle</h1>
     <p>The Checkstyle core and the eclipse-cs plugin can be extended to add one or more of the following artifacts: </p>
     <ul>

--- a/docs/partials/faq.html
+++ b/docs/partials/faq.html
@@ -29,5 +29,5 @@
     <p><b>A:</b>
         <br/> Yes, checking such a project takes some time and memory resources. <br/> You should try to decrease the
         number of files that are actually checked by using <a href="advanced_file_sets.html">file sets</a> and <a
-            data-ng-href="#advanced_filters.html">filter</a> .</p>
+            data-ng-href="#advanced_filters.html">filter</a>.</p>
 </div>

--- a/docs/partials/faq.html
+++ b/docs/partials/faq.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Frequently Asked Questions</h1>
     <p>If you feel there is a very obvious, essential question missing please drop us a note on the forums or enter a
         bug report.</p>

--- a/docs/partials/filesets.html
+++ b/docs/partials/filesets.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Configuring file sets</h1>
     <p>In the <a href="#!/project-setup">getting started section</a> we configured our project using the simple
         configuration approach. <br/> With the simple configuration all files in your project get checked by the same

--- a/docs/partials/filters.html
+++ b/docs/partials/filters.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Restrict Checkstyle validation using project filters</h1>
     <p>The Eclipse Checkstyle Plugin contains a filter facility to exclude certain files from Checkstyle. <br/> Knowing
         that the plug-in allows you to configure file sets you might ask why there are also filters. <br/> This feature

--- a/docs/partials/filters.html
+++ b/docs/partials/filters.html
@@ -79,5 +79,5 @@
 
     <p>The Eclipse Checkstyle Plugin provides an extension point for custom filters which can be used to implement
         your own filter. Read <a href="#!/custom-filters">here</a> for more info about <a href="#!/custom-filters"
-            >extending the plugin with filters</a> .</p>
+            >extending the plugin with filters</a>.</p>
 </div>

--- a/docs/partials/google-ad.html
+++ b/docs/partials/google-ad.html
@@ -1,7 +1,0 @@
-<div>
-    <div data-ng-show="showAd" class="container ad-container">
-        <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-9204862326418919"
-            data-ad-slot="7685742630" data-ad-format="auto"/>
-    </div>
-    <hr data-ng-show="showAd"/>
-</div>

--- a/docs/partials/index.html
+++ b/docs/partials/index.html
@@ -45,21 +45,7 @@
         </div>
     </div>
 
-    <!--div data-google-ad=""/> -->
-
     <div class="container">
-        <div class="row">
-            <div class="alert alert-warning text-center">
-                <p class="lead text-danger">
-                    <a href="https://sourceforge.net/p/eclipse-cs/discussion/274376/thread/3b44a5eb/?limit=25#977e">
-                        <i class="fa fa-2x fa-exclamation-triangle ">
-                        </i>
-                        Help keeping this project afloat!
-
-                    </a>
-                </p>
-            </div>
-        </div>
         <div class="row">
             <div class="col-md-4">
                 <h2>What is it?</h2>

--- a/docs/partials/index.html
+++ b/docs/partials/index.html
@@ -24,8 +24,8 @@
                     <small>
                         <sup>1 </sup>
                         Install via Eclipse Marketplace. Drag and drop this link into a running Eclipse
-                        (2021-06 or higher version) workspace. Latest release 10.12.6, based on Checkstyle 10.12.0, see
-                        <a href="#!/releasenotes">release notes</a>
+                        (2021-06 or higher version) workspace. Latest release 10.12.6, see
+                        <a href="#!/releasenotes">release notes</a>.
                     </small>
                 </div>
                 <div id="award-badge" class="col-md-2 panel panel-default" style="margin-top: 20px;">
@@ -73,7 +73,7 @@
                     </a>
                     into the Eclipse IDE.
                     <br />
-                    Checkstyle is a Open Source development tool to help you
+                    Checkstyle is an Open Source development tool to help you
                     ensure that your Java code adheres to a set
                     of coding standards. Checkstyle does this by inspecting
                     your Java source code and pointing out items
@@ -172,8 +172,7 @@
                             <br />
                             A short introduction into creating your own Checkstyle configurations can be
                             found
-                            <a href="#!/custom-config">here</a>
-                            .
+                            <a href="#!/custom-config">here</a>.
                         </p>
                     </div>
                 </div>

--- a/docs/partials/install.html
+++ b/docs/partials/install.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Installation</h1>
     <p>The following section describes various ways to install the Eclipse Checkstyle Plugin.</p>
 

--- a/docs/partials/install.html
+++ b/docs/partials/install.html
@@ -17,12 +17,12 @@
                 <li>Drag&amp;Drop the link above to a running Eclipse instance (2021-06 or higher version). This will trigger the
                     Eclipse Marketplace client with the Eclipse Checkstyle Plugin being pre-selected for
                     installation.</li>
-                <li>Confirm the selection of features to install</li>
-                <li>Read/accept the license terms</li>
-                <li>Eclipse will now download the necessary files</li>
+                <li>Confirm the selection of features to install.</li>
+                <li>Read/accept the license terms.</li>
+                <li>Eclipse will now download the necessary files.</li>
                 <li>After all file have been downloaded, Eclipse will ask about installing unsigned content. If you're
                     ok with that accept.</li>
-                <li>After installation you will be promted for a restart of Eclipse, which is recommended</li>
+                <li>After installation you will be prompted for a restart of Eclipse, which is recommended.</li>
 
             </ol>
         </div>
@@ -32,8 +32,8 @@
         <div class="panel-heading">Via Eclipse Marketplace client</div>
         <div class="panel-body">
             <ol>
-                <li>Launch the Marketplace client within Eclipse (<em>Help -> Eclipse Marketplace...</em>)</li>
-                <li>Search for the solution to install, e.g. <em>Checkstyle</em> and click <em>Install</em></li>
+                <li>Launch the Marketplace client within Eclipse (<em>Help -> Eclipse Marketplace...</em>).</li>
+                <li>Search for the solution to install, e.g. <em>Checkstyle</em> and click <em>Install</em>.</li>
                 <li>Conclude the installation as described above.</li>
             </ol>
         </div>
@@ -45,8 +45,8 @@
             <ol>
                 <li>Within Eclipse go to: <em>Help -> Install New Software...</em></li>
                 <li>Enter the following update site url: <code>https://checkstyle.org/eclipse-cs-update-site</code></li>
-                <li>Select the Eclipse Checkstyle Plugin feature to install</li>
-                <li>Conclude the installation as described above</li>
+                <li>Select the Eclipse Checkstyle Plugin feature to install.</li>
+                <li>Conclude the installation as described above.</li>
             </ol>
         </div>
     </div>

--- a/docs/partials/preferences.html
+++ b/docs/partials/preferences.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Advanced Preference Settings</h1>
     <p>This page explains the meaning of the other preferences on the plugin's preference page.</p>
     <p>

--- a/docs/partials/project-setup.html
+++ b/docs/partials/project-setup.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Setting up a project</h1>
     <p>To get your files checked by Checkstyle there are a few simple steps set up the Checkstyle plug-in for your
         project.</p>

--- a/docs/partials/project-setup.html
+++ b/docs/partials/project-setup.html
@@ -57,7 +57,7 @@
         <h3>Congratulations!</h3>
         <p>You audited your first eclipse project with Checkstyle. <br/> Now you surely want to know how to change the
             rules for the audit to accommodate your own (or your companies) coding style. <br/> Read on in the <a
-                href="#!/custom-config">next chapter</a> . <br/>
+                href="#!/custom-config">next chapter</a>. <br/>
         </p>
     </div>
 </div>

--- a/docs/partials/properties.html
+++ b/docs/partials/properties.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Property expansion in Checkstyle configuration files</h1>
     <p>Checkstyle contains a <a target="_blank" href="https://checkstyle.org/config.html#Properties">feature
                 <i class="fa fa-external-link"> </i></a> that lets you define module properties in a way that they can

--- a/docs/partials/releasenotes.html
+++ b/docs/partials/releasenotes.html
@@ -1,26 +1,4 @@
 <div class="container" data-ng-controller="ReleaseNotesCtrl">
-    <!-- <div data-google-ad=""/> -->
-
-    <div class="alert alert-info">
-        The slow rate of recent updates is owed to a shift in personal interest and how I spend my spare
-        time.
-        <p>
-            If you want to help keep this project afloat and steadily updated please send me a message or
-            <a href="https://sourceforge.net/p/eclipse-cs/discussion/274376/thread/3b44a5eb/">post to the
-                forums
-            </a>
-            .
-        </p>
-        <p>
-            Additionally activity has started to migrate the project to Github (
-            <a href="https://github.com/checkstyle/eclipse-cs">eclipse-cs Github page</a>
-            ), hoping this will make it easier for contributions.
-            Code and issue tracking have already been moved, other facilities will
-            follow over the course of the next weeks.
-        </p>
-        -- Lars
-    </div>
-
     <h1>Release notes <button class="btn btn-primary btn-sm" data-ng-click="expandAll()"><i class="fa fa-plus-square-o"
             > </i> Expand all</button></h1>
     <accordion data-close-others="false">

--- a/docs/partials/releases/5.6.0/release_notes.html
+++ b/docs/partials/releases/5.6.0/release_notes.html
@@ -4,7 +4,7 @@
         <br/> Other changes: <br/> The plugins internal handling of extension plugins has been changed to not rely on
         buddy-classloading anymore. Immediate action from extension providers is not required since the old way of
         intergration still works. However, certain usecases (providing custom quickfixes) only work with the new way of
-        setup. <br/> Please check out the updated docs <a href="#!/custom-checks">here</a> . The sample extension project
+        setup. <br/> Please check out the updated docs <a href="#!/custom-checks">here</a>. The sample extension project
         in CVS has been updated as well. <br/>
         <br/> I have given the plugin a short spin on the "new" Juno release of Eclipse (4.2), which seemed to work fine
         so far. </p>

--- a/docs/releases.json
+++ b/docs/releases.json
@@ -66,253 +66,203 @@
   },
   {
     "version": "Release 10.8.1",
-    "template": "partials/releases/10.8.1/release_notes.html",
-    "open": true
+    "template": "partials/releases/10.8.1/release_notes.html"
   },
   {
     "version": "Release 10.8.0",
-    "template": "partials/releases/10.8.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/10.8.0/release_notes.html"
   },
   {
     "version": "Release 10.7.0",
-    "template": "partials/releases/10.7.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/10.7.0/release_notes.html"
   },
   {
     "version": "Release 10.6.0",
-    "template": "partials/releases/10.6.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/10.6.0/release_notes.html"
   },
   {
     "version": "Release 10.5.0",
-    "template": "partials/releases/10.5.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/10.5.0/release_notes.html"
   },
   {
     "version": "Release 10.4.0",
-    "template": "partials/releases/10.4.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/10.4.0/release_notes.html"
   },
   {
     "version": "Release 10.3.4",
-    "template": "partials/releases/10.3.4/release_notes.html",
-    "open": true
+    "template": "partials/releases/10.3.4/release_notes.html"
   },
   {
     "version": "Release 10.3.3",
-    "template": "partials/releases/10.3.3/release_notes.html",
-    "open": true
+    "template": "partials/releases/10.3.3/release_notes.html"
   },
   {
     "version": "Release 10.3.2",
-    "template": "partials/releases/10.3.2/release_notes.html",
-    "open": true
+    "template": "partials/releases/10.3.2/release_notes.html"
   },
   {
     "version": "Release 10.3.1",
-    "template": "partials/releases/10.3.1/release_notes.html",
-    "open": true
+    "template": "partials/releases/10.3.1/release_notes.html"
   },
   {
     "version": "Release 10.3.0",
-    "template": "partials/releases/10.3.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/10.3.0/release_notes.html"
   },
   {
     "version": "Release 10.2.0",
-    "template": "partials/releases/10.2.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/10.2.0/release_notes.html"
   },
   {
     "version": "Release 10.1.0",
-    "template": "partials/releases/10.1.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/10.1.0/release_notes.html"
   },
   {
     "version": "Release 10.0.0",
-    "template": "partials/releases/10.0.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/10.0.0/release_notes.html"
   },
   {
     "version": "Release 9.3.0",
-    "template": "partials/releases/9.3.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/9.3.0/release_notes.html"
   },
   {
     "version": "Release 9.2.1",
-    "template": "partials/releases/9.2.1/release_notes.html",
-    "open": true
+    "template": "partials/releases/9.2.1/release_notes.html"
   },
   {
     "version": "Release 9.2.0",
-    "template": "partials/releases/9.2.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/9.2.0/release_notes.html"
   },
   {
     "version": "Release 9.1.0",
-    "template": "partials/releases/9.1.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/9.1.0/release_notes.html"
   },
   {
     "version": "Release 9.0.1",
-    "template": "partials/releases/9.0.1/release_notes.html",
-    "open": true
+    "template": "partials/releases/9.0.1/release_notes.html"
   },
   {
     "version": "Release 9.0.0",
-    "template": "partials/releases/9.0.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/9.0.0/release_notes.html"
   },
   {
     "version": "Release 8.45.1",
-    "template": "partials/releases/8.45.1/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.45.1/release_notes.html"
   },
   {
     "version": "Release 8.45.0",
-    "template": "partials/releases/8.45.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.45.0/release_notes.html"
   },
   {
     "version": "Release 8.44.0",
-    "template": "partials/releases/8.44.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.44.0/release_notes.html"
   },
   {
     "version": "Release 8.43.0",
-    "template": "partials/releases/8.43.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.43.0/release_notes.html"
   },
   {
     "version": "Release 8.42.0",
-    "template": "partials/releases/8.42.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.42.0/release_notes.html"
   },
   {
     "version": "Release 8.41.1",
-    "template": "partials/releases/8.41.1/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.41.1/release_notes.html"
   },
   {
     "version": "Release 8.41.0",
-    "template": "partials/releases/8.41.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.41.0/release_notes.html"
   },
   {
     "version": "Release 8.40.0",
-    "template": "partials/releases/8.40.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.40.0/release_notes.html"
   },
   {
     "version": "Release 8.39.0",
-    "template": "partials/releases/8.39.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.39.0/release_notes.html"
   },
   {
     "version": "Release 8.38.0",
-    "template": "partials/releases/8.38.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.38.0/release_notes.html"
   },
   {
     "version": "Release 8.37.0",
-    "template": "partials/releases/8.37.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.37.0/release_notes.html"
   },
   {
     "version": "Release 8.36.2",
-    "template": "partials/releases/8.36.2/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.36.2/release_notes.html"
   },
   {
     "version": "Release 8.36.1",
-    "template": "partials/releases/8.36.1/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.36.1/release_notes.html"
   },
   {
     "version": "Release 8.35.0",
-    "template": "partials/releases/8.35.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.35.0/release_notes.html"
   },
   {
     "version": "Release 8.34.0",
-    "template": "partials/releases/8.34.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.34.0/release_notes.html"
   },
   {
     "version": "Release 8.33.0",
-    "template": "partials/releases/8.33.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.33.0/release_notes.html"
   },
   {
     "version": "Release 8.32.0",
-    "template": "partials/releases/8.32.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.32.0/release_notes.html"
   },
   {
     "version": "Release 8.31.0",
-    "template": "partials/releases/8.31.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.31.0/release_notes.html"
   },
   {
     "version": "Release 8.30.0",
-    "template": "partials/releases/8.30.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.30.0/release_notes.html"
   },
   {
     "version": "Release 8.29.0",
-    "template": "partials/releases/8.29.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.29.0/release_notes.html"
   },
   {
     "version": "Release 8.28.0",
-    "template": "partials/releases/8.28.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.28.0/release_notes.html"
   },
   {
     "version": "Release 8.27.0",
-    "template": "partials/releases/8.27.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.27.0/release_notes.html"
   },
   {
     "version": "Release 8.26.0",
-    "template": "partials/releases/8.26.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.26.0/release_notes.html"
   },
   {
     "version": "Release 8.25.0",
-    "template": "partials/releases/8.25.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.25.0/release_notes.html"
   },
   {
     "version": "Release 8.24.0",
-    "template": "partials/releases/8.24.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.24.0/release_notes.html"
   },
   {
     "version": "Release 8.23.0",
-    "template": "partials/releases/8.23.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.23.0/release_notes.html"
   },
   {
     "version": "Release 8.22.0",
-    "template": "partials/releases/8.22.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.22.0/release_notes.html"
   },
   {
     "version": "Release 8.21.0",
-    "template": "partials/releases/8.21.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.21.0/release_notes.html"
   },
   {
     "version": "Release 8.20.0",
-    "template": "partials/releases/8.20.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.20.0/release_notes.html"
   },
   {
     "version": "Release 8.19.0",
-    "template": "partials/releases/8.19.0/release_notes.html",
-    "open": true
+    "template": "partials/releases/8.19.0/release_notes.html"
   },
   {
     "version": "Release 8.18.0",
@@ -353,7 +303,7 @@
   {
     "version": "Release 8.10.0",
     "template": "partials/releases/8.10.0/release_notes.html"
-  }, 
+  },
   {
     "version": "Release 8.8.0",
     "template": "partials/releases/8.8.0/release_notes.html"
@@ -361,11 +311,11 @@
   {
     "version": "Release 8.7.0",
     "template": "partials/releases/8.7.0/release_notes.html"
-  }, 
+  },
   {
     "version": "Release 8.5.1",
     "template": "partials/releases/8.5.1/release_notes.html"
-  }, 
+  },
   {
     "version": "Release 8.5.0",
     "template": "partials/releases/8.5.0/release_notes.html"

--- a/net.sf.eclipsecs.doc/src/main/resources/googlea9a1beab32866ee0.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/googlea9a1beab32866ee0.html
@@ -1,1 +1,0 @@
-google-site-verification: googlea9a1beab32866ee0.html

--- a/net.sf.eclipsecs.doc/src/main/resources/index.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/index.html
@@ -78,7 +78,6 @@
       <div id="main" role="main" data-ng-view=""> </div>
     </div>
     <!--  javascript -->
-    <!-- script src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script> -->
     <script src="3rd-party/angular-1.2.26/angular.min.js" data-semver="1.2.26" data-require="angular.js@1.2.x"></script>
     <script src="3rd-party/angular-1.2.26/angular-animate.min.js" data-semver="1.2.26" data-require="angular.js@1.2.x"></script>
     <script src="3rd-party/angular-1.2.26/angular-route.min.js" data-semver="1.2.26" data-require="angular.js@1.2.x"></script>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/builtin-config.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/builtin-config.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Provide a custom built-in configuration</h1>
     <p>By providing an <a href="#!/extensions">extension plugin</a> Eclipse Checkstyle enables you to roll out an immutable
         Checkstyle configuration to your team members.<br/> This is especially powerful if you distribute your plugin

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/builtin-config.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/builtin-config.html
@@ -2,10 +2,10 @@
     <!-- <div data-google-ad=""/> -->
 
     <h1>Provide a custom built-in configuration</h1>
-    <p>By providing a <a href="#!/extensions">extension plugin</a> the eclipse-cs enables you to roll out a immutable
+    <p>By providing an <a href="#!/extensions">extension plugin</a> Eclipse Checkstyle enables you to roll out an immutable
         Checkstyle configuration to your team members.<br/> This is especially powerful if you distribute your plugin
-        via a corporate update site</p>
-    <p>You can provide such a built-in configuration by the use of the <code>net.sf.eclipsecs.core.configurations</code>
+        via a corporate update site.</p>
+    <p>You can provide such a built-in configuration by extending the <code>net.sf.eclipsecs.core.configurations</code>
         extension point.</p>
     <p>Simply put your configuration file into the root of the extension plugin project and add a similar entry (see
         example below) to your <code>plugin.xml</code>. <br/>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/configtypes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/configtypes.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Configuration types</h1>
     <p>The Eclipse Checkstyle Plugin uses plain standard Checkstyle configuration files. For easier reuse of existing
         Checkstyle configurations and to support some common use cases different Configuration types were introduced

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/custom-checks.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/custom-checks.html
@@ -4,7 +4,7 @@
     <h1>Providing custom Checkstyle checks</h1>
     <p> One great feature of Checkstyle is its extensibility. You can easily write own checks as explained <a
             target="_blank" href="https://checkstyle.org/writingchecks.html">here <i
-                class="fa fa-external-link"> </i></a> . <br/> To hook your checks into the eclipse-cs plugin you need to
+                class="fa fa-external-link"> </i></a>. <br/> To hook your checks into the eclipse-cs plugin you need to
         provide them as a extension plugin. </p>
     <p> In the further steps I am - for the sake of simplicity - assuming that you start off with the <a
             href="#!/extensions">sample plugin</a> the eclipse-cs project provides. <br/> If not then you are supposedly
@@ -48,7 +48,7 @@
                         <code>checkstyle_packages.xml</code> file (see point 2). </strong>
                 <br/> The metadata file must adhere to this dtd: <a target="_blank"
                     href="https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd"
-                    >https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd</a> . <br/> So it would be a
+                    >https://checkstyle.org/eclipse-cs/dtds/checkstyle-metadata_1_1.dtd</a>. <br/> So it would be a
                 good idea to include this document type declaration to your metadata file: </p>
             <pre><code>&lt;!DOCTYPE checkstyle-metadata
     PUBLIC &quot;-//eclipse-cs//DTD Check Metadata 1.1//EN&quot;

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/custom-checks.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/custom-checks.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Providing custom Checkstyle checks</h1>
     <p> One great feature of Checkstyle is its extensibility. You can easily write own checks as explained <a
             target="_blank" href="https://checkstyle.org/writingchecks.html">here <i

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/custom-config.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/custom-config.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Creating a custom Checkstyle configuration</h1>
 
     <p>The built-in configurations that ship with the plugin will only get you so far. Chances are that you will require

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/custom-filters.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/custom-filters.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Custom plugin filters</h1>
     <p>As you surely know by now, the Eclipse Checkstyle Plug-in sports filters to exclude files from the checks.<br/>
         These filters are available on the plug-ins project properties page.</p>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/extensions.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/extensions.html
@@ -1,7 +1,7 @@
 <div class="container">
     <!-- <div data-google-ad=""/> -->
 
-    <h1>Extending the Eclipse Checkstyle Plugin</h1>
+    <h1>Extending Eclipse Checkstyle</h1>
     <p>The Checkstyle core and the eclipse-cs plugin can be extended to add one or more of the following artifacts: </p>
     <ul>
         <li>
@@ -18,7 +18,7 @@
         not as complicated as it sounds.</p>
     <p> The easiest way is to check out the sample eclipse-cs extension plugin from the Git repository, this sample
         plugin provides an example for each documented extension hook.</p>
-    <p>The repository location is: <code>https://github.com/checkstyle/eclipse-cs.git</code><br/>The project to check out is:
+    <p>The repository location is: <code>https://github.com/checkstyle/eclipse-cs.git</code>.<br/>The project to check out is:
             <code>net.sf.eclipsecs.sample</code></p>
     <p>After you got the project in your workspace you can just disconnect it from the Git and rename the project and
         the plugins symbolic bundle name in <code>META-INF/MANIFEST.MF</code> to your liking.</p>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/extensions.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/extensions.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Extending Eclipse Checkstyle</h1>
     <p>The Checkstyle core and the eclipse-cs plugin can be extended to add one or more of the following artifacts: </p>
     <ul>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/faq.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/faq.html
@@ -29,5 +29,5 @@
     <p><b>A:</b>
         <br/> Yes, checking such a project takes some time and memory resources. <br/> You should try to decrease the
         number of files that are actually checked by using <a href="advanced_file_sets.html">file sets</a> and <a
-            data-ng-href="#advanced_filters.html">filter</a> .</p>
+            data-ng-href="#advanced_filters.html">filter</a>.</p>
 </div>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/faq.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/faq.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Frequently Asked Questions</h1>
     <p>If you feel there is a very obvious, essential question missing please drop us a note on the forums or enter a
         bug report.</p>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/filesets.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/filesets.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Configuring file sets</h1>
     <p>In the <a href="#!/project-setup">getting started section</a> we configured our project using the simple
         configuration approach. <br/> With the simple configuration all files in your project get checked by the same

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/filters.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/filters.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Restrict Checkstyle validation using project filters</h1>
     <p>The Eclipse Checkstyle Plugin contains a filter facility to exclude certain files from Checkstyle. <br/> Knowing
         that the plug-in allows you to configure file sets you might ask why there are also filters. <br/> This feature

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/filters.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/filters.html
@@ -79,5 +79,5 @@
 
     <p>The Eclipse Checkstyle Plugin provides an extension point for custom filters which can be used to implement
         your own filter. Read <a href="#!/custom-filters">here</a> for more info about <a href="#!/custom-filters"
-            >extending the plugin with filters</a> .</p>
+            >extending the plugin with filters</a>.</p>
 </div>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/google-ad.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/google-ad.html
@@ -1,7 +1,0 @@
-<div>
-    <div data-ng-show="showAd" class="container ad-container">
-        <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-9204862326418919"
-            data-ad-slot="7685742630" data-ad-format="auto"/>
-    </div>
-    <hr data-ng-show="showAd"/>
-</div>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/index.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/index.html
@@ -45,21 +45,7 @@
         </div>
     </div>
 
-    <!--div data-google-ad=""/> -->
-
     <div class="container">
-        <div class="row">
-            <div class="alert alert-warning text-center">
-                <p class="lead text-danger">
-                    <a href="https://sourceforge.net/p/eclipse-cs/discussion/274376/thread/3b44a5eb/?limit=25#977e">
-                        <i class="fa fa-2x fa-exclamation-triangle ">
-                        </i>
-                        Help keeping this project afloat!
-
-                    </a>
-                </p>
-            </div>
-        </div>
         <div class="row">
             <div class="col-md-4">
                 <h2>What is it?</h2>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/index.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/index.html
@@ -24,8 +24,8 @@
                     <small>
                         <sup>1 </sup>
                         Install via Eclipse Marketplace. Drag and drop this link into a running Eclipse
-                        (2021-06 or higher version) workspace. Latest release 10.12.6, based on Checkstyle 10.12.0, see
-                        <a href="#!/releasenotes">release notes</a>
+                        (2021-06 or higher version) workspace. Latest release 10.12.6, see
+                        <a href="#!/releasenotes">release notes</a>.
                     </small>
                 </div>
                 <div id="award-badge" class="col-md-2 panel panel-default" style="margin-top: 20px;">
@@ -73,7 +73,7 @@
                     </a>
                     into the Eclipse IDE.
                     <br />
-                    Checkstyle is a Open Source development tool to help you
+                    Checkstyle is an Open Source development tool to help you
                     ensure that your Java code adheres to a set
                     of coding standards. Checkstyle does this by inspecting
                     your Java source code and pointing out items
@@ -172,8 +172,7 @@
                             <br />
                             A short introduction into creating your own Checkstyle configurations can be
                             found
-                            <a href="#!/custom-config">here</a>
-                            .
+                            <a href="#!/custom-config">here</a>.
                         </p>
                     </div>
                 </div>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/install.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/install.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Installation</h1>
     <p>The following section describes various ways to install the Eclipse Checkstyle Plugin.</p>
 

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/install.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/install.html
@@ -17,12 +17,12 @@
                 <li>Drag&amp;Drop the link above to a running Eclipse instance (2021-06 or higher version). This will trigger the
                     Eclipse Marketplace client with the Eclipse Checkstyle Plugin being pre-selected for
                     installation.</li>
-                <li>Confirm the selection of features to install</li>
-                <li>Read/accept the license terms</li>
-                <li>Eclipse will now download the necessary files</li>
+                <li>Confirm the selection of features to install.</li>
+                <li>Read/accept the license terms.</li>
+                <li>Eclipse will now download the necessary files.</li>
                 <li>After all file have been downloaded, Eclipse will ask about installing unsigned content. If you're
                     ok with that accept.</li>
-                <li>After installation you will be promted for a restart of Eclipse, which is recommended</li>
+                <li>After installation you will be prompted for a restart of Eclipse, which is recommended.</li>
 
             </ol>
         </div>
@@ -32,8 +32,8 @@
         <div class="panel-heading">Via Eclipse Marketplace client</div>
         <div class="panel-body">
             <ol>
-                <li>Launch the Marketplace client within Eclipse (<em>Help -> Eclipse Marketplace...</em>)</li>
-                <li>Search for the solution to install, e.g. <em>Checkstyle</em> and click <em>Install</em></li>
+                <li>Launch the Marketplace client within Eclipse (<em>Help -> Eclipse Marketplace...</em>).</li>
+                <li>Search for the solution to install, e.g. <em>Checkstyle</em> and click <em>Install</em>.</li>
                 <li>Conclude the installation as described above.</li>
             </ol>
         </div>
@@ -45,8 +45,8 @@
             <ol>
                 <li>Within Eclipse go to: <em>Help -> Install New Software...</em></li>
                 <li>Enter the following update site url: <code>https://checkstyle.org/eclipse-cs-update-site</code></li>
-                <li>Select the Eclipse Checkstyle Plugin feature to install</li>
-                <li>Conclude the installation as described above</li>
+                <li>Select the Eclipse Checkstyle Plugin feature to install.</li>
+                <li>Conclude the installation as described above.</li>
             </ol>
         </div>
     </div>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/preferences.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/preferences.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Advanced Preference Settings</h1>
     <p>This page explains the meaning of the other preferences on the plugin's preference page.</p>
     <p>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/project-setup.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/project-setup.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Setting up a project</h1>
     <p>To get your files checked by Checkstyle there are a few simple steps set up the Checkstyle plug-in for your
         project.</p>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/project-setup.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/project-setup.html
@@ -57,7 +57,7 @@
         <h3>Congratulations!</h3>
         <p>You audited your first eclipse project with Checkstyle. <br/> Now you surely want to know how to change the
             rules for the audit to accommodate your own (or your companies) coding style. <br/> Read on in the <a
-                href="#!/custom-config">next chapter</a> . <br/>
+                href="#!/custom-config">next chapter</a>. <br/>
         </p>
     </div>
 </div>

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/properties.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/properties.html
@@ -1,6 +1,4 @@
 <div class="container">
-    <!-- <div data-google-ad=""/> -->
-
     <h1>Property expansion in Checkstyle configuration files</h1>
     <p>Checkstyle contains a <a target="_blank" href="https://checkstyle.org/config.html#Properties">feature
                 <i class="fa fa-external-link"> </i></a> that lets you define module properties in a way that they can

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releasenotes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releasenotes.html
@@ -1,26 +1,4 @@
 <div class="container" data-ng-controller="ReleaseNotesCtrl">
-    <!-- <div data-google-ad=""/> -->
-
-    <div class="alert alert-info">
-        The slow rate of recent updates is owed to a shift in personal interest and how I spend my spare
-        time.
-        <p>
-            If you want to help keep this project afloat and steadily updated please send me a message or
-            <a href="https://sourceforge.net/p/eclipse-cs/discussion/274376/thread/3b44a5eb/">post to the
-                forums
-            </a>
-            .
-        </p>
-        <p>
-            Additionally activity has started to migrate the project to Github (
-            <a href="https://github.com/checkstyle/eclipse-cs">eclipse-cs Github page</a>
-            ), hoping this will make it easier for contributions.
-            Code and issue tracking have already been moved, other facilities will
-            follow over the course of the next weeks.
-        </p>
-        -- Lars
-    </div>
-
     <h1>Release notes <button class="btn btn-primary btn-sm" data-ng-click="expandAll()"><i class="fa fa-plus-square-o"
             > </i> Expand all</button></h1>
     <accordion data-close-others="false">

--- a/net.sf.eclipsecs.doc/src/main/resources/partials/releases/5.6.0/release_notes.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/partials/releases/5.6.0/release_notes.html
@@ -4,7 +4,7 @@
         <br/> Other changes: <br/> The plugins internal handling of extension plugins has been changed to not rely on
         buddy-classloading anymore. Immediate action from extension providers is not required since the old way of
         intergration still works. However, certain usecases (providing custom quickfixes) only work with the new way of
-        setup. <br/> Please check out the updated docs <a href="#!/custom-checks">here</a> . The sample extension project
+        setup. <br/> Please check out the updated docs <a href="#!/custom-checks">here</a>. The sample extension project
         in CVS has been updated as well. <br/>
         <br/> I have given the plugin a short spin on the "new" Juno release of Eclipse (4.2), which seemed to work fine
         so far. </p>

--- a/net.sf.eclipsecs.doc/toc.xml
+++ b/net.sf.eclipsecs.doc/toc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?NLS TYPE="org.eclipse.help.toc"?>
 
-<toc label="Checkstyle Plug-in" topic="docs/index.html">
+<toc label="Eclipse Checkstyle" topic="docs/index.html">
     <topic label="Getting Started">
         <topic label="Setting up a project" href="docs/index.html#!/project-setup"/>
         <topic label="Creating a checkstyle configuration" href="docs/index.html#!/custom-config"/>
@@ -13,7 +13,7 @@
         <topic label="Expanding properties" href="docs/index.html#!/properties"/>
         <topic label="Advanced Preferences" href="docs/index.html#!/preferences"/>
     </topic>
-    <topic label="Extending the Checkstyle Plug-in">
+    <topic label="Extending Eclipse Checkstyle">
         <topic label="Building an extension plugin" href="docs/index.html#!/extensions"/>
         <topic label="Custom Checkstyle modules" href="docs/index.html#!/custom-checks"/>
         <topic label="Providing a built-in configuration" href="docs/index.html#!/builtin-config"/>


### PR DESCRIPTION
* rename eclipse-cs to Eclipse Checkstyle in documentation
* fix typos, wording, typography
* remove "based on Checkstyle x.y.z" since that is always the exact same version now
* remove project help alert from the time when the project was transferred
* remove all Google Ads related code