### PR TITLE
Multiple Maven fixes

### DIFF
--- a/net.sf.eclipsecs-updatesite/pom.xml
+++ b/net.sf.eclipsecs-updatesite/pom.xml
@@ -130,7 +130,7 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.eclipse.tycho.extras</groupId>
+                        <groupId>org.eclipse.tycho</groupId>
                         <artifactId>tycho-eclipserun-plugin</artifactId>
                         <configuration>
                             <repositories>

--- a/net.sf.eclipsecs.target/Maven update check.launch
+++ b/net.sf.eclipsecs.target/Maven update check.launch
@@ -2,7 +2,7 @@
 <launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
     <intAttribute key="M2_COLORS" value="0"/>
     <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
-    <stringAttribute key="M2_GOALS" value="versions:display-dependency-updates versions:display-plugin-updates -Dtycho.mode=maven -T1"/>
+    <stringAttribute key="M2_GOALS" value="versions:display-dependency-updates versions:display-plugin-updates -T1"/>
     <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
     <booleanAttribute key="M2_OFFLINE" value="false"/>
     <stringAttribute key="M2_PROFILES" value=""/>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <maven-resources-plugin-version>3.3.1</maven-resources-plugin-version>
         <maven-site-plugin-version>3.12.1</maven-site-plugin-version>
         <maven-surefire-plugin-version>3.2.5</maven-surefire-plugin-version>
-        <maven-version>3.6.3</maven-version>
+        <maven-version>3.9.0</maven-version>
         <tycho-version>4.0.6</tycho-version>
         <versions-maven-plugin-version>2.16.2</versions-maven-plugin-version>
 
@@ -239,7 +239,7 @@
                     </executions>
                 </plugin>
                 <plugin>
-                    <groupId>org.eclipse.tycho.extras</groupId>
+                    <groupId>org.eclipse.tycho</groupId>
                     <artifactId>tycho-eclipserun-plugin</artifactId>
                     <version>${tycho-version}</version>
                 </plugin>


### PR DESCRIPTION
* require Maven 3.9.0, as that is the minimum version required by the Maven plugins that we use
* remove tycho.mode system property, it's deprecated
* relocate the eclipse-run plugin, it's published under the tycho namespace, not the tycho.extras namespace anymore