### PR TITLE
Re-enable quickfixes

### DIFF
--- a/net.sf.eclipsecs.ui/plugin.xml
+++ b/net.sf.eclipsecs.ui/plugin.xml
@@ -539,75 +539,75 @@
     <extension
           point="net.sf.eclipsecs.ui.quickfix">
        <quickfix
-             module="ArrayTypeStyleCheck"
+             module="ArrayTypeStyle"
              class="net.sf.eclipsecs.ui.quickfixes.misc.ArrayTypeStyleQuickfix">
        </quickfix>
        <quickfix
-             module="AvoidNestedBlocksCheck"
+             module="AvoidNestedBlocks"
              class="net.sf.eclipsecs.ui.quickfixes.blocks.AvoidNestedBlocksQuickfix">
        </quickfix>
        <quickfix
-             module="DefaultComesLastCheck"
+             module="DefaultComesLast"
              class="net.sf.eclipsecs.ui.quickfixes.coding.DefaultComesLastQuickfix">
        </quickfix>
        <quickfix
-             module="DesignForExtensionCheck"
+             module="DesignForExtension"
              class="net.sf.eclipsecs.ui.quickfixes.design.DesignForExtensionQuickfix">
        </quickfix>
        <quickfix
-             module="EmptyStatementCheck"
+             module="EmptyStatement"
              class="net.sf.eclipsecs.ui.quickfixes.coding.EmptyStatementQuickfix">
        </quickfix>
        <quickfix
-             module="ExplicitInitializationCheck"
+             module="ExplicitInitialization"
              class="net.sf.eclipsecs.ui.quickfixes.coding.ExplicitInitializationQuickfix">
        </quickfix>
        <quickfix
-             module="FinalClassCheck"
+             module="FinalClass"
              class="net.sf.eclipsecs.ui.quickfixes.design.FinalClassQuickfix">
        </quickfix>
        <quickfix
-             module="FinalLocalVariableCheck"
+             module="FinalLocalVariable"
              class="net.sf.eclipsecs.ui.quickfixes.coding.FinalLocalVariableQuickfix">
        </quickfix>
        <quickfix
-             module="FinalParametersCheck"
+             module="FinalParameters"
              class="net.sf.eclipsecs.ui.quickfixes.misc.FinalParametersQuickfix">
        </quickfix>
        <quickfix
-             module="MissingSwitchDefaultCheck"
+             module="MissingSwitchDefault"
              class="net.sf.eclipsecs.ui.quickfixes.coding.MissingSwitchDefaultQuickfix">
        </quickfix>
        <quickfix
-             module="ModifierOrderCheck"
+             module="ModifierOrder"
              class="net.sf.eclipsecs.ui.quickfixes.modifier.ModifierOrderQuickfix">
        </quickfix>
        <quickfix
-             module="NeedBracesCheck"
+             module="NeedBraces"
              class="net.sf.eclipsecs.ui.quickfixes.blocks.NeedBracesQuickfix">
        </quickfix>
        <quickfix
-             module="RedundantModifierCheck"
+             module="RedundantModifier"
              class="net.sf.eclipsecs.ui.quickfixes.modifier.RedundantModifierQuickfix">
        </quickfix>
        <quickfix
-             module="RequireThisCheck"
+             module="RequireThis"
              class="net.sf.eclipsecs.ui.quickfixes.coding.RequireThisQuickfix">
        </quickfix>
        <quickfix
-             module="SimplifyBooleanReturnCheck"
+             module="SimplifyBooleanReturn"
              class="net.sf.eclipsecs.ui.quickfixes.coding.SimplifyBooleanReturnQuickfix">
        </quickfix>
        <quickfix
-             module="StringLiteralEqualityCheck"
+             module="StringLiteralEquality"
              class="net.sf.eclipsecs.ui.quickfixes.coding.StringLiteralEqualityQuickfix">
        </quickfix>
        <quickfix
-             module="UncommentedMainCheck"
+             module="UncommentedMain"
              class="net.sf.eclipsecs.ui.quickfixes.misc.UncommentedMainQuickfix">
        </quickfix>
        <quickfix
-             module="UpperEllCheck"
+             module="UpperEll"
              class="net.sf.eclipsecs.ui.quickfixes.misc.UpperEllQuickfix">
        </quickfix>
    </extension>


### PR DESCRIPTION
f3e15909fc489de6695510b25263d065d44534cc fixed the metadata registration for markers. That also led to the module name in the marker attributes to no longer be named FooCheck, but just Foo. Therefore the marker resolution no longer  matches, and the "Check" suffix needs to be removed there, too.

Looks like this after the fix: 
![grafik](https://github.com/checkstyle/eclipse-cs/assets/406876/f7592b5d-73c8-477f-b1f7-a52996bc79ba)

The light bulbs (and the actual quick fixes) were missing since above commit.