### PR TITLE
Add name to target platform module

### DIFF
--- a/net.sf.eclipsecs.target/pom.xml
+++ b/net.sf.eclipsecs.target/pom.xml
@@ -8,6 +8,7 @@
     </parent>
     <artifactId>net.sf.eclipsecs.target</artifactId>
     <packaging>pom</packaging>
+    <name>eclipse-cs Target Platform</name>
 
     <profiles>
         <profile>


### PR DESCRIPTION
Just to have a more nice Maven output, as all other modules have a better readable name already.