### PR TITLE
only scan relevant classpaths for metadata

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -396,6 +396,12 @@
             <message key="import.illegal"
                      value="Use org.assertj.core.api.Assertions instead."/>
         </module>
+        <module name="IllegalImport">
+            <property name="illegalPkgs"
+                      value="org.reflections"/>
+            <message key="import.illegal"
+                     value="Use io.github.classgraph.ClassGraph instead."/>
+        </module>
         <module name="ImportControl">
             <property name="id" value="ImportControlMain"/>
             <property name="file" value="${checkstyle.importcontrol.file}"/>

--- a/net.sf.eclipsecs.core/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.core/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Bundle-ClassPath: .,
 Bundle-Activator: net.sf.eclipsecs.core.CheckstylePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Bundle-Vendor
-Require-Bundle: net.sf.eclipsecs.checkstyle;visibility:=reexport
+Require-Bundle: net.sf.eclipsecs.checkstyle;visibility:=reexport,
+ io.github.classgraph.classgraph;bundle-version="4.8.168"
 Eclipse-BuddyPolicy: registered
 Export-Package: net.sf.eclipsecs.core,
  net.sf.eclipsecs.core.builder,

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Eclipse Checkstyle" sequenceNumber="1710065411">
+<target name="Eclipse Checkstyle" sequenceNumber="1711958226">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.jdt.feature.group" version="3.18.1300.v20220831-1800"/>
@@ -37,54 +37,64 @@
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220830213456/repository"/>
     </location>
     <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="SnakeYaml">
-    <dependencies>
-    	<dependency>
-    		<groupId>org.yaml</groupId>
-    		<artifactId>snakeyaml</artifactId>
-    		<version>2.2</version>
-    		<type>jar</type>
-    	</dependency>
-    </dependencies>
+      <dependencies>
+        <dependency>
+          <groupId>org.yaml</groupId>
+          <artifactId>snakeyaml</artifactId>
+          <version>2.2</version>
+          <type>jar</type>
+        </dependency>
+      </dependencies>
     </location>
     <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="Javassist">
-    <dependencies>
-    	<dependency>
-    		<groupId>org.javassist</groupId>
-    		<artifactId>javassist</artifactId>
-    		<version>3.29.2-GA</version>
-    		<type>jar</type>
-    	</dependency>
-    </dependencies>
+      <dependencies>
+        <dependency>
+          <groupId>org.javassist</groupId>
+          <artifactId>javassist</artifactId>
+          <version>3.29.2-GA</version>
+          <type>jar</type>
+        </dependency>
+      </dependencies>
     </location>
     <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="DOM4J">
-    <dependencies>
-    	<dependency>
-    		<groupId>org.dom4j</groupId>
-    		<artifactId>dom4j</artifactId>
-    		<version>2.1.4</version>
-    		<type>jar</type>
-    	</dependency>
-    </dependencies>
+      <dependencies>
+        <dependency>
+          <groupId>org.dom4j</groupId>
+          <artifactId>dom4j</artifactId>
+          <version>2.1.4</version>
+          <type>jar</type>
+        </dependency>
+      </dependencies>
+    </location>
+    <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="Classgraph">
+      <dependencies>
+        <dependency>
+          <groupId>io.github.classgraph</groupId>
+          <artifactId>classgraph</artifactId>
+          <version>4.8.168</version>
+          <type>jar</type>
+        </dependency>
+      </dependencies>
     </location>
     <location includeDependencyDepth="direct" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="AssertJ">
-    <dependencies>
-    	<dependency>
-    		<groupId>org.assertj</groupId>
-    		<artifactId>assertj-core</artifactId>
-    		<version>3.25.1</version>
-    		<type>jar</type>
-    	</dependency>
-    </dependencies>
+      <dependencies>
+        <dependency>
+          <groupId>org.assertj</groupId>
+          <artifactId>assertj-core</artifactId>
+          <version>3.25.1</version>
+          <type>jar</type>
+        </dependency>
+      </dependencies>
     </location>
     <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="ApacheCommons">
-    <dependencies>
-    	<dependency>
-    		<groupId>org.apache.commons</groupId>
-    		<artifactId>commons-lang3</artifactId>
-    		<version>3.14.0</version>
-    		<type>jar</type>
-    	</dependency>
-    </dependencies>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+          <version>3.14.0</version>
+          <type>jar</type>
+        </dependency>
+      </dependencies>
     </location>
   </locations>
   <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
@@ -71,6 +71,18 @@ maven AssertJ
 		version="3.25.1"
 	}
 }
+maven Classgraph
+	scope=compile
+	dependencyDepth=none
+	missingManifest=generate
+	includeSources
+{
+	dependency {
+		groupId="io.github.classgraph"
+		artifactId="classgraph"
+		version="4.8.168"
+	}
+}
 maven DOM4J
 	scope=compile
 	dependencyDepth=none


### PR DESCRIPTION
* don't scan the com.* package hierarchy
* calculate the common root packages of all known packages with checks and metadata instead
* scans only the ...puppycrawl... and net.fs...samplechecks packages in a default developer runtime now

This still finds all relevant metadata files, but takes 480 ms instead of 12 seconds on my laptop.

fixes #515