### PR TITLE
Lift Java version requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -392,7 +392,7 @@
                                     <banDuplicatePomDependencyVersions/>
                                     <requireExplicitDependencyScope/>
                                     <requireJavaVersion>
-                                        <version>[11,18)</version>
+                                        <version>[17,)</version>
                                     </requireJavaVersion>
                                     <requireMavenVersion>
                                         <version>${maven-version}</version>


### PR DESCRIPTION
The minimum version of 17 is needed since a while and should have been changed with the Tycho 4 upgrade already. The previous limit of the upper version is no longer needed, all involved tools work fine with 21.

Noticed because my personal default Java is 21 meanwhile, and the build would stop there, for no good reason.