### PR TITLE
selectable marker properties

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/marker/MarkerPropertyPage.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/marker/MarkerPropertyPage.java
@@ -22,16 +22,15 @@ package net.sf.eclipsecs.ui.properties.marker;
 
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.PropertyPage;
@@ -71,7 +70,7 @@ public class MarkerPropertyPage extends PropertyPage {
               getSeverityImage(getIssue().getAttribute(IMarker.SEVERITY, -1)));
       new Label(composite, SWT.NONE).setText(Messages.MarkerPropertyPage_Issue);
       String message = (String) getIssue().getAttribute(IMarker.MESSAGE);
-      Label labelMessage = new Label(composite, SWT.NONE);
+      Text labelMessage = new Text(composite, SWT.WRAP | SWT.READ_ONLY);
       labelMessage.setText(message);
 
       new Label(composite, SWT.NONE).setImage(
@@ -80,26 +79,15 @@ public class MarkerPropertyPage extends PropertyPage {
 
       String moduleName = (String) getIssue().getAttribute(CheckstyleMarker.MODULE_NAME);
       RuleMetadata metaData = MetadataFactory.getRuleMetadata(moduleName);
-      new Label(composite, SWT.NONE).setText(metaData.getGroup().getGroupName());
+      Text labelGroupName = new Text(composite, SWT.WRAP | SWT.READ_ONLY);
+      labelGroupName.setText(metaData.getGroup().getGroupName());
 
       new Label(composite, SWT.NONE).setImage(
               CheckstyleUIPluginImages.MODULE_ICON.getImage());
       new Label(composite, SWT.NONE).setText(Messages.MarkerPropertyPage_Module);
 
-      RowLayout rowLayout = new RowLayout(SWT.HORIZONTAL);
-      rowLayout.marginLeft = 0;
-      rowLayout.marginTop = 0;
-      rowLayout.marginBottom = 0;
-      rowLayout.marginRight = 0;
-      Composite nameComposite = new Composite(composite, SWT.NONE);
-      nameComposite.setLayout(rowLayout);
-
-      new Label(nameComposite, SWT.NONE).setText(metaData.getRuleName());
-
-      Label helpIcon = new Label(nameComposite, SWT.NONE);
-      helpIcon.setImage(CheckstyleUIPluginImages.HELP_ICON.getImage());
-      helpIcon.setToolTipText(NLS.bind(Messages.MarkerPropertyPage_SuppressionHint,
-              metaData.getInternalName()));
+      Text labelRuleName = new Text(composite, SWT.WRAP | SWT.READ_ONLY);
+      labelRuleName.setText(metaData.getRuleName());
 
       Label descriptionLabel = new Label(composite, SWT.NONE);
       descriptionLabel.setText(Messages.MarkerPropertyPage_Description);


### PR DESCRIPTION
* convert the marker property labels to selectable text, similar like it is in most file and resource property pages
* remove the suppression help icon (functionality will come back as explicit suppression action in a separate change)

You can now select the text with the mouse:
![grafik](https://github.com/checkstyle/eclipse-cs/assets/406876/c2cb9841-a9b1-432e-827f-92c19ec22160)
