### PR TITLE
upgrade external target platform dependencies

### DIFF
--- a/net.sf.eclipsecs.target/Maven target update check.launch
+++ b/net.sf.eclipsecs.target/Maven target update check.launch
@@ -2,10 +2,10 @@
 <launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
     <intAttribute key="M2_COLORS" value="0"/>
     <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
-    <stringAttribute key="M2_GOALS" value="versions:display-dependency-updates versions:display-plugin-updates -T1"/>
+    <stringAttribute key="M2_GOALS" value="verify -T1"/>
     <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
     <booleanAttribute key="M2_OFFLINE" value="false"/>
-    <stringAttribute key="M2_PROFILES" value=""/>
+    <stringAttribute key="M2_PROFILES" value="update-check-for-target-maven-artifacts"/>
     <listAttribute key="M2_PROPERTIES"/>
     <stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
     <booleanAttribute key="M2_SKIP_TESTS" value="false"/>
@@ -21,5 +21,5 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
-    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${git_work_tree:/eclipse-cs}"/>
+    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/net.sf.eclipsecs.target}"/>
 </launchConfiguration>

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Eclipse Checkstyle" sequenceNumber="1711962228">
+<target name="Eclipse Checkstyle" sequenceNumber="1717393787">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.jdt.feature.group" version="3.18.1300.v20220831-1800"/>
@@ -75,7 +75,7 @@
         <dependency>
           <groupId>io.github.classgraph</groupId>
           <artifactId>classgraph</artifactId>
-          <version>4.8.168</version>
+          <version>4.8.172</version>
           <type>jar</type>
         </dependency>
       </dependencies>
@@ -85,7 +85,7 @@
         <dependency>
           <groupId>org.assertj</groupId>
           <artifactId>assertj-core</artifactId>
-          <version>3.25.1</version>
+          <version>3.26.0</version>
           <type>jar</type>
         </dependency>
       </dependencies>

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
@@ -73,7 +73,7 @@ maven AssertJ
 	dependency {
 		groupId="org.assertj"
 		artifactId="assertj-core"
-		version="3.25.1"
+		version="3.26.0"
 	}
 }
 maven Classgraph
@@ -85,7 +85,7 @@ maven Classgraph
 	dependency {
 		groupId="io.github.classgraph"
 		artifactId="classgraph"
-		version="4.8.168"
+		version="4.8.172"
 	}
 }
 maven DOM4J

--- a/net.sf.eclipsecs.target/pom.xml
+++ b/net.sf.eclipsecs.target/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>net.sf.eclipsecs.parent</artifactId>
+        <groupId>net.sf.eclipsecs</groupId>
+        <version>10.14.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>net.sf.eclipsecs.target</artifactId>
+    <packaging>pom</packaging>
+
+    <profiles>
+        <profile>
+            <id>update-check-for-target-maven-artifacts</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- scan target files and add maven artifacts as dependencies to this pom -->
+                    <plugin>
+                        <groupId>org.codehaus.gmaven</groupId>
+                        <artifactId>groovy-maven-plugin</artifactId>
+                        <version>2.1.1</version>
+                        <executions>
+                            <execution>
+                                <id>add-dependencies-from-m2e-target</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <configuration>
+                                    <source>${project.basedir}/target_platform_maven_updates.groovy</source>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- this execution should be in a later phase than the groovy execution which adds artificial dependencies -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>versions-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>dependency-updates</id>
+                                <goals>
+                                    <goal>display-dependency-updates</goal>
+                                </goals>
+                                <phase>generate-resources</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>checkstyle-check</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>sevntu-checkstyle-check</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/net.sf.eclipsecs.target/target_platform_maven_updates.groovy
+++ b/net.sf.eclipsecs.target/target_platform_maven_updates.groovy
@@ -1,0 +1,34 @@
+/*
+ * This is a script to check for updates of the Maven artifacts in target files.
+ * When executed with the maven-groovy plugin, it will inject all target platform dependencies into the Maven model.
+ * Invoking versions-maven-plugin:display-dependency-updates immediately afterwards then shows the available updates.
+ */
+import org.apache.maven.model.Dependency
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+def files = basedir.listFiles()
+for (File file : files) {
+	if (file.getName().endsWith('.target')) {
+		log.info('analyzing target {}', file.getName())
+		String targetContent = file.getText('UTF-8')
+		Pattern pattern = Pattern.compile('<groupId>(.+?)</groupId>\\s*<artifactId>(.+?)</artifactId>\\s*<version>(.+?)</version>', Pattern.DOTALL)
+		Matcher matcher = pattern.matcher(targetContent)
+
+		while (matcher.find()) {
+			String groupId = matcher.group(1)
+			String artifactId = matcher.group(2)
+			String version = matcher.group(3)
+			log.info('adding m2e target dependency {}:{}:{}', groupId, artifactId, version)
+
+			def dependency = new Dependency()
+			dependency.setGroupId(groupId)
+			dependency.setArtifactId(artifactId)
+			dependency.setVersion(version)
+			dependency.setScope("compile")
+
+			project.getDependencies().add(dependency)
+		}
+	}
+}


### PR DESCRIPTION
Simplify looking for target platform upgrades by injecting them into the Maven object model and let Maven check for available upgrades. That's why this project now has a pom.xml, but is NOT part of the modules list of the parent.