### PR TITLE
Fix new violations

### DIFF
--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ConfigurationWriter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ConfigurationWriter.java
@@ -66,7 +66,7 @@ public final class ConfigurationWriter {
 
     // write an empty list of modules
     // mandatory modules are added automatically
-    write(out, new ArrayList<Module>(), checkConfig);
+    write(out, new ArrayList<>(), checkConfig);
   }
 
   /**
@@ -141,8 +141,6 @@ public final class ConfigurationWriter {
   private static void writeModule(Module module, Branch parent, Severity parentSeverity,
           List<Module> remainingModules) {
 
-    Severity severity = parentSeverity;
-
     // remove this module from the list of modules to write
     remainingModules.remove(module);
 
@@ -161,6 +159,7 @@ public final class ConfigurationWriter {
     }
 
     // Write severity only if it differs from the parents severity
+    Severity severity = parentSeverity;
     if (module.getSeverity() != null && !Severity.inherit.equals(module.getSeverity())) {
 
       Element propertyEl = moduleEl.addElement(XMLTags.PROPERTY_TAG);

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/PackageFilterEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/PackageFilterEditor.java
@@ -488,8 +488,11 @@ public class PackageFilterEditor implements IFilterEditor {
     protected Control createDialogArea(Composite parent) {
       Composite composite = (Composite) super.createDialogArea(parent);
       Label messageLabel = createMessageArea(composite);
-      CheckboxTreeViewer treeViewer = createTreeViewer(composite);
+      if (mIsEmpty) {
+        messageLabel.setEnabled(false);
+      }
 
+      CheckboxTreeViewer treeViewer = createTreeViewer(composite);
       GridData data = new GridData(GridData.FILL_BOTH);
       data.widthHint = convertWidthInCharsToPixels(mWidth);
       data.heightHint = convertHeightInCharsToPixels(mHeight);
@@ -497,7 +500,6 @@ public class PackageFilterEditor implements IFilterEditor {
       treeWidget.setLayoutData(data);
       treeWidget.setFont(parent.getFont());
       if (mIsEmpty) {
-        messageLabel.setEnabled(false);
         treeWidget.setEnabled(false);
       }
       return composite;

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityQuickfix.java
@@ -72,8 +72,6 @@ public class StringLiteralEqualityQuickfix extends AbstractASTResolution {
             return true;
           }
 
-          Expression replacementNode = null;
-
           MethodInvocation equalsInvocation = node.getAST().newMethodInvocation();
           equalsInvocation.setName(node.getAST().newSimpleName("equals")); //$NON-NLS-1$
           equalsInvocation.setExpression((Expression) ASTNode.copySubtree(node.getAST(), literal));
@@ -81,6 +79,7 @@ public class StringLiteralEqualityQuickfix extends AbstractASTResolution {
 
           // if the string was compared with != create a not
           // expression
+          final Expression replacementNode;
           if (node.getOperator().equals(InfixExpression.Operator.NOT_EQUALS)) {
             PrefixExpression prefixExpression = node.getAST().newPrefixExpression();
             prefixExpression.setOperator(PrefixExpression.Operator.NOT);


### PR DESCRIPTION
These violations are shown with the most recent 10.14.1 by the eclipse plugin itself (because there was a fix in the "maximum distance between declaration and first usage" check), but are not part of the github verification due to an older version being used there.
@rnveach I guess we still can't do anything about upgrading that 10.4 version in the build? I don't remember exactly but I believe you had told me about either the filters or sevntu project being an issue there.