### PR TITLE
Show module id on property page

### DIFF
--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.core.filebuffers.FileBuffers;
 import org.eclipse.core.filebuffers.ITextFileBufferManager;
 import org.eclipse.core.resources.IFile;
@@ -325,6 +326,10 @@ public class Auditor {
             mMarkerAttributes.put(CheckstyleMarker.MODULE_NAME, metaData.getInternalName());
             mMarkerAttributes.put(CheckstyleMarker.MESSAGE_KEY,
                     error.getViolation().getKey());
+            String moduleId = error.getModuleId();
+            if (StringUtils.isNotBlank(moduleId)) {
+              mMarkerAttributes.put(CheckstyleMarker.MODULE_ID, moduleId);
+            }
             mMarkerAttributes.put(IMarker.PRIORITY, Integer.valueOf(IMarker.PRIORITY_NORMAL));
             mMarkerAttributes.put(IMarker.SEVERITY, Integer.valueOf(getSeverityValue(severity)));
             mMarkerAttributes.put(IMarker.LINE_NUMBER, Integer.valueOf(error.getLine()));

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/CheckstyleMarker.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/CheckstyleMarker.java
@@ -32,8 +32,11 @@ public final class CheckstyleMarker {
   /** ID for the CheckstyleMarker. */
   public static final String MARKER_ID = CheckstylePlugin.PLUGIN_ID + ".CheckstyleMarker"; //$NON-NLS-1$
 
-  /** Constant for module info additionally stored. */
+  /** Module name key in marker attributes. */
   public static final String MODULE_NAME = "ModuleName"; //$NON-NLS-1$
+
+  /** Module Id key in marker attributes. */
+  public static final String MODULE_ID = "ModuleId"; //$NON-NLS-1$
 
   /** Constant for message key info additionally stored. */
   public static final String MESSAGE_KEY = "MessageKey"; //$NON-NLS-1$

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/Messages.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/Messages.java
@@ -500,5 +500,7 @@ public final class Messages extends NLS {
   public static String MarkerPropertyPage_Group;
 
   public static String MarkerPropertyPage_Description;
+
+  public static String MarkerPropertyPage_Id;
   // CHECKSTYLE:ON
 }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/messages.properties
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/messages.properties
@@ -163,6 +163,7 @@ InternalConfigurationEditor_btnImport = Import...
 InternalConfigurationEditor_titleImportDialog = Choose Checkstyle configuration file to import
 MarkerPropertyPage_Description=Description:
 MarkerPropertyPage_Group=Group:
+MarkerPropertyPage_Id=Id:
 MarkerPropertyPage_Issue=Issue:
 MarkerPropertyPage_Module=Module:
 MarkerPropertyPage_SuppressionHint=For suppression comments use "{0}"

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/marker/MarkerPropertyPage.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/marker/MarkerPropertyPage.java
@@ -20,6 +20,7 @@
 
 package net.sf.eclipsecs.ui.properties.marker;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.swt.SWT;
@@ -66,47 +67,75 @@ public class MarkerPropertyPage extends PropertyPage {
     composite.setLayout(layout);
 
     try {
-      new Label(composite, SWT.NONE).setImage(
-              getSeverityImage(getIssue().getAttribute(IMarker.SEVERITY, -1)));
-      new Label(composite, SWT.NONE).setText(Messages.MarkerPropertyPage_Issue);
-      String message = (String) getIssue().getAttribute(IMarker.MESSAGE);
-      Text labelMessage = new Text(composite, SWT.WRAP | SWT.READ_ONLY);
-      labelMessage.setText(message);
-
-      new Label(composite, SWT.NONE).setImage(
-              CheckstyleUIPluginImages.MODULEGROUP_ICON.getImage());
-      new Label(composite, SWT.NONE).setText(Messages.MarkerPropertyPage_Group);
-
-      String moduleName = (String) getIssue().getAttribute(CheckstyleMarker.MODULE_NAME);
-      RuleMetadata metaData = MetadataFactory.getRuleMetadata(moduleName);
-      Text labelGroupName = new Text(composite, SWT.WRAP | SWT.READ_ONLY);
-      labelGroupName.setText(metaData.getGroup().getGroupName());
-
-      new Label(composite, SWT.NONE).setImage(
-              CheckstyleUIPluginImages.MODULE_ICON.getImage());
-      new Label(composite, SWT.NONE).setText(Messages.MarkerPropertyPage_Module);
-
-      Text labelRuleName = new Text(composite, SWT.WRAP | SWT.READ_ONLY);
-      labelRuleName.setText(metaData.getRuleName());
-
-      Label descriptionLabel = new Label(composite, SWT.NONE);
-      descriptionLabel.setText(Messages.MarkerPropertyPage_Description);
-      GridData gridData = new GridData();
-      gridData.horizontalSpan = 3;
-      gridData.verticalIndent = 20;
-      descriptionLabel.setLayoutData(gridData);
-
-      gridData = new GridData(GridData.FILL_BOTH);
-      gridData.heightHint = 100;
-      gridData.horizontalSpan = 3;
-      Browser browserDescription = new Browser(composite, SWT.BORDER);
-      browserDescription.setLayoutData(gridData);
-      browserDescription.setText(
-              CheckConfigurationConfigureDialog.getDescriptionHtml(metaData.getDescription()));
+      createSeverityText(composite);
+      RuleMetadata metaData = createGroupText(composite);
+      createRuleText(composite, metaData);
+      createIdText(composite);
+      createDescriptionText(composite, metaData);
     } catch (CoreException ex) {
       CheckstyleLog.log(ex);
     }
     return composite;
+  }
+
+  private void createSeverityText(final Composite composite) throws CoreException {
+    new Label(composite, SWT.NONE).setImage(
+            getSeverityImage(getIssue().getAttribute(IMarker.SEVERITY, -1)));
+    new Label(composite, SWT.NONE).setText(Messages.MarkerPropertyPage_Issue);
+    String message = (String) getIssue().getAttribute(IMarker.MESSAGE);
+    Text labelMessage = new Text(composite, SWT.WRAP | SWT.READ_ONLY);
+    labelMessage.setText(message);
+  }
+
+  private RuleMetadata createGroupText(final Composite composite) throws CoreException {
+    new Label(composite, SWT.NONE).setImage(
+            CheckstyleUIPluginImages.MODULEGROUP_ICON.getImage());
+    new Label(composite, SWT.NONE).setText(Messages.MarkerPropertyPage_Group);
+
+    String moduleName = (String) getIssue().getAttribute(CheckstyleMarker.MODULE_NAME);
+    RuleMetadata metaData = MetadataFactory.getRuleMetadata(moduleName);
+    Text labelGroupName = new Text(composite, SWT.WRAP | SWT.READ_ONLY);
+    labelGroupName.setText(metaData.getGroup().getGroupName());
+    return metaData;
+  }
+
+  private void createRuleText(final Composite composite, RuleMetadata metaData) {
+    new Label(composite, SWT.NONE).setImage(
+            CheckstyleUIPluginImages.MODULE_ICON.getImage());
+    new Label(composite, SWT.NONE).setText(Messages.MarkerPropertyPage_Module);
+
+    Text labelRuleName = new Text(composite, SWT.WRAP | SWT.READ_ONLY);
+    labelRuleName.setText(metaData.getRuleName());
+  }
+
+  private void createIdText(final Composite composite) {
+    var id = getIssue().getAttribute(CheckstyleMarker.MODULE_ID, null);
+    if (StringUtils.isEmpty(id)) {
+      return;
+    }
+    new Label(composite, SWT.NONE).setImage(
+            PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_OBJS_INFO_TSK));
+    new Label(composite, SWT.NONE).setText(Messages.MarkerPropertyPage_Id);
+
+    Text labelId = new Text(composite, SWT.WRAP | SWT.READ_ONLY);
+    labelId.setText(id);
+  }
+
+  private void createDescriptionText(final Composite composite, RuleMetadata metaData) {
+    Label descriptionLabel = new Label(composite, SWT.NONE);
+    descriptionLabel.setText(Messages.MarkerPropertyPage_Description);
+    GridData gridData = new GridData();
+    gridData.horizontalSpan = 3;
+    gridData.verticalIndent = 20;
+    descriptionLabel.setLayoutData(gridData);
+
+    gridData = new GridData(GridData.FILL_BOTH);
+    gridData.heightHint = 100;
+    gridData.horizontalSpan = 3;
+    Browser browserDescription = new Browser(composite, SWT.BORDER);
+    browserDescription.setLayoutData(gridData);
+    browserDescription.setText(
+            CheckConfigurationConfigureDialog.getDescriptionHtml(metaData.getDescription()));
   }
 
   /**


### PR DESCRIPTION
Also show the module id of a rule on the marker property page. The same rule can have multiple different ids in different check configurations. Therefore it seems most simple to store the module id at the time of marker creation instead of later calculating it again.

![grafik](https://github.com/checkstyle/eclipse-cs/assets/406876/1a2e0b3b-b70c-4771-9ca9-f3070486264c)

For old markers or rules without an id, nothing is displayed.

fixes #468