### PR TITLE
Remove duplicate checkstyle.jar

### DIFF
--- a/net.sf.eclipsecs.checkstyle/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.checkstyle/META-INF/MANIFEST.MF
@@ -7,6 +7,9 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: .,
+ com.google.common.base,
+ com.google.common.cache,
+ com.google.common.io,
  com.puppycrawl.tools.checkstyle,
  com.puppycrawl.tools.checkstyle.api;
   uses:="org.xml.sax.helpers,
@@ -31,7 +34,9 @@ Export-Package: .,
  com.puppycrawl.tools.checkstyle.checks.whitespace,
  com.puppycrawl.tools.checkstyle.filefilters,
  com.puppycrawl.tools.checkstyle.filters,
- com.puppycrawl.tools.checkstyle.utils
+ com.puppycrawl.tools.checkstyle.meta,
+ com.puppycrawl.tools.checkstyle.utils,
+ org.apache.commons.lang3
 Bundle-ClassPath: .,
  checkstyle-10.14.2-all.jar
 Automatic-Module-Name: net.sf.eclipsecs.checkstyle

--- a/net.sf.eclipsecs.core/.classpath
+++ b/net.sf.eclipsecs.core/.classpath
@@ -7,6 +7,5 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="lib" path="lib/checkstyle-10.14.2-all.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/net.sf.eclipsecs.core/.gitignore
+++ b/net.sf.eclipsecs.core/.gitignore
@@ -1,0 +1,2 @@
+# only the eclipsecs.checkstyle project shall contain a copy of the checkstyle jar
+**/checkstyle*.jar

--- a/net.sf.eclipsecs.core/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.core/META-INF/MANIFEST.MF
@@ -4,8 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: net.sf.eclipsecs.core;singleton:=true
 Bundle-Version: 10.14.2.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Bundle-ClassPath: .,
- lib/checkstyle-10.14.2-all.jar
+Bundle-ClassPath: .
 Bundle-Activator: net.sf.eclipsecs.core.CheckstylePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Bundle-Vendor

--- a/net.sf.eclipsecs.core/build.properties
+++ b/net.sf.eclipsecs.core/build.properties
@@ -2,10 +2,8 @@ source.. = src/
 jars.compile.order = .
 bin.includes = .,\
                META-INF/,\
-               lib/,\
                license/,\
                plugin.xml,\
                schema/,\
-               lib/checkstyle-10.14.2-all.jar,\
                OSGI-INF/
 javacDefaultEncoding.. = UTF-8

--- a/upgrade-version.build.xml
+++ b/upgrade-version.build.xml
@@ -52,9 +52,7 @@ Apply all necessary manual code changes now.
 
 		<!-- download new version -->
 		<get src="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${toVersion}/checkstyle-${toVersion}-all.jar"
-		     dest="${basedir}/net.sf.eclipsecs.checkstyle/checkstyle-${toVersion}-all.jar"/>
-		<copy file="${basedir}/net.sf.eclipsecs.checkstyle/checkstyle-${toVersion}-all.jar"
-		     tofile="${basedir}/net.sf.eclipsecs.core/lib/checkstyle-${toVersion}-all.jar"/>
+			dest="${basedir}/net.sf.eclipsecs.checkstyle/checkstyle-${toVersion}-all.jar"/>
 	</target>
 
 </project>


### PR DESCRIPTION
* remove and gitignore the checkstyle.jar in eclipsecs.core
* have only the copy in eclipsecs.checkstyle remain
* export packages of transitive dependencies from the eclipsecs.checkstyle project. this is not a good practice, but represents exactly what happened before: consuming the third party dependencies from the checkstyle library

fixes #385

In a follow-up change the re-exported packages should be removed, and instead be replaced by taking the respective libraries into the target platform.

Please be aware this change is based on #684 and #681, therefore those should be merged first.