### PR TITLE
Add command for running checkstyle

### DIFF
--- a/net.sf.eclipsecs.ui/plugin.xml
+++ b/net.sf.eclipsecs.ui/plugin.xml
@@ -308,7 +308,13 @@
         point="org.eclipse.ui.commands">
         <category id="net.sf.eclipsecs.ui" name="%commands.category.name"/>
         <command
-            categoryId="org.eclipse.jdt.ui.category.source"
+            categoryId="net.sf.eclipsecs.ui"
+            description="%CheckSelectedFilesAction.tooltip"
+            id="CheckstylePlugin.CheckSelectedFiles"
+            name="%CheckSelectedFilesAction.label"
+            defaultHandler="net.sf.eclipsecs.ui.actions.CheckSelectedFilesAction"/>
+        <command
+            categoryId="net.sf.eclipsecs.ui"
             description="%FixCheckstyleMarkersAction.tooltip"
             id="CheckstylePlugin.ApplyCheckstyleFixes"
             name="%FixCheckstyleMarkersAction.label"
@@ -326,7 +332,8 @@
             sequence="M1+M3+C"
             commandId="CheckstylePlugin.ApplyCheckstyleFixes"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-            contextId="org.eclipse.jdt.ui.javaEditorScope"/>></extension>
+            contextId="org.eclipse.jdt.ui.javaEditorScope"/>
+    </extension>
 
     <!-- Popupmenu action for the 'Configure Project(s) from blueprint...' action -->
     <extension
@@ -534,6 +541,10 @@
        <image
              commandId="CheckstylePlugin.PurgeCaches"
              icon="platform:/plugin/org.eclipse.ui/icons/full/etool16/clear.png">
+       </image>
+       <image
+             commandId="CheckstylePlugin.CheckSelectedFiles"
+             icon="icons/checkstyle_command.png">
        </image>
     </extension>
     <extension


### PR DESCRIPTION
This adds a command for the already existing action to run checkstyle on the selected resources. That way users can invoke the command also via Ctrl-3 quick assist or via a key binding.

There is no default key binding, as the normal workflow for users is to rely on the Eclipse builder and to not invoke this command manually.

fixes #99

![grafik](https://github.com/checkstyle/eclipse-cs/assets/406876/fa993baa-b37d-4f5b-b5e8-9dcff36ab026)

Be aware the shown keybinding is not available by default. I just added that for testing and to illustrate that a keybinding _can_ be given by the user.