### PR TITLE
ClassCastException in "Apply all fixes"

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/FixCheckstyleMarkersJob.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/FixCheckstyleMarkersJob.java
@@ -65,8 +65,7 @@ public class FixCheckstyleMarkersJob extends UIJob {
 
       for (int i = 0; i < markers.length; i++) {
 
-        ICheckstyleMarkerResolution[] resolutions = (ICheckstyleMarkerResolution[]) generator
-                .getResolutions(markers[i]);
+        var resolutions = generator.getResolutions(markers[i]);
 
         if (resolutions.length > 0) {
           // only run the first fix for this marker


### PR DESCRIPTION
The code contained an unchecked cast, and the declaration of the called method had changed in the past, therefore making this incompatible. With the change the menu works fine in a file with multiple fixable violations.

```
java.lang.ClassCastException: class [Lorg.eclipse.ui.IMarkerResolution; cannot be cast to class
[Lnet.sf.eclipsecs.ui.quickfixes.ICheckstyleMarkerResolution; ([Lorg.eclipse.ui.IMarkerResolution; is in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @6be67f3a; [Lnet.sf.eclipsecs.ui.quickfixes.ICheckstyleMarkerResolution; is in unnamed module of loader
org.eclipse.osgi.internal.loader.EquinoxClassLoader @138bfa5)
	at net.sf.eclipsecs.ui.quickfixes.FixCheckstyleMarkersJob.runInUIThread(FixCheckstyleMarkersJob.java:68)
	at org.eclipse.ui.progress.UIJob.lambda$0(UIJob.java:95)
```