### PR TITLE
simplify feature branding

### DIFF
--- a/net.sf.eclipsecs.branding/about.properties
+++ b/net.sf.eclipsecs.branding/about.properties
@@ -3,9 +3,4 @@ aboutText=Eclipse Checkstyle {featureVersion}\n\
 Checkstyle integration for Eclipse, distributed under the terms of the GNU Lesser General Public License 2.1.\n\
 Visit https://checkstyle.org/eclipse-cs/ for updates, documentation and support.\n\
 \n\
-(c) Copyright David Schneider, Lars K\u00f6dderitzsch and others, 2002-2018\n\
-This software includes the following 3rd-party libraries:\n\
-Checkstyle, licensed under LGPL 2.1. Visit https://checkstyle.org/\n\
-Jakarta Commons Lang/IO, licensed under APL 2.0. Visit http://commons.apache.org/\n\
-DOM4J, licensed under BSD. Visit http://sourceforge.net/projects/dom4j/\n\
-JFreeChart, licensed under LGPL 3. Visit http://www.jfree.org/jfreechart/
+(c) Copyright David Schneider, Lars K\u00f6dderitzsch and others, 2002-2024


### PR DESCRIPTION
The list of contained third-party software is both incomplete as well as containing a meanwhile unused library. Remove that part of the feature description.

This is the old version of that branding dialog: 
![image](https://github.com/user-attachments/assets/82c11122-7c91-41bf-9b35-c4f8be311081)
