### PR TITLE
Correctly look up metadata from checkstyle marker

### DIFF
--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.Element;
@@ -186,10 +187,19 @@ public final class MetadataFactory {
             packageTokens[packageTokens.length - 1], MetadataFactory.getDefaultSeverity(),
             false, true, true, false, group);
     ruleMeta.setDescription(moduleDetails.getDescription());
+
+    var altName = moduleDetails.getFullQualifiedName();
+    registerAlternative(altName, ruleMeta);
+
     moduleDetails.getProperties().forEach(modulePropertyDetails -> ruleMeta.getPropertyMetadata()
             .add(createPropertyConfig(moduleDetails, modulePropertyDetails)));
 
     return ruleMeta;
+  }
+
+  private static void registerAlternative(String alternativeName, RuleMetadata ruleMetadata) {
+    ruleMetadata.addAlternativeName(alternativeName);
+    sAlternativeNamesMap.put(alternativeName, ruleMetadata);
   }
 
   /**
@@ -551,12 +561,9 @@ public final class MetadataFactory {
    * @return
    */
   private static String groupId(String metadataFile) {
-    var start = metadataFile.indexOf("checks/") + 7;
-    var end = metadataFile.lastIndexOf("/");
-    if (start >= end) {
-      return "";
-    }
-    return metadataFile.substring(start, end);
+    String res = StringUtils.substringBetween(metadataFile, "/checks/", "/");
+    res = StringUtils.defaultString(res, metadataFile);
+    return res;
   }
 
   /**
@@ -745,10 +752,7 @@ public final class MetadataFactory {
       for (Element altNameEl : moduleEl.elements(XMLTags.ALTERNATIVE_NAME_TAG)) {
 
         String alternativeName = altNameEl.attributeValue(XMLTags.INTERNAL_NAME_TAG);
-
-        // register alternative name
-        sAlternativeNamesMap.put(alternativeName, module);
-        module.addAlternativeName(alternativeName);
+        registerAlternative(alternativeName, module);
       }
 
       // process message keys


### PR DESCRIPTION
Rule metadata is registered only under the short name of the rule. But markers created for checkstyle violations use the fully qualified name of the checker class instead. Register the fully qualified name as alternative name in the metadata, and the lookup from a stored marker works as expected.

Fixes #397

Looks like this on a stored marker _without running a new analysis_:
![grafik](https://github.com/checkstyle/eclipse-cs/assets/406876/3e546c62-d2b0-458d-9226-77119bd6051a)

Before the fix it would just say "Other" and not find a description.