### PR TITLE
Wrong context help for some uncategorized checks

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/MarkerHelpContextProvider.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/MarkerHelpContextProvider.java
@@ -99,7 +99,7 @@ public class MarkerHelpContextProvider extends AbstractContextProvider
     }
     var group = metadata.getGroup().getGroupId().toLowerCase();
     // some web pages are different to the packages in Checkstyle
-    if ("indentation".equals(group)) {
+    if ("indentation".equals(group) || StringUtils.isEmpty(group)) {
       group = "misc";
     }
     var file = moduleName.toLowerCase();


### PR DESCRIPTION
Some checks have no category and need to be redirected to "misc". Example: UpperEll would wrongly try to open `https://checkstyle.org/checks//upperell.html`. Note the double slash where the category is missing.