### PR TITLE
Revert "remove duplicate checkstyle.jar"

### DIFF
--- a/net.sf.eclipsecs.checkstyle/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.checkstyle/META-INF/MANIFEST.MF
@@ -7,9 +7,6 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: .,
- com.google.common.base,
- com.google.common.cache,
- com.google.common.io,
  com.puppycrawl.tools.checkstyle,
  com.puppycrawl.tools.checkstyle.api;
   uses:="org.xml.sax.helpers,
@@ -34,9 +31,7 @@ Export-Package: .,
  com.puppycrawl.tools.checkstyle.checks.whitespace,
  com.puppycrawl.tools.checkstyle.filefilters,
  com.puppycrawl.tools.checkstyle.filters,
- com.puppycrawl.tools.checkstyle.meta,
- com.puppycrawl.tools.checkstyle.utils,
- org.apache.commons.lang3
+ com.puppycrawl.tools.checkstyle.utils
 Bundle-ClassPath: .,
  checkstyle-10.14.2-all.jar
 Automatic-Module-Name: net.sf.eclipsecs.checkstyle

--- a/net.sf.eclipsecs.core/.classpath
+++ b/net.sf.eclipsecs.core/.classpath
@@ -7,5 +7,6 @@
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="lib" path="lib/checkstyle-10.14.2-all.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/net.sf.eclipsecs.core/.gitignore
+++ b/net.sf.eclipsecs.core/.gitignore
@@ -1,2 +1,0 @@
-# only the eclipsecs.checkstyle project shall contain a copy of the checkstyle jar
-**/checkstyle*.jar

--- a/net.sf.eclipsecs.core/META-INF/MANIFEST.MF
+++ b/net.sf.eclipsecs.core/META-INF/MANIFEST.MF
@@ -4,7 +4,8 @@ Bundle-ManifestVersion: 2
 Bundle-SymbolicName: net.sf.eclipsecs.core;singleton:=true
 Bundle-Version: 10.14.2.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Bundle-ClassPath: .
+Bundle-ClassPath: .,
+ lib/checkstyle-10.14.2-all.jar
 Bundle-Activator: net.sf.eclipsecs.core.CheckstylePlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Bundle-Vendor

--- a/net.sf.eclipsecs.core/build.properties
+++ b/net.sf.eclipsecs.core/build.properties
@@ -2,8 +2,10 @@ source.. = src/
 jars.compile.order = .
 bin.includes = .,\
                META-INF/,\
+               lib/,\
                license/,\
                plugin.xml,\
                schema/,\
+               lib/checkstyle-10.14.2-all.jar,\
                OSGI-INF/
 javacDefaultEncoding.. = UTF-8

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
@@ -303,9 +303,11 @@ public final class MetadataFactory {
    * Create repository of Module Details from checkstyle metadata and third party extension checks metadata.
    */
   private static void createMetadataMap() {
-    XmlMetaReader.readAllModulesIncludingThirdPartyIfAny(
-        sPackageNameSet.toArray(new String[sPackageNameSet.size()]))
-        .forEach(moduleDetail -> sModuleDetailsRepo.put(moduleDetail.getName(), moduleDetail));
+    List<ModuleDetails> moduleDetails = XmlMetaReader.readAllModulesIncludingThirdPartyIfAny(sPackageNameSet.toArray(new String[0]));
+    if (moduleDetails.isEmpty()) {
+      CheckstyleLog.log(null, "Cannot read module details");
+    }
+    moduleDetails.forEach(moduleDetail -> sModuleDetailsRepo.put(moduleDetail.getName(), moduleDetail));
   }
 
   /**

--- a/upgrade-version.build.xml
+++ b/upgrade-version.build.xml
@@ -52,7 +52,9 @@ Apply all necessary manual code changes now.
 
 		<!-- download new version -->
 		<get src="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${toVersion}/checkstyle-${toVersion}-all.jar"
-			dest="${basedir}/net.sf.eclipsecs.checkstyle/checkstyle-${toVersion}-all.jar"/>
+		     dest="${basedir}/net.sf.eclipsecs.checkstyle/checkstyle-${toVersion}-all.jar"/>
+		<copy file="${basedir}/net.sf.eclipsecs.checkstyle/checkstyle-${toVersion}-all.jar"
+		     tofile="${basedir}/net.sf.eclipsecs.core/lib/checkstyle-${toVersion}-all.jar"/>
 	</target>
 
 </project>


### PR DESCRIPTION
This reverts commit d74a25f7f64ccaf650d11fa3431e2e2b4216f21f.

The removal of the second copy of the checkstyle.jar worked fine, no compiler issues, no failing tests, and all checks working as intended. However, the configuration dialog didn't display module configurations any more. There is a problem with the re-exported package for the metadata, specifically this line: https://github.com/checkstyle/eclipse-cs/blob/33ce44e8801d824387d4b90bad1e8c096a5ece4c/net.sf.eclipsecs.checkstyle/META-INF/MANIFEST.MF#L37

I have to investigate more deeply how to make the classpath work correctly without re-exporting that package. Until then, revert the commit, and also add a new check that will throw a runtime error, if no module metadata can be read.