### PR TITLE
infra: avoid outdated local checkstyle ZIPs

### DIFF
--- a/net.sf.eclipsecs.checkstyle/pom.xml
+++ b/net.sf.eclipsecs.checkstyle/pom.xml
@@ -24,6 +24,10 @@
                         <phase>generate-sources</phase>
                         <configuration>
                             <target>
+                                <!-- delete all the outdated ZIPs before downloading the current -->
+                                <delete>
+                                    <fileset dir="${basedir}" includes="checkstyle-*.zip" excludes="checkstyle-${checkstyle.version}.zip"/>
+                                </delete>
                                 <get src="https://github.com/checkstyle/checkstyle/archive/checkstyle-${checkstyle.version}.zip"
                                      dest="${basedir}/checkstyle-${checkstyle.version}.zip"
                                      verbose="false"


### PR DESCRIPTION
After version upgrades outdated ZIP files from former versions can remain in the local git repository. Get rid of all but the current version when building.

I've noticed these outdated ZIPs several times and instead of continuing to manually delete them, this now automates their deletion.