### PR TITLE
Add sevntu to target platform

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -402,6 +402,12 @@
             <message key="import.illegal"
                      value="Use io.github.classgraph.ClassGraph instead."/>
         </module>
+        <module name="IllegalImport">
+            <property name="illegalPkgs"
+                      value="com.github.sevntu"/>
+            <message key="import.illegal"
+                     value="The sevntu plugin is only available for debugging. Don''t reference it anywhere in our code."/>
+        </module>
         <module name="ImportControl">
             <property name="id" value="ImportControlMain"/>
             <property name="file" value="${checkstyle.importcontrol.file}"/>

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Eclipse Checkstyle" sequenceNumber="1711958226">
+<target name="Eclipse Checkstyle" sequenceNumber="1711962228">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.jdt.feature.group" version="3.18.1300.v20220831-1800"/>
@@ -35,6 +35,10 @@
       <unit id="org.objectweb.asm" version="9.3.0.v20220409-0157"/>
       <unit id="org.objectweb.asm.tree" version="9.3.0.v20220409-0157"/>
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220830213456/repository"/>
+    </location>
+    <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="com.github.sevntu.checkstyle.checks.feature.feature.group" version="1.44.1"/>
+      <repository location="https://sevntu-checkstyle.github.io/sevntu.checkstyle/update-site/"/>
     </location>
     <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="SnakeYaml">
       <dependencies>

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
@@ -45,6 +45,11 @@ location "https://download.eclipse.org/tools/orbit/downloads/drops/R202208302134
 	org.objectweb.asm.tree
 }
 
+// include sevntu plugin, so we can test it easily when launching a debug runtime
+location "https://sevntu-checkstyle.github.io/sevntu.checkstyle/update-site/" {
+	com.github.sevntu.checkstyle.checks.feature.feature.group
+}
+
 // If the following part has errors and no syntax highlighting, then please use Help>About>Installation>Installed Software>Target Platform DSL>Uninstall.
 // After restarting please install the current version from the URL in line 1.
 maven ApacheCommons


### PR DESCRIPTION
This adds the sevntu plugin to the target platform. That way launching a debug runtime from the IDE automatically includes sevntu. Have a checkstyle import check to avoid anyone referencing code from the sevntu plugin.

Be aware that this PR includes #681, because changes on the generated .target file are _always_ conflicting. Therefore 681 should be merged first, and then this PR.