### PR TITLE
Use Tycho smart builder

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-build</artifactId>
+        <version>4.0.9</version>
+    </extension>
+</extensions>


### PR DESCRIPTION
The Tycho smart builder runs modules in parallel more aggressively than the standard maven parallel builder, thereby saving some build time.