### PR TITLE
Refresh SCM filter info correctly

### DIFF
--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/CheckstyleBuilder.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/CheckstyleBuilder.java
@@ -364,6 +364,9 @@ public class CheckstyleBuilder extends IncrementalProjectBuilder {
           // add to the resources to check
           resources.add(child);
         }
+        else {
+          child.deleteMarkers(CheckstyleMarker.MARKER_ID, true, IResource.DEPTH_ZERO);
+        }
 
         // recurse over containers
         if (child instanceof IContainer) {

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Eclipse Checkstyle" sequenceNumber="1717393787">
+<target name="Eclipse Checkstyle" sequenceNumber="1721491250">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.jdt.feature.group" version="3.18.1300.v20220831-1800"/>
@@ -40,6 +40,22 @@
       <unit id="com.github.sevntu.checkstyle.checks.feature.feature.group" version="1.44.1"/>
       <repository location="https://sevntu-checkstyle.github.io/sevntu.checkstyle/update-site/"/>
     </location>
+    <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.eclipse.egit.feature.group" version="6.5.0.202303070854-r"/>
+      <unit id="org.eclipse.jgit.feature.group" version="6.5.0.202303070854-r"/>
+      <unit id="org.eclipse.jgit.gpg.bc.feature.group" version="6.5.0.202303070854-r"/>
+      <unit id="org.eclipse.jgit.ssh.apache.feature.group" version="6.5.0.202303070854-r"/>
+      <unit id="org.eclipse.jgit.http.apache.feature.group" version="6.5.0.202303070854-r"/>
+      <unit id="org.apache.commons.codec" version="1.14.0.v20221112-0806"/>
+      <unit id="org.apache.commons.compress" version="1.22.0.v20221207-1049"/>
+      <unit id="org.apache.httpcomponents.httpclient" version="4.5.14.v20221207-1049"/>
+      <unit id="org.apache.httpcomponents.httpcore" version="4.4.16.v20221207-1049"/>
+      <unit id="org.apache.sshd.osgi" version="2.9.2.v20221117-1942"/>
+      <unit id="org.apache.sshd.sftp" version="2.9.2.v20221117-1942"/>
+      <unit id="javaewah" version="1.1.13.v20211029-0839"/>
+      <unit id="net.i2p.crypto.eddsa" version="0.3.0.v20220506-1020"/>
+      <repository location="https://download.eclipse.org/egit/updates-6.5"/>
+    </location>
     <location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven" label="SnakeYaml">
       <dependencies>
         <dependency>
@@ -75,7 +91,7 @@
         <dependency>
           <groupId>io.github.classgraph</groupId>
           <artifactId>classgraph</artifactId>
-          <version>4.8.172</version>
+          <version>4.8.174</version>
           <type>jar</type>
         </dependency>
       </dependencies>
@@ -85,7 +101,7 @@
         <dependency>
           <groupId>org.assertj</groupId>
           <artifactId>assertj-core</artifactId>
-          <version>3.26.0</version>
+          <version>3.26.3</version>
           <type>jar</type>
         </dependency>
       </dependencies>
@@ -95,7 +111,7 @@
         <dependency>
           <groupId>org.apache.commons</groupId>
           <artifactId>commons-lang3</artifactId>
-          <version>3.14.0</version>
+          <version>3.15.0</version>
           <type>jar</type>
         </dependency>
       </dependencies>

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
@@ -50,6 +50,24 @@ location "https://sevntu-checkstyle.github.io/sevntu.checkstyle/update-site/" {
 	com.github.sevntu.checkstyle.checks.feature.feature.group
 }
 
+location "https://download.eclipse.org/egit/updates-6.5" {
+	// for testing the SCM filter
+	// have to use an old version of egit, as most recent requires a more recent eclipse core version
+	org.eclipse.egit.feature.group
+	org.eclipse.jgit.feature.group
+	org.eclipse.jgit.gpg.bc.feature.group
+	org.eclipse.jgit.ssh.apache.feature.group
+	org.eclipse.jgit.http.apache.feature.group
+	org.apache.commons.codec
+	org.apache.commons.compress
+	org.apache.httpcomponents.httpclient
+	org.apache.httpcomponents.httpcore
+	org.apache.sshd.osgi
+	org.apache.sshd.sftp
+	javaewah
+	net.i2p.crypto.eddsa
+}
+
 // If the following part has errors and no syntax highlighting, then please use Help>About>Installation>Installed Software>Target Platform DSL>Uninstall.
 // After restarting please install the current version from the URL in line 1.
 maven ApacheCommons
@@ -61,7 +79,7 @@ maven ApacheCommons
 	dependency {
 		groupId="org.apache.commons"
 		artifactId="commons-lang3"
-		version="3.14.0"
+		version="3.15.0"
 	}
 }
 maven AssertJ
@@ -73,7 +91,7 @@ maven AssertJ
 	dependency {
 		groupId="org.assertj"
 		artifactId="assertj-core"
-		version="3.26.0"
+		version="3.26.3"
 	}
 }
 maven Classgraph
@@ -85,7 +103,7 @@ maven Classgraph
 	dependency {
 		groupId="io.github.classgraph"
 		artifactId="classgraph"
-		version="4.8.172"
+		version="4.8.174"
 	}
 }
 maven DOM4J


### PR DESCRIPTION
* refresh SCM change info for every file when filtering
* remove markers from files which don't pass the filter (because those markers are stale)

Changes in target platform are only for local debugging, this has no effect on the published plugin.

Fixes #714 