### PR TITLE
remove "fork me on GitHub" button

### DIFF
--- a/net.sf.eclipsecs.doc/src/main/resources/index.html
+++ b/net.sf.eclipsecs.doc/src/main/resources/index.html
@@ -22,7 +22,6 @@
 
   <body>
       <header class="navbar navbar-default navbar-fixed-top" role="navigation">
-        <a id="gh-banner" href="https://github.com/checkstyle/eclipse-cs"><img src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"></a>
         <div class="navbar-header">
           <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-responsive-collapse"
             data-ng-init="navCollapsed = true" data-ng-click="navCollapsed = !navCollapsed">


### PR DESCRIPTION
The old version required some publicly hosted resources. We could replace that with own hosted resources, but it seems okay to just remove it. Nowadays people don't need this "fork me" button for learning how to contribute like 15 years ago.