### PR TITLE
remove Orbit update site

### DIFF
--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Eclipse Checkstyle" sequenceNumber="1726901996">
+<target name="Eclipse Checkstyle" sequenceNumber="1728798967">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.jdt.feature.group" version="3.18.1300.v20220831-1800"/>
@@ -17,6 +17,8 @@
       <unit id="org.sat4j.core" version="2.3.6.v20201214"/>
       <unit id="org.sat4j.pb" version="2.3.6.v20201214"/>
       <unit id="org.apache.commons.io" version="2.8.0.v20210415-0900"/>
+      <unit id="org.objectweb.asm" version="9.3.0.v20220409-0157"/>
+      <unit id="org.objectweb.asm.tree" version="9.3.0.v20220409-0157"/>
       <unit id="junit-jupiter-api" version="5.9.0"/>
       <unit id="junit-jupiter-engine" version="5.9.0"/>
       <unit id="junit-jupiter-migrationsupport" version="5.9.0"/>
@@ -30,11 +32,6 @@
       <unit id="junit-vintage-engine" version="5.9.0"/>
       <unit id="org.apiguardian.api" version="1.1.2"/>
       <repository location="https://download.eclipse.org/releases/2022-09/202209141001/"/>
-    </location>
-    <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
-      <unit id="org.objectweb.asm" version="9.3.0.v20220409-0157"/>
-      <unit id="org.objectweb.asm.tree" version="9.3.0.v20220409-0157"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220830213456/repository"/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="com.github.sevntu.checkstyle.checks.feature.feature.group" version="1.44.1"/>
@@ -91,7 +88,7 @@
         <dependency>
           <groupId>io.github.classgraph</groupId>
           <artifactId>classgraph</artifactId>
-          <version>4.8.176</version>
+          <version>4.8.177</version>
           <type>jar</type>
         </dependency>
       </dependencies>

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
@@ -23,6 +23,8 @@ location "https://download.eclipse.org/releases/2022-09/202209141001/" {
 	org.sat4j.core
 	org.sat4j.pb
 	org.apache.commons.io
+	org.objectweb.asm
+	org.objectweb.asm.tree
 
 	// test dependencies used by the JUnit IDE integration
 	junit-jupiter-api
@@ -37,12 +39,6 @@ location "https://download.eclipse.org/releases/2022-09/202209141001/" {
 	junit-platform-suite-commons
 	junit-vintage-engine
 	org.apiguardian.api
-}
-
-// Eclipse Orbit repository for third party dependencies matching the above 2022-09 release
-location "https://download.eclipse.org/tools/orbit/downloads/drops/R20220830213456/repository" {
-	org.objectweb.asm
-	org.objectweb.asm.tree
 }
 
 // include sevntu plugin, so we can test it easily when launching a debug runtime
@@ -103,7 +99,7 @@ maven Classgraph
 	dependency {
 		groupId="io.github.classgraph"
 		artifactId="classgraph"
-		version="4.8.176"
+		version="4.8.177"
 	}
 }
 maven DOM4J


### PR DESCRIPTION
For newer releases of Eclipse, third party dependencies are typically also available on the main release update site, so we can take them from there instead of from Orbit.

There is no functional change.