### PR TITLE
configure and run OpenRewrite

### DIFF
--- a/net.sf.eclipsecs.checkstyle/pom.xml
+++ b/net.sf.eclipsecs.checkstyle/pom.xml
@@ -17,9 +17,11 @@
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
             </plugin>
         </plugins>
     </build>

--- a/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/ChecksTest.java
+++ b/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/ChecksTest.java
@@ -43,10 +43,10 @@ import com.puppycrawl.tools.checkstyle.TreeWalker;
 import net.sf.eclipsecs.checkstyle.utils.CheckUtil;
 import net.sf.eclipsecs.checkstyle.utils.XmlUtil;
 
-public class ChecksTest {
+class ChecksTest {
 
   @Test
-  public void metadataFiles() throws Exception {
+  void metadataFiles() throws Exception {
     final Set<Class<?>> modules = new HashSet<>(CheckUtil.getCheckstyleModules());
 
     // don't test root modules

--- a/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/ChecksTest.java
+++ b/net.sf.eclipsecs.checkstyle/test/net/sf/eclipsecs/checkstyle/ChecksTest.java
@@ -46,7 +46,7 @@ import net.sf.eclipsecs.checkstyle.utils.XmlUtil;
 public class ChecksTest {
 
   @Test
-  public void testMetadataFiles() throws Exception {
+  public void metadataFiles() throws Exception {
     final Set<Class<?>> modules = new HashSet<>(CheckUtil.getCheckstyleModules());
 
     // don't test root modules

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/CheckstylePluginPrefs.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/CheckstylePluginPrefs.java
@@ -33,7 +33,6 @@ import net.sf.eclipsecs.core.util.CheckstyleLog;
 /**
  * Class for handling preferences of the <code>net.sf.eclipsecs.core</code> plugin.
  *
- * @author Lars Ködderitzsch
  */
 public class CheckstylePluginPrefs extends AbstractPreferenceInitializer {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/Messages.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/Messages.java
@@ -25,7 +25,6 @@ import org.eclipse.osgi.util.NLS;
 /**
  * Class providing messages for the checkstyle plugin. Uses the eclipse new nls mechanism.
  *
- * @author Lars Ködderitzsch
  */
 public final class Messages extends NLS {
   // CHECKSTYLE:OFF

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
@@ -82,10 +82,10 @@ public class Auditor {
   private IProgressMonitor mMonitor;
 
   /** Add the check rule name to the message. */
-  private boolean mAddRuleName = false;
+  private boolean mAddRuleName;
 
   /** Add the check module id to the message. */
-  private boolean mAddModuleId = false;
+  private boolean mAddModuleId;
 
   /**
    * Creates an auditor.

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
@@ -211,8 +211,6 @@ public class Auditor {
 
   /**
    * Helper method to get an array of java.io.Files. This array gets passed to the checker.
-   *
-   * @return
    */
   private List<File> getFilesList() {
     List<File> files = new ArrayList<>();

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/Auditor.java
@@ -226,8 +226,6 @@ public class Auditor {
    * Implementation of the audit listener. This listener creates markers on the file resources if
    * checkstyle messages are reported.
    *
-   * @author David Schneider
-   * @author Lars Ködderitzsch
    */
   private class CheckstyleAuditListener implements AuditListener {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/CheckerFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/CheckerFactory.java
@@ -162,9 +162,7 @@ public final class CheckerFactory {
     URL configLocation = configFileData.getResolvedConfigFileURL();
     String checkConfigName = config.getName() + "#" + (config.isGlobal() ? "Global" : "Local");
 
-    String cacheKey = project.getName() + "#" + configLocation + "#" + checkConfigName;
-
-    return cacheKey;
+    return project.getName() + "#" + configLocation + "#" + checkConfigName;
   }
 
   /**

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/CheckerFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/CheckerFactory.java
@@ -55,7 +55,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
 /**
  * Factory class to create (and cache) checker objects.
  *
- * @author Lars Ködderitzsch
  */
 public final class CheckerFactory {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/CheckstyleBuilder.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/builder/CheckstyleBuilder.java
@@ -61,8 +61,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
 /**
  * Project builder for Checkstyle plug-in.
  *
- * @author David Schneider
- * @author Lars Ködderitzsch
  */
 public class CheckstyleBuilder extends IncrementalProjectBuilder {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckConfiguration.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckConfiguration.java
@@ -63,7 +63,7 @@ public class CheckConfiguration implements ICheckConfiguration {
   private CheckstyleConfigurationFile mCheckstyleConfigurationFile;
 
   /** Time stamp when the cached configuration file data expires. */
-  private long mExpirationTime = 0;
+  private long mExpirationTime;
 
   /**
    * Creates a check configuration instance.

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckConfiguration.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckConfiguration.java
@@ -35,7 +35,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
  * Base implementation of a check configuration. Leaves the specific tasks to the concrete
  * subclasses.
  *
- * @author Lars Ködderitzsch
  */
 public class CheckConfiguration implements ICheckConfiguration {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckConfigurationFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckConfigurationFactory.java
@@ -147,9 +147,8 @@ public final class CheckConfigurationFactory {
       return sDefaultBuiltInConfig;
     } else if (!sConfigurations.isEmpty()) {
       return sConfigurations.get(0);
-    } else {
-      return null;
     }
+    return null;
   }
 
   /**

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckConfigurationFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckConfigurationFactory.java
@@ -145,7 +145,7 @@ public final class CheckConfigurationFactory {
       return sDefaultCheckConfig;
     } else if (sDefaultBuiltInConfig != null) {
       return sDefaultBuiltInConfig;
-    } else if (sConfigurations.size() > 0) {
+    } else if (!sConfigurations.isEmpty()) {
       return sConfigurations.get(0);
     } else {
       return null;

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckConfigurationFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckConfigurationFactory.java
@@ -282,8 +282,7 @@ public final class CheckConfigurationFactory {
     currentStateLocation = currentStateLocation.removeFirstSegments(segmentsToRemove);
 
     // Now add to the target workspace root
-    IPath targetStateLocation = newWorkspaceRoot.append(currentStateLocation);
-    return targetStateLocation;
+    return newWorkspaceRoot.append(currentStateLocation);
 
   }
 
@@ -335,8 +334,7 @@ public final class CheckConfigurationFactory {
   private static File getInternalConfigurationFile() {
     IPath configPath = CheckstylePlugin.getDefault().getStateLocation();
     configPath = configPath.append(CHECKSTYLE_CONFIG_FILE);
-    File configFile = configPath.toFile();
-    return configFile;
+    return configPath.toFile();
   }
 
   /**

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckConfigurationTester.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckConfigurationTester.java
@@ -45,7 +45,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
  * </ul>
  * .
  *
- * @author Lars Ködderitzsch
  */
 public class CheckConfigurationTester {
 
@@ -112,7 +111,6 @@ public class CheckConfigurationTester {
    * not being resolved by a given other property resolver. This is used to find unresolved
    * properties after all other property reolvers have been asked.
    *
-   * @author Lars Ködderitzsch
    */
   private static class MissingPropertyCollector implements PropertyResolver {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckConfigurationWorkingCopy.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckConfigurationWorkingCopy.java
@@ -53,7 +53,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
  * This class acts as wrapper around check configurations to add editing aspects. Check
  * configurations by themself are not editable.
  *
- * @author Lars Ködderitzsch
  */
 public class CheckConfigurationWorkingCopy implements ICheckConfiguration, Cloneable {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckstyleConfigurationFile.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/CheckstyleConfigurationFile.java
@@ -31,7 +31,6 @@ import com.puppycrawl.tools.checkstyle.PropertyResolver;
  * Simple object containing all sort of data of a Checkstyle configuration. This is done to not
  * access the Checkstyle configuration file too many times to get small bits of information.
  *
- * @author Lars Ködderitzsch
  */
 public class CheckstyleConfigurationFile {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ConfigProperty.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ConfigProperty.java
@@ -148,8 +148,7 @@ public class ConfigProperty implements Comparable<ConfigProperty>, Cloneable {
   @Override
   public ConfigProperty clone() {
     try {
-      ConfigProperty clone = (ConfigProperty) super.clone();
-      return clone;
+      return (ConfigProperty) super.clone();
     } catch (CloneNotSupportedException ex) {
       // Should not happen
       throw new InternalError(ex);

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ConfigurationReader.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ConfigurationReader.java
@@ -43,7 +43,6 @@ import net.sf.eclipsecs.core.util.XMLUtil;
 /**
  * Utility class to read a checkstyle configuration and transform to the plugins module objects.
  *
- * @author Lars Ködderitzsch
  */
 public final class ConfigurationReader {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ConfigurationReader.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ConfigurationReader.java
@@ -200,14 +200,14 @@ public final class ConfigurationReader {
       final boolean isPropertyRef = (value != null)
               && PROPERTY_REF_PATTERN.matcher(value).matches();
 
-      if (name.equals(XMLTags.SEVERITY_TAG) && (module.getMetaData() != null)
+      if (XMLTags.SEVERITY_TAG.equals(name) && (module.getMetaData() != null)
               && module.getMetaData().hasSeverity()) {
         try {
           module.setSeverity(Severity.valueOf(value));
         } catch (final IllegalArgumentException ex) {
           module.setSeverity(Severity.inherit);
         }
-      } else if (name.equals(XMLTags.ID_TAG)) {
+      } else if (XMLTags.ID_TAG.equals(name)) {
         module.setId(Strings.emptyToNull(value));
       } else if (module.getMetaData() != null) {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ConfigurationWriter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ConfigurationWriter.java
@@ -42,7 +42,6 @@ import net.sf.eclipsecs.core.util.XMLUtil;
 /**
  * Writes the modules of a checkstyle configuration to an output stream.
  *
- * @author Lars Ködderitzsch
  */
 public final class ConfigurationWriter {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ConfigurationWriter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ConfigurationWriter.java
@@ -159,7 +159,7 @@ public final class ConfigurationWriter {
 
     // Write severity only if it differs from the parents severity
     Severity severity = parentSeverity;
-    if (module.getSeverity() != null && !Severity.inherit.equals(module.getSeverity())) {
+    if (module.getSeverity() != null && Severity.inherit != module.getSeverity()) {
 
       Element propertyEl = moduleEl.addElement(XMLTags.PROPERTY_TAG);
       propertyEl.addAttribute(XMLTags.NAME_TAG, XMLTags.SEVERITY_TAG);

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ConfigurationWriter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ConfigurationWriter.java
@@ -239,7 +239,7 @@ public final class ConfigurationWriter {
       String childParent = tmp.getMetaData().getParentModule();
 
       // only the checker module has no parent
-      if (parentInternalName == null && childParent.equals("Root")) {
+      if (parentInternalName == null && "Root".equals(childParent)) {
         childModules.add(tmp);
       } else if (childParent.equals(parentInternalName)) {
         childModules.add(tmp);

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ConfigurationWriter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ConfigurationWriter.java
@@ -109,7 +109,7 @@ public final class ConfigurationWriter {
       // find the root module (Checker)
       // the root module is the only module that has no parent
       List<Module> rootModules = getChildModules(null, modules);
-      if (rootModules.size() < 1) {
+      if (rootModules.isEmpty()) {
         throw new CheckstylePluginException(Messages.errorNoRootModule);
       }
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/GlobalCheckConfigurationWorkingSet.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/GlobalCheckConfigurationWorkingSet.java
@@ -52,7 +52,6 @@ import net.sf.eclipsecs.core.util.XMLUtil;
  * Working set implementation that manages global configurations configured for the Eclipse
  * workspace.
  *
- * @author Lars Ködderitzsch
  */
 public class GlobalCheckConfigurationWorkingSet implements ICheckConfigurationWorkingSet {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/GlobalCheckConfigurationWorkingSet.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/GlobalCheckConfigurationWorkingSet.java
@@ -167,7 +167,7 @@ public class GlobalCheckConfigurationWorkingSet implements ICheckConfigurationWo
 
   @Override
   public boolean isDirty() {
-    if (mDeletedConfigurations.size() > 0) {
+    if (!mDeletedConfigurations.isEmpty()) {
       return true;
     }
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ICheckConfiguration.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ICheckConfiguration.java
@@ -30,7 +30,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
 /**
  * Interface for a check configuration object.
  *
- * @author Lars Ködderitzsch
  */
 public interface ICheckConfiguration {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ICheckConfigurationWorkingSet.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ICheckConfigurationWorkingSet.java
@@ -30,7 +30,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
 /**
  * Interface for implementations that provide editing services for a group of check configuration.
  *
- * @author Lars Ködderitzsch
  */
 public interface ICheckConfigurationWorkingSet {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/Module.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/Module.java
@@ -32,7 +32,6 @@ import net.sf.eclipsecs.core.config.meta.RuleMetadata;
 /**
  * Object representing a module from a checkstyle configuration. Can be augmented with meta data.
  *
- * @author Lars Ködderitzsch
  */
 public class Module implements Cloneable {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/Module.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/Module.java
@@ -271,11 +271,11 @@ public class Module implements Cloneable {
     }
 
     if (defaultLevel != null) {
-      if (severityLevel.equals(defaultLevel)) {
+      if (severityLevel == defaultLevel) {
         mSeverityLevel = null;
         setLastEnabledSeverity(null);
-      } else if (Severity.ignore.equals(severityLevel)) {
-        if (mSeverityLevel != null && !Severity.ignore.equals(mSeverityLevel)) {
+      } else if (Severity.ignore == severityLevel) {
+        if (mSeverityLevel != null && Severity.ignore != mSeverityLevel) {
           setLastEnabledSeverity(mSeverityLevel);
         }
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ResolvableProperty.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ResolvableProperty.java
@@ -27,8 +27,6 @@ import com.google.common.base.MoreObjects;
 /**
  * Represents a configuration property who's value must be resolved.
  *
- * @author David Schneider
- * @author Lars Ködderitzsch
  */
 public class ResolvableProperty implements Cloneable {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ResolvableProperty.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/ResolvableProperty.java
@@ -99,8 +99,7 @@ public class ResolvableProperty implements Cloneable {
   @Override
   public ResolvableProperty clone() {
     try {
-      ResolvableProperty clone = (ResolvableProperty) super.clone();
-      return clone;
+      return (ResolvableProperty) super.clone();
     } catch (CloneNotSupportedException ex) {
       // should never happen
       throw new InternalError(ex);

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/Severity.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/Severity.java
@@ -24,7 +24,6 @@ package net.sf.eclipsecs.core.config;
  * Enumeration for Checkstyle's severity levels. The intent is to decouple highler level funtions
  * (UI) from dealing with Checkstyle code API.
  *
- * @author Lars Ködderitzsch
  */
 public enum Severity {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/BuiltInConfigurationType.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/BuiltInConfigurationType.java
@@ -36,7 +36,6 @@ import net.sf.eclipsecs.core.config.ICheckConfiguration;
  * Implementation of the configuration type for a built in check configuration, that is located
  * inside the plugin.
  *
- * @author Lars Ködderitzsch
  */
 public class BuiltInConfigurationType extends ConfigurationType {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/BuiltInFilePropertyResolver.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/BuiltInFilePropertyResolver.java
@@ -33,7 +33,6 @@ import com.puppycrawl.tools.checkstyle.PropertyResolver;
  * Adds support for additional checkstyle config files (header, suppressions etc.) to be delivered
  * with a builtin configuration.
  *
- * @author Lars Ködderitzsch
  */
 public class BuiltInFilePropertyResolver implements PropertyResolver {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ClasspathVariableResolver.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ClasspathVariableResolver.java
@@ -28,7 +28,6 @@ import com.puppycrawl.tools.checkstyle.PropertyResolver;
 /**
  * Property resolver that tries to resolve values from classpath variables.
  *
- * @author Lars Ködderitzsch
  */
 public class ClasspathVariableResolver implements PropertyResolver {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ConfigurationType.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ConfigurationType.java
@@ -42,7 +42,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
 /**
  * Base implementation of <code>IConfigurationType</code>.
  *
- * @author Lars Ködderitzsch
  */
 public abstract class ConfigurationType implements IConfigurationType {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ConfigurationTypes.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ConfigurationTypes.java
@@ -37,7 +37,6 @@ import net.sf.eclipsecs.core.util.CheckstyleLog;
  * Register for the configuration types thats use the <i>net.sf.eclipsecs.core.configurationtypes
  * </i> extension point.
  *
- * @author Lars Ködderitzsch
  */
 public final class ConfigurationTypes {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ExternalFileConfigurationType.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ExternalFileConfigurationType.java
@@ -34,7 +34,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
 /**
  * Implementation of a check configuration that uses an exteral checkstyle configuration file.
  *
- * @author Lars Ködderitzsch
  */
 public class ExternalFileConfigurationType extends ConfigurationType {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/IConfigurationType.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/IConfigurationType.java
@@ -29,7 +29,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
 /**
  * Interface for a configuration type.
  *
- * @author Lars Ködderitzsch
  */
 public interface IConfigurationType {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/IContextAware.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/IContextAware.java
@@ -25,7 +25,6 @@ import org.eclipse.core.resources.IProject;
 /**
  * Interface for plugin property resolvers.
  *
- * @author Lars Ködderitzsch
  */
 public interface IContextAware {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/InternalConfigurationType.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/InternalConfigurationType.java
@@ -36,7 +36,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
  * Implementation of the configuration type for a internal check configuration, that is located
  * inside the plugin.
  *
- * @author Lars Ködderitzsch
  */
 public class InternalConfigurationType extends ConfigurationType {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/MultiPropertyResolver.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/MultiPropertyResolver.java
@@ -34,7 +34,6 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
  * child resolvers are asked to resolve the properties in the order they are added. This
  * PropertyResolver adds the property chaining feature, to allow properties within properties.
  *
- * @author Lars Ködderitzsch
  */
 public class MultiPropertyResolver implements PropertyResolver, IContextAware {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ProjectConfigurationType.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ProjectConfigurationType.java
@@ -39,7 +39,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
 /**
  * Implementation of a check configuration that uses an exteral checkstyle configuration file.
  *
- * @author Lars Ködderitzsch
  */
 public class ProjectConfigurationType extends ConfigurationType {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/PropertyUtil.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/PropertyUtil.java
@@ -31,7 +31,6 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
  * Utility class for handling strings that contain properties using the very common ${propertyName}
  * pattern. The code originally comes from the ANT project.
  *
- * @author Lars Ködderitzsch
  */
 public final class PropertyUtil {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/RemoteConfigurationType.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/RemoteConfigurationType.java
@@ -57,7 +57,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
 /**
  * Implementation of a check configuration that uses an exteral checkstyle configuration file.
  *
- * @author Lars Ködderitzsch
  */
 public class RemoteConfigurationType extends ConfigurationType {
 
@@ -332,7 +331,6 @@ public class RemoteConfigurationType extends ConfigurationType {
   /**
    * Support for http authentication.
    *
-   * @author Lars Ködderitzsch
    */
   public static final class RemoteConfigAuthenticator {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ResolvablePropertyResolver.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ResolvablePropertyResolver.java
@@ -30,7 +30,6 @@ import net.sf.eclipsecs.core.config.ResolvableProperty;
 /**
  * Resolves properties set up with the check configuration.
  *
- * @author Lars Ködderitzsch
  */
 public class ResolvablePropertyResolver implements PropertyResolver {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ResourceBundlePropertyResolver.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/ResourceBundlePropertyResolver.java
@@ -28,7 +28,6 @@ import com.puppycrawl.tools.checkstyle.PropertyResolver;
 /**
  * Property resolver that resolves properties from a resource bundle.
  *
- * @author Lars Ködderitzsch
  */
 class ResourceBundlePropertyResolver implements PropertyResolver {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/StandardPropertyResolver.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/StandardPropertyResolver.java
@@ -28,7 +28,6 @@ import com.puppycrawl.tools.checkstyle.PropertyResolver;
 /**
  * Property resolver that resolves some eclipse standard variables.
  *
- * @author Lars Ködderitzsch
  */
 public class StandardPropertyResolver implements PropertyResolver, IContextAware {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/SystemPropertyResolver.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/configtypes/SystemPropertyResolver.java
@@ -25,7 +25,6 @@ import com.puppycrawl.tools.checkstyle.PropertyResolver;
 /**
  * Property resolver implementation that resolves system properties.
  *
- * @author Lars Ködderitzsch
  */
 public class SystemPropertyResolver implements PropertyResolver {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/AllTokensProvider.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/AllTokensProvider.java
@@ -30,7 +30,6 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Class that provides all known tokens from the checkstyle java grammar. This is used for modules
  * that allow all tokens as options - which is very tedious to maintain in the metadata.
  *
- * @author Lars Ködderitzsch
  */
 public class AllTokensProvider implements IOptionProvider {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/ConfigPropertyMetadata.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/ConfigPropertyMetadata.java
@@ -139,7 +139,7 @@ public class ConfigPropertyMetadata {
    * @return boolean
    */
   public boolean isHidden() {
-    return ConfigPropertyType.Hidden.equals(mDatatype);
+    return ConfigPropertyType.Hidden == mDatatype;
   }
 
 }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/IOptionProvider.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/IOptionProvider.java
@@ -27,7 +27,6 @@ import java.util.List;
  * which would be too difficult to handle in metadata. For instance this is true for module metadata
  * that need all token types as options.
  *
- * @author Lars Ködderitzsch
  */
 public interface IOptionProvider {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
@@ -519,8 +519,7 @@ public final class MetadataFactory {
                 CheckstylePlugin.getPlatformLocale(), CheckstylePlugin.class.getClassLoader(),
                 new UTF8Control());
 
-        String message = resourceBundle.getString(messageKey);
-        return message;
+        return resourceBundle.getString(messageKey);
       } catch (MissingResourceException ex) {
         // let's continue to check the other alternative names
       }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
@@ -873,7 +873,6 @@ public final class MetadataFactory {
    * Custom ResourceBundle.Control implementation which allows explicitly read the properties files
    * as UTF-8.
    *
-   * @author <a href="mailto:nesterenko-aleksey@list.ru">Aleksey Nesterenko</a>
    */
   private static class UTF8Control extends Control {
     @Override

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
@@ -578,10 +578,6 @@ public final class MetadataFactory {
     loadRuleMetadata();
   }
 
-  /**
-   * @param metadataFile
-   * @return
-   */
   private static String groupId(String metadataFile) {
     String res = StringUtils.substringBetween(metadataFile, "/checks/", "/");
     res = StringUtils.defaultString(res, metadataFile);

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/meta/MetadataFactory.java
@@ -220,9 +220,9 @@ public final class MetadataFactory {
     if (sPropertyTypeMap.get(propertyType) != null) {
       String validationType = modulePropertyDetails.getValidationType();
       if (validationType != null) {
-        if (validationType.equals(TYPE_ID_PATTERN)) {
+        if (TYPE_ID_PATTERN.equals(validationType)) {
           dataType = ConfigPropertyType.Regex;
-        } else if (validationType.equals("tokenSet") || validationType.equals("tokenTypesSet")) {
+        } else if ("tokenSet".equals(validationType) || "tokenTypesSet".equals(validationType)) {
           dataType = ConfigPropertyType.MultiCheck;
         }
       } else {

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/savefilter/CheckerModuleSaveFilter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/savefilter/CheckerModuleSaveFilter.java
@@ -29,7 +29,6 @@ import net.sf.eclipsecs.core.config.meta.MetadataFactory;
 /**
  * Special module logic for the Checker module.
  *
- * @author Lars Ködderitzsch
  */
 public class CheckerModuleSaveFilter implements ISaveFilter {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/savefilter/ISaveFilter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/savefilter/ISaveFilter.java
@@ -27,7 +27,6 @@ import net.sf.eclipsecs.core.config.Module;
 /**
  * Interface to implement special module logic.
  *
- * @author Lars Ködderitzsch
  */
 public interface ISaveFilter {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/savefilter/SaveFilters.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/savefilter/SaveFilters.java
@@ -35,7 +35,6 @@ import net.sf.eclipsecs.core.util.CheckstyleLog;
  * Register for the filters thats use the <i>net.sf.eclipsecs.core.checkstyleFilter </i> extension
  * point. Checkstyle filters can be enabled per project.
  *
- * @author Lars Ködderitzsch
  */
 public final class SaveFilters {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/savefilter/SortingSaveFilter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/savefilter/SortingSaveFilter.java
@@ -30,7 +30,6 @@ import net.sf.eclipsecs.core.config.XMLTags;
 /**
  * Save filter that sorts modules in a certain order.
  *
- * @author Lars Ködderitzsch
  */
 public class SortingSaveFilter implements ISaveFilter {
 
@@ -45,7 +44,6 @@ public class SortingSaveFilter implements ISaveFilter {
    * Comparator to sort modules so that Checker and TreeWalker come first. This is done because of a
    * bug in SuppressionCommentFilter.
    *
-   * @author Lars Ködderitzsch
    */
   private static class ModuleComparator implements Comparator<Module> {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/savefilter/SuppressWarningsHolderSaveFilter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/savefilter/SuppressWarningsHolderSaveFilter.java
@@ -29,7 +29,6 @@ import net.sf.eclipsecs.core.config.meta.MetadataFactory;
 /**
  * Special module logic for the SuppressWarningsHolder module.
  *
- * @author Lars Ködderitzsch
  */
 public class SuppressWarningsHolderSaveFilter implements ISaveFilter {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/savefilter/TreeWalkerModuleSaveFilter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/config/savefilter/TreeWalkerModuleSaveFilter.java
@@ -29,7 +29,6 @@ import net.sf.eclipsecs.core.config.meta.MetadataFactory;
 /**
  * Special module logic for the TreeWalker module.
  *
- * @author Lars Ködderitzsch
  */
 public class TreeWalkerModuleSaveFilter implements ISaveFilter {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/AuditorJob.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/AuditorJob.java
@@ -37,7 +37,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
  * Job to de-couple an audit. Used for the "Run Checkstyle in background on full build"
  * functionality.
  *
- * @author Lars Ködderitzsch
  */
 public class AuditorJob extends AbstractCheckJob {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/BuildProjectJob.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/BuildProjectJob.java
@@ -34,7 +34,6 @@ import net.sf.eclipsecs.core.nature.CheckstyleNature;
 /**
  * Operation which builds a project.
  *
- * @author Lars Ködderitzsch
  */
 public class BuildProjectJob extends Job {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/ConfigureDeconfigureNatureJob.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/ConfigureDeconfigureNatureJob.java
@@ -39,7 +39,6 @@ import net.sf.eclipsecs.core.Messages;
  * already configured with this nature, the nature will be deconfigured. Otherwise if the project is
  * not configured with this nature, the nature will be configured for this project
  *
- * @author Lars Ködderitzsch
  */
 public class ConfigureDeconfigureNatureJob extends WorkspaceJob {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/RunCheckstyleOnFilesJob.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/RunCheckstyleOnFilesJob.java
@@ -47,7 +47,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
 /**
  * Job that invokes Checkstyle on a list of workspace files.
  *
- * @author Lars Ködderitzsch
  */
 public class RunCheckstyleOnFilesJob extends AbstractCheckJob {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/TransformCheckstyleRulesJob.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/TransformCheckstyleRulesJob.java
@@ -53,7 +53,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
 /**
  * Job which starts transforming the checkstyle-rules to eclipse-formatter-settings.
  *
- * @author Lukas Frena
  *
  */
 public class TransformCheckstyleRulesJob extends WorkspaceJob {

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/TransformFormatterRulesJob.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/jobs/TransformFormatterRulesJob.java
@@ -40,7 +40,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
 /**
  * Job who starts transforming the formatter-rules to checkstyle-settings.
  *
- * @author Lukas Frena
  *
  */
 public class TransformFormatterRulesJob extends WorkspaceJob {

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/IProjectConfiguration.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/IProjectConfiguration.java
@@ -30,7 +30,6 @@ import net.sf.eclipsecs.core.projectconfig.filters.IFilter;
 /**
  * The public interface of a project configuration.
  *
- * @author Lars Ködderitzsch
  */
 public interface IProjectConfiguration {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/LocalCheckConfigurationWorkingSet.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/LocalCheckConfigurationWorkingSet.java
@@ -37,7 +37,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
 /**
  * Working set implementation that manages local configurations configured for the project.
  *
- * @author Lars Ködderitzsch
  */
 public class LocalCheckConfigurationWorkingSet implements ICheckConfigurationWorkingSet {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/LocalCheckConfigurationWorkingSet.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/LocalCheckConfigurationWorkingSet.java
@@ -110,7 +110,7 @@ public class LocalCheckConfigurationWorkingSet implements ICheckConfigurationWor
 
   @Override
   public boolean isDirty() {
-    if (mDeletedConfigurations.size() > 0) {
+    if (!mDeletedConfigurations.isEmpty()) {
       return true;
     }
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/PluginFilters.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/PluginFilters.java
@@ -34,7 +34,6 @@ import net.sf.eclipsecs.core.util.CheckstyleLog;
  * Register for the filters thats use the <i>net.sf.eclipsecs.core.checkstyleFilter </i> extension
  * point. Checkstyle filters can be enabled per project.
  *
- * @author Lars Ködderitzsch
  */
 public final class PluginFilters {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/ProjectConfiguration.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/ProjectConfiguration.java
@@ -39,7 +39,6 @@ import net.sf.eclipsecs.core.projectconfig.filters.IFilter;
  * Represents the configuration for a project. Contains the file sets configured for the project
  * plus the additional filters.
  *
- * @author Lars Ködderitzsch
  */
 public class ProjectConfiguration implements Cloneable, IProjectConfiguration {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/ProjectConfigurationFactory.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/ProjectConfigurationFactory.java
@@ -123,7 +123,7 @@ public final class ProjectConfigurationFactory {
    */
   public static boolean isCheckConfigInUse(ICheckConfiguration checkConfig)
           throws CheckstylePluginException {
-    return getProjectsUsingConfig(checkConfig).size() > 0;
+    return !getProjectsUsingConfig(checkConfig).isEmpty();
   }
 
   /**

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/ProjectConfigurationWorkingCopy.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/ProjectConfigurationWorkingCopy.java
@@ -56,7 +56,6 @@ import net.sf.eclipsecs.core.util.XMLUtil;
 /**
  * A modifiable project configuration implementation.
  *
- * @author Lars Ködderitzsch
  */
 public class ProjectConfigurationWorkingCopy implements Cloneable, IProjectConfiguration {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/AbstractFilter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/AbstractFilter.java
@@ -28,7 +28,6 @@ import com.google.common.base.MoreObjects;
 /**
  * Base implementation of a filter.
  *
- * @author Lars Ködderitzsch
  */
 public abstract class AbstractFilter implements IFilter {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/DerivedFilesFilter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/DerivedFilesFilter.java
@@ -25,7 +25,6 @@ import org.eclipse.core.resources.IResource;
 /**
  * Implementation of a filter that filters all ressources that are derived (e.g. generated sources).
  *
- * @author Lars Ködderitzsch
  */
 public class DerivedFilesFilter extends AbstractFilter {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/FilesInSyncFilter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/FilesInSyncFilter.java
@@ -34,7 +34,6 @@ import net.sf.eclipsecs.core.util.CheckstyleLog;
 /**
  * Filters all files that are in sync with the source repository.
  *
- * @author Lars Ködderitzsch
  */
 public class FilesInSyncFilter extends AbstractFilter {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/IFilter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/IFilter.java
@@ -25,7 +25,6 @@ import java.util.List;
 /**
  * Interface for a filter.
  *
- * @author Lars Ködderitzsch
  */
 public interface IFilter extends Cloneable {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/NonSrcDirsFilter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/NonSrcDirsFilter.java
@@ -36,7 +36,6 @@ import net.sf.eclipsecs.core.util.CheckstyleLog;
 /**
  * Implementation of a filter that filters all ressources that are not within a source directory.
  *
- * @author Lars Ködderitzsch
  */
 public class NonSrcDirsFilter extends AbstractFilter {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/PackageFilter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/PackageFilter.java
@@ -33,7 +33,6 @@ import org.eclipse.core.runtime.Path;
  * filters resources that lie within excluded packages. This filter is used for the checkstyle audit
  * function of this plugin.
  *
- * @author Lars Ködderitzsch
  */
 public class PackageFilter extends AbstractFilter {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/UnOpenedFilesFilter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/UnOpenedFilesFilter.java
@@ -28,7 +28,6 @@ import org.eclipse.core.resources.IFile;
 /**
  * Filter that excludes all files that are not opened in an eclipse editor.
  *
- * @author Lars Ködderitzsch
  */
 public class UnOpenedFilesFilter extends AbstractFilter {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/WriteProtectedFilter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/projectconfig/filters/WriteProtectedFilter.java
@@ -26,7 +26,6 @@ import org.eclipse.core.resources.ResourceAttributes;
 /**
  * Implementation of a filter that filters all ressources that are write protected.
  *
- * @author Lars Ködderitzsch
  */
 public class WriteProtectedFilter extends AbstractFilter {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/CTransformationClass.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/CTransformationClass.java
@@ -30,7 +30,6 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
  * Abstract class which all transformationclasses have to implement. These classes handle how to
  * react on a checkstyle-rule.
  *
- * @author Lukas Frena
  */
 public abstract class CTransformationClass {
   /** The eclipse-configuration for this rule. */

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/CheckstyleFileWriter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/CheckstyleFileWriter.java
@@ -31,7 +31,6 @@ import net.sf.eclipsecs.core.util.CheckstyleLog;
 /**
  * Class for writing the checkstyle configuration to a xml-file.
  *
- * @author Lukas Frena
  *
  */
 public class CheckstyleFileWriter {

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/CheckstyleSetting.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/CheckstyleSetting.java
@@ -26,7 +26,6 @@ import java.util.Iterator;
 /**
  * Class for storing all settings of a checkstyle-configuration file.
  *
- * @author Lukas Frena
  *
  */
 public class CheckstyleSetting {

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/CheckstyleTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/CheckstyleTransformer.java
@@ -35,7 +35,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
  * The Class for transforming the checkstyle-rules into eclipse-formatter-settings. A new
  * formatter-profile gets created.
  *
- * @author Lukas Frena
  */
 public class CheckstyleTransformer {
   /** An object containing all settings for the eclipse-formatter. */

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/FTransformationClass.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/FTransformationClass.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
  * Abstract class which all transformationclasses have to implement. These classes handle how to
  * react on a formatter-setting.
  *
- * @author Lukas Frena
  */
 public abstract class FTransformationClass {
   /** The checkstyle-configuration for this rule. */

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/FormatterConfigParser.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/FormatterConfigParser.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 /**
  * Class for parsing a eclipse-formatter-configuration-file for formatter-settings.
  *
- * @author Lukas Frena
  */
 public class FormatterConfigParser {
   /** A FormatterConfiguration with all rules that will be found. */

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/FormatterConfigWriter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/FormatterConfigWriter.java
@@ -36,9 +36,6 @@ import net.sf.eclipsecs.core.util.CheckstyleLog;
  * Class for writing a new eclipse-configuration-file. Gets used by class Transformer. Two
  * eclipse-formatter-profile files gets written to the project root.
  *
- * @author Alexandros Karypidis
- * @author Lukas Frena
- * @author Lars Ködderitzsch
  */
 public class FormatterConfigWriter {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/FormatterConfiguration.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/FormatterConfiguration.java
@@ -28,7 +28,6 @@ import java.util.Map;
 /**
  * Class containing all configurations for a eclipse-formatter-profile.
  *
- * @author Lukas Frena
  */
 public class FormatterConfiguration {
   /** Map containing all eclipse editor-settings. */

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/FormatterTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/FormatterTransformer.java
@@ -31,7 +31,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
  * The Class for transforming the formatter-settings to Checkstyle-rules. A new checkstyle-xml file
  * gets generated.
  *
- * @author Lukas Frena
  */
 public class FormatterTransformer {
   /** An object containing all settings for the checkstyle-file. */

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/XmlProfileWriter.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/XmlProfileWriter.java
@@ -45,7 +45,6 @@ import net.sf.eclipsecs.core.util.CheckstyleLog;
 /**
  * Utility class to write eclipse formatter/cleanup profile XML files.
  *
- * @author Alexandros Karypidis
  *
  */
 public final class XmlProfileWriter {

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/AvoidStarImportTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/AvoidStarImportTransformer.java
@@ -27,7 +27,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule AvoidStarImport to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class AvoidStarImportTransformer extends CTransformationClass {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/FileTabCharacterTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/FileTabCharacterTransformer.java
@@ -27,7 +27,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule FileTabCharacter to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class FileTabCharacterTransformer extends CTransformationClass {
   @Override

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/FinalLocalVariableTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/FinalLocalVariableTransformer.java
@@ -29,7 +29,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule FinalLocalVariableWrap to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class FinalLocalVariableTransformer extends CTransformationClass {
   @Override

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/FinalLocalVariableTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/FinalLocalVariableTransformer.java
@@ -42,10 +42,10 @@ public class FinalLocalVariableTransformer extends CTransformationClass {
     String token;
     while (args.hasMoreTokens()) {
       token = args.nextToken();
-      if (token.equals("VARIABLE_DEF")) {
+      if ("VARIABLE_DEF".equals(token)) {
         useCleanupSetting("make_local_variable_final", "true");
         useCleanupSetting("make_private_fields_final", "true");
-      } else if (token.equals("PARAMETER_DEF")) {
+      } else if ("PARAMETER_DEF".equals(token)) {
         useCleanupSetting("make_parameters_final", "true");
       }
     }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/FinalParametersTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/FinalParametersTransformer.java
@@ -27,7 +27,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule FinalParameters to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class FinalParametersTransformer extends CTransformationClass {
   @Override

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/GenericWhitespaceTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/GenericWhitespaceTransformer.java
@@ -27,7 +27,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule GerenricWhitespace to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class GenericWhitespaceTransformer extends CTransformationClass {
   @Override

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/IndentationTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/IndentationTransformer.java
@@ -46,9 +46,9 @@ public class IndentationTransformer extends CTransformationClass {
       val = "4";
     }
 
-    if (val.equals("4")) {
+    if ("4".equals(val)) {
       userFormatterSetting("indent_switchstatements_compare_to_switch", "true");
-    } else if (val.equals("0")) {
+    } else if ("0".equals(val)) {
       userFormatterSetting("indent_switchstatements_compare_to_switch", "false");
     }
     return getFormatterSetting();

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/IndentationTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/IndentationTransformer.java
@@ -27,7 +27,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule IdentationWrap to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class IndentationTransformer extends CTransformationClass {
   @Override

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/LeftCurlyTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/LeftCurlyTransformer.java
@@ -28,7 +28,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
 /**
  * Wrapperclass for converting the checkstyle-rule LeftCurly to appropriate eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class LeftCurlyTransformer extends CTransformationClass {
   @Override

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/LeftCurlyTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/LeftCurlyTransformer.java
@@ -45,33 +45,33 @@ public class LeftCurlyTransformer extends CTransformationClass {
     if (option == null) {
       option = "eol";
     }
-    if (option.equals("eol")) {
+    if ("eol".equals(option)) {
       option = "end_of_line";
-    } else if (option.equals("nl") || option.equals("nlow")) {
+    } else if ("nl".equals(option) || "nlow".equals(option)) {
       option = "next_line";
     }
 
     while (token.hasMoreTokens()) {
       tok = token.nextToken();
-      if (tok.equals("CLASS_DEF")) {
+      if ("CLASS_DEF".equals(tok)) {
         userFormatterSetting("brace_position_for_anonymous_type_declaration", option);
         userFormatterSetting("brace_position_for_enum_constant", option);
         userFormatterSetting("brace_position_for_enum_declaration", option);
         userFormatterSetting("brace_position_for_type_declaration", option);
         userFormatterSetting("brace_position_for_annotation_type_declaration", option);
-      } else if (tok.equals("INTERFACE_DEF")) {
+      } else if ("INTERFACE_DEF".equals(tok)) {
         userFormatterSetting("brace_position_for_annotation_type_declaration", option);
         userFormatterSetting("brace_position_for_type_declaration", option);
-      } else if (tok.equals("CTOR_DEF")) {
+      } else if ("CTOR_DEF".equals(tok)) {
         userFormatterSetting("brace_position_for_constructor_declaration", option);
-      } else if (tok.equals("METHOD_DEF")) {
+      } else if ("METHOD_DEF".equals(tok)) {
         userFormatterSetting("brace_position_for_method_declaration", option);
-      } else if (tok.equals("LITERAL_DO") || tok.equals("LITERAL_ELSE") || tok.equals("LITERAL_FOR")
-              || tok.equals("LITERAL_IF") || tok.equals("LITERAL_WHILE")
-              || tok.equals("LITERAL_CATCH") || tok.equals("LITERAL_FINALLY")
-              || tok.equals("LITERAL_TRY")) {
+      } else if ("LITERAL_DO".equals(tok) || "LITERAL_ELSE".equals(tok) || "LITERAL_FOR".equals(tok)
+              || "LITERAL_IF".equals(tok) || "LITERAL_WHILE".equals(tok)
+              || "LITERAL_CATCH".equals(tok) || "LITERAL_FINALLY".equals(tok)
+              || "LITERAL_TRY".equals(tok)) {
         userFormatterSetting("brace_position_for_block", option);
-      } else if (tok.equals("LITERAL_SWITCH")) {
+      } else if ("LITERAL_SWITCH".equals(tok)) {
         userFormatterSetting("brace_position_for_switch", option);
       }
     }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/LineLengthTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/LineLengthTransformer.java
@@ -27,7 +27,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule LineLength to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class LineLengthTransformer extends CTransformationClass {
   @Override

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/MethodParamPadTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/MethodParamPadTransformer.java
@@ -43,13 +43,13 @@ public class MethodParamPadTransformer extends CTransformationClass {
     String token;
     while (args.hasMoreTokens()) {
       token = args.nextToken();
-      if (token.equals("CTOR_DEF")) {
+      if ("CTOR_DEF".equals(token)) {
         userFormatterSetting("insert_space_before_opening_paren_in_constructor_declaration",
                 "do not insert");
-      } else if (token.equals("METHOD_CALL") || token.equals("SUPER_CTOR_CALL")) {
+      } else if ("METHOD_CALL".equals(token) || "SUPER_CTOR_CALL".equals(token)) {
         userFormatterSetting("insert_space_before_opening_paren_in_method_invocation",
                 "do not insert");
-      } else if (token.equals("METHOD_DEF")) {
+      } else if ("METHOD_DEF".equals(token)) {
         userFormatterSetting("insert_space_before_opening_paren_in_method_declaration",
                 "do not insert");
       }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/MethodParamPadTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/MethodParamPadTransformer.java
@@ -29,7 +29,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule MethodParamPad to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class MethodParamPadTransformer extends CTransformationClass {
   @Override

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/MissingDeprecatedTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/MissingDeprecatedTransformer.java
@@ -27,7 +27,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule MissingDeprecated to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class MissingDeprecatedTransformer extends CTransformationClass {
   @Override

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/MissingOverrideTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/MissingOverrideTransformer.java
@@ -27,7 +27,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule MissingOverride to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class MissingOverrideTransformer extends CTransformationClass {
   @Override

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/NeedBracesTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/NeedBracesTransformer.java
@@ -27,7 +27,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule NeedBraces to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class NeedBracesTransformer extends CTransformationClass {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/NewlineAtEndOfFileTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/NewlineAtEndOfFileTransformer.java
@@ -26,7 +26,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
 /**
  * Transforms the "New Line At End Of File" checkstyle rule to the respective formatter setting.
  *
- * @author Lukas Frena
  */
 public class NewlineAtEndOfFileTransformer extends CTransformationClass {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/NoWhitespaceAfterTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/NoWhitespaceAfterTransformer.java
@@ -29,7 +29,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule NoWhitespaceAfter to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class NoWhitespaceAfterTransformer extends CTransformationClass {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/NoWhitespaceAfterTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/NoWhitespaceAfterTransformer.java
@@ -44,12 +44,12 @@ public class NoWhitespaceAfterTransformer extends CTransformationClass {
     // TODO tokens DOT ARRAY_INIT
     while (args.hasMoreTokens()) {
       token = args.nextToken();
-      if (token.equals("DEC") || token.equals("INC")) {
+      if ("DEC".equals(token) || "INC".equals(token)) {
         userFormatterSetting("insert_space_after_prefix_operator", "do not insert");
-      } else if (token.equals("UNARY_MINUS") || token.equals("LNOT") || token.equals("UNARY_PLUS")
-              || token.equals("BNOT")) {
+      } else if ("UNARY_MINUS".equals(token) || "LNOT".equals(token) || "UNARY_PLUS".equals(token)
+              || "BNOT".equals(token)) {
         userFormatterSetting("insert_space_after_unary_operator", "do not insert");
-      } else if (token.equals("TYPECAST")) {
+      } else if ("TYPECAST".equals(token)) {
         userFormatterSetting("insert_space_after_closing_paren_in_cast", "do not insert");
       }
     }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/NoWhitespaceBeforeTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/NoWhitespaceBeforeTransformer.java
@@ -27,7 +27,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule NoWhitespaceBefore to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class NoWhitespaceBeforeTransformer extends CTransformationClass {
   @Override

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/ParenPadTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/ParenPadTransformer.java
@@ -41,7 +41,7 @@ public class ParenPadTransformer extends CTransformationClass {
     if (option == null) {
       option = "nospace";
     }
-    if (option.equals("nospace")) {
+    if ("nospace".equals(option)) {
       option = "do not insert";
     } else {
       option = "insert";
@@ -51,7 +51,7 @@ public class ParenPadTransformer extends CTransformationClass {
     String token;
     while (tokens.hasMoreTokens()) {
       token = tokens.nextToken();
-      if (token.equals("LPAREN")) {
+      if ("LPAREN".equals(token)) {
         userFormatterSetting("insert_space_after_opening_paren_in_parenthesized_expression",
                 option);
         userFormatterSetting("insert_space_after_opening_paren_in_while", option);
@@ -65,7 +65,7 @@ public class ParenPadTransformer extends CTransformationClass {
         userFormatterSetting("insert_space_after_opening_paren_in_constructor_declaration", option);
         userFormatterSetting("insert_space_after_opening_paren_in_enum_constant", option);
         userFormatterSetting("insert_space_after_opening_paren_in_method_declaration", option);
-      } else if (token.equals("RPAREN")) {
+      } else if ("RPAREN".equals(token)) {
         userFormatterSetting("insert_space_before_closing_paren_in_parenthesized_expression",
                 option);
         userFormatterSetting("insert_space_before_closing_paren_in_while", option);
@@ -80,8 +80,8 @@ public class ParenPadTransformer extends CTransformationClass {
                 option);
         userFormatterSetting("insert_space_before_closing_paren_in_enum_constant", option);
         userFormatterSetting("insert_space_before_closing_paren_in_annotation", option);
-      } else if (token.equals("CTOR_CALL") || token.equals("METHOD_CALL")
-              || token.equals("SUPER_CTOR_CALL")) {
+      } else if ("CTOR_CALL".equals(token) || "METHOD_CALL".equals(token)
+              || "SUPER_CTOR_CALL".equals(token)) {
         userFormatterSetting("insert_space_before_closing_paren_in_method_invocation", option);
         userFormatterSetting("insert_space_after_opening_paren_in_method_invocation", option);
       }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/ParenPadTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/ParenPadTransformer.java
@@ -28,7 +28,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
 /**
  * Wrapperclass for converting the checkstyle-rule ParenPad to appropriate eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class ParenPadTransformer extends CTransformationClass {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/RedundantImportTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/RedundantImportTransformer.java
@@ -27,7 +27,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule RedundantImport to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class RedundantImportTransformer extends CTransformationClass {
   @Override

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/RequireThisTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/RequireThisTransformer.java
@@ -27,7 +27,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule RequireThis to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class RequireThisTransformer extends CTransformationClass {
   @Override

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/RightCurlyTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/RightCurlyTransformer.java
@@ -29,7 +29,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule RightCurly to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class RightCurlyTransformer extends CTransformationClass {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/RightCurlyTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/RightCurlyTransformer.java
@@ -46,7 +46,7 @@ public class RightCurlyTransformer extends CTransformationClass {
     if (option == null) {
       option = "same";
     }
-    if (option.equals("same")) {
+    if ("same".equals(option)) {
       option = "do not insert";
     } else {
       option = "insert";
@@ -54,11 +54,11 @@ public class RightCurlyTransformer extends CTransformationClass {
 
     while (token.hasMoreTokens()) {
       tok = token.nextToken();
-      if (tok.equals("LITERAL_CATCH")) {
+      if ("LITERAL_CATCH".equals(tok)) {
         userFormatterSetting("insert_new_line_before_catch_in_try_statement", option);
-      } else if (tok.equals("LITERAL_FINALLY")) {
+      } else if ("LITERAL_FINALLY".equals(tok)) {
         userFormatterSetting("insert_new_line_before_finally_in_try_statement", option);
-      } else if (tok.equals("LITERAL_ELSE")) {
+      } else if ("LITERAL_ELSE".equals(tok)) {
         userFormatterSetting("insert_new_line_before_else_in_if_statement", option);
       }
     }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/TabCharacterTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/TabCharacterTransformer.java
@@ -27,7 +27,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule TabCharacter to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class TabCharacterTransformer extends CTransformationClass {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/TypecastParenPadTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/TypecastParenPadTransformer.java
@@ -36,7 +36,7 @@ public class TypecastParenPadTransformer extends CTransformationClass {
     if (option == null) {
       option = "nospace";
     }
-    if (option.equals("space")) {
+    if ("space".equals(option)) {
       option = "insert";
     } else {
       option = "do not insert";

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/TypecastParenPadTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/TypecastParenPadTransformer.java
@@ -27,7 +27,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule TypecastParenPad to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class TypecastParenPadTransformer extends CTransformationClass {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/UnusedImportsTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/UnusedImportsTransformer.java
@@ -27,7 +27,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule UnusedImports to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class UnusedImportsTransformer extends CTransformationClass {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/WhitespaceAfterTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/WhitespaceAfterTransformer.java
@@ -44,7 +44,7 @@ public class WhitespaceAfterTransformer extends CTransformationClass {
 
     while (token.hasMoreTokens()) {
       tok = token.nextToken();
-      if (tok.equals("COMMA")) {
+      if ("COMMA".equals(tok)) {
         userFormatterSetting("insert_space_after_comma_in_annotation", "insert");
         userFormatterSetting("insert_space_after_comma_in_type_arguments", "insert");
         userFormatterSetting("insert_space_after_comma_in_type_parameters", "insert");
@@ -67,7 +67,7 @@ public class WhitespaceAfterTransformer extends CTransformationClass {
         userFormatterSetting("insert_space_after_comma_in_parameterized_type_reference", "insert");
         userFormatterSetting("insert_space_after_comma_in_method_invocation_arguments", "insert");
         userFormatterSetting("insert_space_after_comma_in_multiple_local_declarations", "insert");
-      } else if (tok.equals("TYPECAST")) {
+      } else if ("TYPECAST".equals(tok)) {
         userFormatterSetting("insert_space_after_closing_paren_in_cast", "insert");
       }
     }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/WhitespaceAfterTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/WhitespaceAfterTransformer.java
@@ -29,7 +29,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule WhitespaceAfter to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class WhitespaceAfterTransformer extends CTransformationClass {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/WhitespaceAroundTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/WhitespaceAroundTransformer.java
@@ -49,29 +49,29 @@ public class WhitespaceAroundTransformer extends CTransformationClass {
 
     while (token.hasMoreTokens()) {
       tok = token.nextToken();
-      if (tok.equals("ASSIGN") || tok.equals("BAND_ASSIGN") || tok.equals("BOR_ASSIGN")
-              || tok.equals("BSR_ASSIGN") || tok.equals("BXOR_ASSIGN") || tok.equals("DIV_ASSIGN")
-              || tok.equals("MINUS_ASSIGN") || tok.equals("MOD_ASSIGN") || tok.equals("PLUS_ASSIGN")
-              || tok.equals("SL_ASSIGN") || tok.equals("SR_ASSIGN") || tok.equals("STAR_ASSIGN")) {
+      if ("ASSIGN".equals(tok) || "BAND_ASSIGN".equals(tok) || "BOR_ASSIGN".equals(tok)
+              || "BSR_ASSIGN".equals(tok) || "BXOR_ASSIGN".equals(tok) || "DIV_ASSIGN".equals(tok)
+              || "MINUS_ASSIGN".equals(tok) || "MOD_ASSIGN".equals(tok) || "PLUS_ASSIGN".equals(tok)
+              || "SL_ASSIGN".equals(tok) || "SR_ASSIGN".equals(tok) || "STAR_ASSIGN".equals(tok)) {
         userFormatterSetting("insert_space_after_assignment_operator", "insert");
         userFormatterSetting("insert_space_before_assignment_operator", "insert");
-      } else if ((tok.equals("BAND") || tok.equals("BOR") || tok.equals("BSR") || tok.equals("BXOR")
-              || tok.equals("DIV") || tok.equals("EQUAL") || tok.equals("GE") || tok.equals("GT")
-              || tok.equals("LAND") || tok.equals("LE") || tok.equals("LOR") || tok.equals("LT")
-              || tok.equals("MINUS") || tok.equals("MOD") || tok.equals("NOT_EQUAL")
-              || tok.equals("PLUS") || tok.equals("SL") || tok.equals("SR")
-              || tok.equals("STAR"))) {
+      } else if (("BAND".equals(tok) || "BOR".equals(tok) || "BSR".equals(tok) || "BXOR".equals(tok)
+              || "DIV".equals(tok) || "EQUAL".equals(tok) || "GE".equals(tok) || "GT".equals(tok)
+              || "LAND".equals(tok) || "LE".equals(tok) || "LOR".equals(tok) || "LT".equals(tok)
+              || "MINUS".equals(tok) || "MOD".equals(tok) || "NOT_EQUAL".equals(tok)
+              || "PLUS".equals(tok) || "SL".equals(tok) || "SR".equals(tok)
+              || "STAR".equals(tok))) {
         userFormatterSetting("insert_space_after_binary_operator", "insert");
         userFormatterSetting("insert_space_before_binary_operator", "insert");
-      } else if (tok.equals("COLON")) {
+      } else if ("COLON".equals(tok)) {
         userFormatterSetting("insert_space_before_colon_in_for", "insert");
         userFormatterSetting("insert_space_after_colon_in_for", "insert");
         userFormatterSetting("insert_space_before_colon_in_conditional", "insert");
         userFormatterSetting("insert_space_after_colon_in_conditional", "insert");
-      } else if (tok.equals("QUESTION")) {
+      } else if ("QUESTION".equals(tok)) {
         userFormatterSetting("insert_space_after_question_in_conditional", "insert");
         userFormatterSetting("insert_space_before_question_in_conditional", "insert");
-      } else if (tok.equals("LCURLY")) {
+      } else if ("LCURLY".equals(tok)) {
         userFormatterSetting("insert_space_before_opening_brace_in_type_declaration", "insert");
         userFormatterSetting("insert_space_after_opening_brace_in_array_initializer", "insert");
         userFormatterSetting("insert_space_before_opening_brace_in_annotation_type_declaration",
@@ -86,20 +86,20 @@ public class WhitespaceAroundTransformer extends CTransformationClass {
         userFormatterSetting("insert_space_before_opening_brace_in_anonymous_type_declaration",
                 "insert");
         userFormatterSetting("insert_space_before_opening_brace_in_array_initializer", "insert");
-      } else if (tok.equals("RCURLY")) {
+      } else if ("RCURLY".equals(tok)) {
         userFormatterSetting("insert_space_after_closing_brace_in_block", "insert");
         userFormatterSetting("insert_space_before_closing_brace_in_array_initializer", "insert");
-      } else if (tok.equals("LITERAL_CATCH")) {
+      } else if ("LITERAL_CATCH".equals(tok)) {
         userFormatterSetting("insert_space_before_opening_paren_in_catch", "insert");
-      } else if (tok.equals("LITERAL_FOR")) {
+      } else if ("LITERAL_FOR".equals(tok)) {
         userFormatterSetting("insert_space_before_opening_paren_in_for", "insert");
-      } else if (tok.equals("LITERAL_IF")) {
+      } else if ("LITERAL_IF".equals(tok)) {
         userFormatterSetting("insert_space_before_opening_paren_in_if", "insert");
-      } else if (tok.equals("LITERAL_RETURN")) {
+      } else if ("LITERAL_RETURN".equals(tok)) {
         userFormatterSetting("insert_space_before_parenthesized_expression_in_return", "insert");
-      } else if (tok.equals("LITERAL_SYNCHRONIZED")) {
+      } else if ("LITERAL_SYNCHRONIZED".equals(tok)) {
         userFormatterSetting("insert_space_before_opening_paren_in_synchronized", "insert");
-      } else if (tok.equals("LITERAL_WHILE")) {
+      } else if ("LITERAL_WHILE".equals(tok)) {
         userFormatterSetting("insert_space_before_opening_paren_in_while", "insert");
       }
     }

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/WhitespaceAroundTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/WhitespaceAroundTransformer.java
@@ -29,7 +29,6 @@ import net.sf.eclipsecs.core.transformer.FormatterConfiguration;
  * Wrapperclass for converting the checkstyle-rule WhitespaceAround to appropriate
  * eclipse-formatter-rules.
  *
- * @author Lukas Frena
  */
 public class WhitespaceAroundTransformer extends CTransformationClass {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ftransformerclasses/T_insert_space_before_opening_paren_in_method_invocation.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ftransformerclasses/T_insert_space_before_opening_paren_in_method_invocation.java
@@ -29,7 +29,6 @@ import net.sf.eclipsecs.core.transformer.FTransformationClass;
  * Transformerclass for converting the formatter-setting
  * "insert.space.before.opening.paren.in.method.invocation" to appropriate checkstyle-modules.
  *
- * @author Lukas Frena
  */
 public class T_insert_space_before_opening_paren_in_method_invocation extends FTransformationClass {
   @Override

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ftransformerclasses/T_tabulation_char.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ftransformerclasses/T_tabulation_char.java
@@ -27,7 +27,6 @@ import net.sf.eclipsecs.core.transformer.FTransformationClass;
  * Transformerclass for converting the formatter-setting tabulation.char to appropriate
  * checkstyle-modules.
  *
- * @author Lukas Frena
  */
 public class T_tabulation_char extends FTransformationClass {
   @Override

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/util/EclipseLogHandler.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/util/EclipseLogHandler.java
@@ -37,7 +37,6 @@ import net.sf.eclipsecs.core.Messages;
  * log events that get directly passed into the internal eclipse logging.<br/>
  * This class act as bridge from java.util.logging to eclipse logging.
  *
- * @author Lars Ködderitzsch
  */
 public class EclipseLogHandler extends Handler {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/util/ExtensionClassLoader.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/util/ExtensionClassLoader.java
@@ -37,7 +37,6 @@ import org.osgi.framework.Bundle;
  * Classloader implementation which can load classes and resources from bundles implementing a
  * specific extension point.
  *
- * @author Lars Ködderitzsch
  */
 public class ExtensionClassLoader extends ClassLoader {
 

--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/util/XMLUtil.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/util/XMLUtil.java
@@ -67,7 +67,6 @@ public final class XMLUtil {
   /**
    * Entity resolver which handles mapping public DTDs to internal DTD resource.
    *
-   * @author Lars Ködderitzsch
    */
   public static class InternalDtdEntityResolver implements EntityResolver {
 

--- a/net.sf.eclipsecs.ui/pom.xml
+++ b/net.sf.eclipsecs.ui/pom.xml
@@ -15,12 +15,6 @@
                 <groupId>org.eclipse.tycho</groupId>
                 <artifactId>tycho-source-plugin</artifactId>
             </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/CheckstyleMarkerImageProvider.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/CheckstyleMarkerImageProvider.java
@@ -30,7 +30,6 @@ import net.sf.eclipsecs.core.builder.CheckstyleMarker;
 /**
  * Image provider for Checkstyle markers.
  *
- * @author Lars Ködderitzsch
  */
 public class CheckstyleMarkerImageProvider implements IAnnotationImageProvider {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/CheckstyleUIPluginImages.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/CheckstyleUIPluginImages.java
@@ -34,7 +34,6 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 /**
  * Manages and caches images for the plugin.
  *
- * @author Lars Ködderitzsch
  */
 public enum CheckstyleUIPluginImages {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/CheckstyleUIPluginPrefs.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/CheckstyleUIPluginPrefs.java
@@ -34,7 +34,6 @@ import net.sf.eclipsecs.core.util.CheckstyleLog;
 /**
  * Initialize the plugin preferences.
  *
- * @author Lars Ködderitzsch
  */
 public class CheckstyleUIPluginPrefs extends AbstractPreferenceInitializer {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/Messages.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/Messages.java
@@ -26,7 +26,6 @@ import org.eclipse.osgi.util.NLS;
  * Class providing messages for the checkstyle plugin. Uses the eclipse new nls
  * mechanism.
  *
- * @author Lars Ködderitzsch
  */
 public final class Messages extends NLS {
   // CHECKSTYLE:OFF

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/ActivateProjectsAction.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/ActivateProjectsAction.java
@@ -41,7 +41,6 @@ import net.sf.eclipsecs.ui.Messages;
 /**
  * Action to enable Checkstyle on one ore more projects.
  *
- * @author Lars Ködderitzsch
  */
 public class ActivateProjectsAction implements IObjectActionDelegate {
 
@@ -70,7 +69,6 @@ public class ActivateProjectsAction implements IObjectActionDelegate {
   /**
    * Activates Checkstyle on a collection of projects.
    *
-   * @author Lars Ködderitzsch
    */
   private static class BulkCheckstyleActivateJob extends WorkspaceJob {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/CheckSelectedFilesAction.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/CheckSelectedFilesAction.java
@@ -47,7 +47,6 @@ import net.sf.eclipsecs.ui.CheckstyleUIPlugin;
 /**
  * Action to run Checkstyle on one ore more projects.
  *
- * @author Lars Ködderitzsch
  */
 public class CheckSelectedFilesAction extends AbstractHandler implements IObjectActionDelegate {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/CheckstyleTransformingAction.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/CheckstyleTransformingAction.java
@@ -32,7 +32,6 @@ import net.sf.eclipsecs.core.jobs.TransformCheckstyleRulesJob;
 /**
  * Action to start transforming checkstyle-rules to formatter-rules.
  *
- * @author lakiluk
  */
 public class CheckstyleTransformingAction implements IObjectActionDelegate {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/ClearSelectedFilesAction.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/ClearSelectedFilesAction.java
@@ -41,7 +41,6 @@ import net.sf.eclipsecs.ui.Messages;
 /**
  * Action to diable Checkstyle on one ore more projects.
  *
- * @author Lars Ködderitzsch
  */
 public class ClearSelectedFilesAction implements IObjectActionDelegate {
 
@@ -73,7 +72,6 @@ public class ClearSelectedFilesAction implements IObjectActionDelegate {
   /**
    * Activates Checkstyle on a collection of projects.
    *
-   * @author Lars Ködderitzsch
    */
   private static class ClearMarkersJob extends WorkspaceJob {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/ConfigureProjectFromBluePrintAction.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/ConfigureProjectFromBluePrintAction.java
@@ -54,7 +54,6 @@ import net.sf.eclipsecs.ui.Messages;
  * Action to configure one ore more projects at once by using another project as
  * blueprint.
  *
- * @author Lars Ködderitzsch
  */
 public class ConfigureProjectFromBluePrintAction implements IObjectActionDelegate {
 
@@ -109,7 +108,6 @@ public class ConfigureProjectFromBluePrintAction implements IObjectActionDelegat
    * Job implementation that configures several projects from a blueprint
    * project.
    *
-   * @author Lars Ködderitzsch
    */
   private static class BulkConfigureJob extends WorkspaceJob {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/DeactivateProjectsAction.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/DeactivateProjectsAction.java
@@ -41,7 +41,6 @@ import net.sf.eclipsecs.ui.Messages;
 /**
  * Action to diable Checkstyle on one ore more projects.
  *
- * @author Lars Ködderitzsch
  */
 public class DeactivateProjectsAction implements IObjectActionDelegate {
 
@@ -70,7 +69,6 @@ public class DeactivateProjectsAction implements IObjectActionDelegate {
   /**
    * Activates Checkstyle on a collection of projects.
    *
-   * @author Lars Ködderitzsch
    */
   private static class BulkCheckstyleActivateJob extends WorkspaceJob {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/FormatterTransformingAction.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/FormatterTransformingAction.java
@@ -30,7 +30,6 @@ import net.sf.eclipsecs.core.jobs.TransformFormatterRulesJob;
 /**
  * Action to start transforming checkstyle-rules to formatter-rules.
  *
- * @author lakiluk
  */
 public class FormatterTransformingAction implements IObjectActionDelegate {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/PurgeCachesAction.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/actions/PurgeCachesAction.java
@@ -34,7 +34,6 @@ import net.sf.eclipsecs.core.builder.CheckerFactory;
  * Simple handle which clears the CheckerFactory caches in order to force reload of supplementary
  * Checkstyle configuration files (suppressions, import control files etc.).
  *
- * @author Lars Ködderitzsch
  */
 public class PurgeCachesAction extends AbstractHandler implements IWorkbenchWindowActionDelegate {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
@@ -100,7 +100,6 @@ import net.sf.eclipsecs.ui.util.table.ITableSettingsProvider;
 /**
  * Enhanced checkstyle configuration editor.
  *
- * @author Lars Ködderitzsch
  */
 public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
 
@@ -500,7 +499,6 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
   /**
    * Controller for this page.
    *
-   * @author Lars Ködderitzsch
    */
   private class PageController implements ISelectionChangedListener, ICheckStateListener,
           IDoubleClickListener, SelectionListener, KeyListener, ModifyListener {
@@ -817,7 +815,6 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
   /**
    * TreeContentProvider that provides the structure of the rule metadata.
    *
-   * @author Lars Ködderitzsch
    */
   private static class MetaDataContentProvider implements ITreeContentProvider {
 
@@ -877,7 +874,6 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
   /**
    * Label-provider for meta data information.
    *
-   * @author Lars Ködderitzsch
    */
   private class MetaDataLabelProvider extends LabelProvider {
 
@@ -941,7 +937,6 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
   /**
    * Label provider for the table showing the configured modules.
    *
-   * @author Lars Ködderitzsch
    */
   private static class ModuleLabelProvider extends LabelProvider
           implements ITableLabelProvider, ITableComparableProvider, ITableSettingsProvider {
@@ -1008,7 +1003,6 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
   /**
    * Viewer filter that includes all modules that belong to the currently selected group.
    *
-   * @author Lars Ködderitzsch
    */
   private static class RuleGroupModuleFilter extends ViewerFilter {
 
@@ -1051,7 +1045,6 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
    * Filter implementation that filters the module tree with respect of a filter text field to input
    * a search word.
    *
-   * @author Lars Ködderitzsch
    */
   private class TreeFilter extends ViewerFilter {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationConfigureDialog.java
@@ -1070,11 +1070,9 @@ public class CheckConfigurationConfigureDialog extends TitleAreaDialog {
       String ruleName = element.getRuleName();
       String internalName = element.getInternalName();
       String description = element.getDescription();
-      boolean passes = (ruleName != null && matchPattern.matcher(ruleName).find())
+      return (ruleName != null && matchPattern.matcher(ruleName).find())
               || (internalName != null && matchPattern.matcher(internalName).find())
               || (description != null && matchPattern.matcher(description).find());
-
-      return passes;
     }
 
     private boolean selectGroup(RuleGroupMetadata group, String filterText) {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationPropertiesDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationPropertiesDialog.java
@@ -65,7 +65,6 @@ import net.sf.eclipsecs.ui.config.configtypes.ICheckConfigurationEditor;
  * Dialog to show/edit the properties (name, location, description) of a check
  * configuration. Also used to create new check configurations.
  *
- * @author Lars Ködderitzsch
  */
 public class CheckConfigurationPropertiesDialog extends TitleAreaDialog {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationWorkingSetEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationWorkingSetEditor.java
@@ -76,7 +76,6 @@ import net.sf.eclipsecs.ui.util.table.ITableSettingsProvider;
 /**
  * This class provides the editor GUI for a check configuration working set.
  *
- * @author Lars Ködderitzsch
  */
 public class CheckConfigurationWorkingSetEditor {
 
@@ -557,7 +556,6 @@ public class CheckConfigurationWorkingSetEditor {
    * Label provider for the check configuration table. Implements also support for table sorting and
    * storing of the table settings.
    *
-   * @author Lars Ködderitzsch
    */
   private class ConfigurationLabelProvider extends CheckConfigurationLabelProvider
           implements ITableLabelProvider, ITableComparableProvider, ITableSettingsProvider {
@@ -628,7 +626,6 @@ public class CheckConfigurationWorkingSetEditor {
   /**
    * Controller for this page.
    *
-   * @author Lars Ködderitzsch
    */
   private class PageController
           implements SelectionListener, IDoubleClickListener, ISelectionChangedListener {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationWorkingSetEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/CheckConfigurationWorkingSetEditor.java
@@ -136,8 +136,7 @@ public class CheckConfigurationWorkingSetEditor {
     //
     // Create the check configuration section of the screen.
     //
-    Composite configComposite = createCheckConfigContents(ancestor);
-    return configComposite;
+    return createCheckConfigContents(ancestor);
   }
 
   /**

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/PropertiesContentAssistProcessor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/PropertiesContentAssistProcessor.java
@@ -37,7 +37,6 @@ import net.sf.eclipsecs.ui.Messages;
 /**
  * Provides content assist for builtin properties.
  *
- * @author Lars Ködderitzsch
  */
 public class PropertiesContentAssistProcessor
         implements ISubjectControlContentAssistProcessor {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/ResolvablePropertiesDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/ResolvablePropertiesDialog.java
@@ -70,7 +70,6 @@ import net.sf.eclipsecs.ui.util.table.ITableSettingsProvider;
  * Dialog to show/edit the properties (name, location, description) of a check
  * configuration. Also used to create new check configurations.
  *
- * @author Lars Ködderitzsch
  */
 public class ResolvablePropertiesDialog extends TitleAreaDialog {
 
@@ -293,7 +292,6 @@ public class ResolvablePropertiesDialog extends TitleAreaDialog {
   /**
    * Controller for this dialog.
    *
-   * @author Lars Ködderitzsch
    */
   private class Controller implements SelectionListener, IDoubleClickListener, KeyListener {
 
@@ -437,7 +435,6 @@ public class ResolvablePropertiesDialog extends TitleAreaDialog {
    * Label provider for the check configuration table. Implements also support
    * for table sorting and storing of the table settings.
    *
-   * @author Lars Ködderitzsch
    */
   private class PropertiesLabelProvider extends LabelProvider
           implements ITableLabelProvider, ITableComparableProvider, ITableSettingsProvider {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/RuleConfigurationEditDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/RuleConfigurationEditDialog.java
@@ -92,7 +92,7 @@ public class RuleConfigurationEditDialog extends TitleAreaDialog {
 
   private Map<String, Text> mCustomMessages;
 
-  private boolean mReadonly = false;
+  private boolean mReadonly;
 
   /**
    * Constructor.

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/BuiltInConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/BuiltInConfigurationEditor.java
@@ -38,7 +38,6 @@ import net.sf.eclipsecs.ui.config.CheckConfigurationPropertiesDialog;
  * Implementation of a location editor with only a not editable text field. This
  * is used to just show the location.
  *
- * @author Lars Ködderitzsch
  */
 public class BuiltInConfigurationEditor implements ICheckConfigurationEditor {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ConfigurationTypesUI.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ConfigurationTypesUI.java
@@ -41,7 +41,6 @@ import net.sf.eclipsecs.ui.CheckstyleUIPlugin;
  * Register for the configuration types ui thats use the
  * <i>net.sf.eclipsecs.ui.configtypesui </i> extension point.
  *
- * @author Lars Ködderitzsch
  */
 public final class ConfigurationTypesUI {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ConfigurationTypesUI.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ConfigurationTypesUI.java
@@ -122,8 +122,7 @@ public final class ConfigurationTypesUI {
     if (editorClass != null) {
 
       try {
-        ICheckConfigurationEditor editor = editorClass.getDeclaredConstructor().newInstance();
-        return editor;
+        return editorClass.getDeclaredConstructor().newInstance();
       } catch (ClassCastException | ReflectiveOperationException ex) {
         CheckstylePluginException.rethrow(ex);
       }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ExternalFileConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ExternalFileConfigurationEditor.java
@@ -53,7 +53,6 @@ import net.sf.eclipsecs.ui.config.CheckConfigurationPropertiesDialog;
  * Implementation of a file based location editor. Contains a text field with
  * the config file path and a 'Browse...' button opening a file dialog.
  *
- * @author Lars Ködderitzsch
  */
 public class ExternalFileConfigurationEditor implements ICheckConfigurationEditor {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ICheckConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ICheckConfigurationEditor.java
@@ -31,7 +31,6 @@ import net.sf.eclipsecs.ui.config.CheckConfigurationPropertiesDialog;
 /**
  * Interface for the check configuration type specific location editor.
  *
- * @author Lars Ködderitzsch
  */
 public interface ICheckConfigurationEditor {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/InternalConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/InternalConfigurationEditor.java
@@ -55,7 +55,6 @@ import net.sf.eclipsecs.ui.config.CheckConfigurationPropertiesDialog;
  * Implementation of a location editor to input a remote location. Contains just
  * a text field to input the URL.
  *
- * @author Lars Ködderitzsch
  */
 public class InternalConfigurationEditor implements ICheckConfigurationEditor {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ProjectConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/ProjectConfigurationEditor.java
@@ -71,7 +71,6 @@ import net.sf.eclipsecs.ui.config.CheckConfigurationPropertiesDialog;
  * Implementation of a file based location editor. Contains a text field with
  * the config file path and a 'Browse...' button opening a file dialog.
  *
- * @author Lars Ködderitzsch
  */
 public class ProjectConfigurationEditor implements ICheckConfigurationEditor {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/RemoteConfigurationEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/configtypes/RemoteConfigurationEditor.java
@@ -47,7 +47,6 @@ import net.sf.eclipsecs.ui.config.CheckConfigurationPropertiesDialog;
  * Implementation of a location editor to input a remote location. Contains just
  * a text field to input the URL.
  *
- * @author Lars Ködderitzsch
  */
 public class RemoteConfigurationEditor implements ICheckConfigurationEditor {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetMultiCheck.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetMultiCheck.java
@@ -185,7 +185,6 @@ public class ConfigPropertyWidgetMultiCheck extends ConfigPropertyWidgetAbstract
   /**
    * Label provider to translate checkstyle tokens into readable form.
    *
-   * @author Lars Ködderitzsch
    */
   private class TokenLabelProvider extends LabelProvider {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetRegex.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetRegex.java
@@ -160,7 +160,6 @@ public class ConfigPropertyWidgetRegex extends ConfigPropertyWidgetAbstractBase 
   /**
    * Simple key listener to test the regular expression.
    *
-   * @author Lars Ködderitzsch
    */
   private class RegexTestListener implements KeyListener {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetSingleSelect.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetSingleSelect.java
@@ -82,8 +82,7 @@ public class ConfigPropertyWidgetSingleSelect extends ConfigPropertyWidgetAbstra
 
   @Override
   public String getValue() {
-    String result = mComboItem.getItem(mComboItem.getSelectionIndex());
-    return result;
+    return mComboItem.getItem(mComboItem.getSelectionIndex());
   }
 
   @Override

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetStringArray.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/config/widgets/ConfigPropertyWidgetStringArray.java
@@ -48,7 +48,6 @@ public class ConfigPropertyWidgetStringArray extends ConfigPropertyWidgetString 
 
   /**
    * normalize array properties to be separated by a comma and a blank for better readability of the plain config file
-   * @param text
    * @return text with normalized separators
    */
   private String normalizeSeparator(String text) {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/preferences/CheckstylePreferencePage.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/preferences/CheckstylePreferencePage.java
@@ -113,7 +113,7 @@ public class CheckstylePreferencePage extends PreferencePage implements IWorkben
 
   private CheckConfigurationWorkingSetEditor mWorkingSetEditor;
 
-  private boolean mRebuildAll = false;
+  private boolean mRebuildAll;
 
   /**
    * Constructor.

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/preferences/CheckstylePreferencePage.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/preferences/CheckstylePreferencePage.java
@@ -502,7 +502,6 @@ public class CheckstylePreferencePage extends PreferencePage implements IWorkben
   /**
    * Controller for this page.
    *
-   * @author Lars Ködderitzsch
    */
   private class PageController extends SelectionAdapter {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/preferences/CheckstylePreferencePage.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/preferences/CheckstylePreferencePage.java
@@ -460,13 +460,13 @@ public class CheckstylePreferencePage extends PreferencePage implements IWorkben
               .getString(CheckstyleUIPluginPrefs.PREF_ASK_BEFORE_REBUILD);
 
       boolean rebuild = MessageDialogWithToggle.ALWAYS.equals(promptRebuildPref)
-              && (needRebuildAllProjects || projectsToBuild.size() > 0);
+              && (needRebuildAllProjects || !projectsToBuild.isEmpty());
 
       //
       // Prompt for rebuild
       //
       if (MessageDialogWithToggle.PROMPT.equals(promptRebuildPref)
-              && (needRebuildAllProjects || projectsToBuild.size() > 0)) {
+              && (needRebuildAllProjects || !projectsToBuild.isEmpty())) {
 
         MessageDialogWithToggle dialog = MessageDialogWithToggle.openYesNoQuestion(getShell(),
                 Messages.CheckstylePreferencePage_titleRebuild,

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/preferences/CheckstyleSettingsTransfer.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/preferences/CheckstyleSettingsTransfer.java
@@ -34,7 +34,6 @@ import net.sf.eclipsecs.ui.Messages;
  * Support for transferring internal eclipse-cs workspace settings to another
  * workspace.
  *
- * @author Lars Ködderitzsch
  */
 public class CheckstyleSettingsTransfer extends SettingsTransfer {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/CheckConfigurationContentProvider.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/CheckConfigurationContentProvider.java
@@ -34,7 +34,6 @@ import net.sf.eclipsecs.core.projectconfig.ProjectConfigurationWorkingCopy;
 /**
  * Content provider implementation that provides check configurations.
  *
- * @author Lars Ködderitzsch
  */
 class CheckConfigurationContentProvider implements IStructuredContentProvider {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/CheckstylePropertyPage.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/CheckstylePropertyPage.java
@@ -84,7 +84,6 @@ import net.sf.eclipsecs.ui.properties.filter.PluginFilterEditors;
 /**
  * Property page for projects to enable checkstyle audit.
  *
- * @author Lars Ködderitzsch
  */
 public class CheckstylePropertyPage extends PropertyPage {
 
@@ -535,7 +534,6 @@ public class CheckstylePropertyPage extends PropertyPage {
    * This class works as controller for the page. It listenes for events to occur and handles the
    * pages context.
    *
-   * @author Lars Ködderitzsch
    */
   private class PageController extends SelectionAdapter
           implements ISelectionChangedListener, ICheckStateListener, IDoubleClickListener {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/FileMatchPatternEditDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/FileMatchPatternEditDialog.java
@@ -43,8 +43,6 @@ import net.sf.eclipsecs.ui.util.regex.RegexCompletionProposalFactory;
 /**
  * Dialog to edit file match patterns.
  *
- * @author David Schneider
- * @author Lars Ködderitzsch
  */
 public class FileMatchPatternEditDialog extends TitleAreaDialog {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/FileSetEditDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/FileSetEditDialog.java
@@ -571,7 +571,6 @@ public class FileSetEditDialog extends TitleAreaDialog {
   /**
    * Controller of this dialog.
    *
-   * @author Lars Ködderitzsch
    */
   private class Controller implements SelectionListener, IDoubleClickListener, ICheckStateListener,
           ISelectionChangedListener {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/IFileSetsEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/IFileSetsEditor.java
@@ -32,7 +32,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
  * Interface for the part of the checkstyle plugin properties page that
  * configures file sets for the project.
  *
- * @author Lars Ködderitzsch
  */
 public interface IFileSetsEditor {
   /**

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/SimpleFileSetsEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/SimpleFileSetsEditor.java
@@ -93,7 +93,7 @@ public class SimpleFileSetsEditor implements IFileSetsEditor {
     mFileSets = fileSets;
 
     ICheckConfiguration config = null;
-    if (mFileSets.size() > 0) {
+    if (!mFileSets.isEmpty()) {
       config = (mFileSets.get(0)).getCheckConfig();
     }
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/SimpleFileSetsEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/SimpleFileSetsEditor.java
@@ -58,7 +58,6 @@ import net.sf.eclipsecs.ui.config.CheckConfigurationViewerSorter;
  * Simple file sets editor producing only one file set that contains all files. Only the check
  * configuration can be chosen.
  *
- * @author Lars Ködderitzsch
  */
 public class SimpleFileSetsEditor implements IFileSetsEditor {
 
@@ -185,7 +184,6 @@ public class SimpleFileSetsEditor implements IFileSetsEditor {
   /**
    * Controller for this file set editor.
    *
-   * @author Lars Ködderitzsch
    */
   private class Controller implements SelectionListener, ISelectionChangedListener {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/CheckFileOnOpenPartListener.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/CheckFileOnOpenPartListener.java
@@ -71,7 +71,6 @@ import net.sf.eclipsecs.ui.CheckstyleUIPlugin;
  * opened file if the UnOpenedFileFilter is active.
  *
  * @see <a href="https://sourceforge.net/p/eclipse-cs/feature-requests/93/">feature request</a>
- * @author Lars Ködderitzsch
  * @implNote To avoid the restricted access, we would need to copy 2 constants of
  *           {@link IWorkbenchConstants}. However, by referencing those we can verify their
  *           existence more easily by simply switching the target platform to a current version.

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/CheckFileOnOpenPartListener.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/CheckFileOnOpenPartListener.java
@@ -272,8 +272,7 @@ public class CheckFileOnOpenPartListener implements IPartListener2 {
       Method getMementoMethod = editorRef.getClass().getMethod("getMemento", new Class<?>[0]);
       getMementoMethod.setAccessible(true);
 
-      IMemento memento = (IMemento) getMementoMethod.invoke(editorRef, (Object[]) null);
-      return memento;
+      return (IMemento) getMementoMethod.invoke(editorRef, (Object[]) null);
     } catch (NoSuchMethodException | SecurityException | IllegalAccessException | InvocationTargetException ex) {
       CheckstyleLog.log(ex);
     }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/FileTypesFilterEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/FileTypesFilterEditor.java
@@ -46,7 +46,6 @@ import net.sf.eclipsecs.ui.Messages;
 /**
  * Editor dialog for the package filter.
  *
- * @author Lars Ködderitzsch
  */
 public class FileTypesFilterEditor implements IFilterEditor {
 
@@ -98,7 +97,6 @@ public class FileTypesFilterEditor implements IFilterEditor {
   /**
    * Dialog to edit file types to check.
    *
-   * @author Lars Ködderitzsch
    */
   private class FileTypesDialog extends Dialog {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/IFilterEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/IFilterEditor.java
@@ -28,7 +28,6 @@ import org.eclipse.swt.widgets.Shell;
 /**
  * Interface for a filter editor.
  *
- * @author Lars Ködderitzsch
  */
 public interface IFilterEditor {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/PackageFilterEditor.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/PackageFilterEditor.java
@@ -64,7 +64,6 @@ import net.sf.eclipsecs.ui.Messages;
 /**
  * Editor dialog for the package filter.
  *
- * @author Lars Ködderitzsch
  */
 public class PackageFilterEditor implements IFilterEditor {
 
@@ -192,7 +191,6 @@ public class PackageFilterEditor implements IFilterEditor {
   /**
    * Content provider that provides the source folders of a project and their container members.
    *
-   * @author Lars Ködderitzsch
    */
   private static class SourceFolderContentProvider implements ITreeContentProvider {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/PluginFilterEditors.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/PluginFilterEditors.java
@@ -35,7 +35,6 @@ import net.sf.eclipsecs.core.util.CheckstylePluginException;
  * Register for the filter editors thats use the
  * <i>net.sf.eclipsecs.ui.filtereditors </i> extension point.
  *
- * @author Lars Ködderitzsch
  */
 public final class PluginFilterEditors {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/PluginFilterEditors.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/properties/filter/PluginFilterEditors.java
@@ -109,8 +109,7 @@ public final class PluginFilterEditors {
     if (editorClass != null) {
 
       try {
-        IFilterEditor editor = editorClass.getDeclaredConstructor().newInstance();
-        return editor;
+        return editorClass.getDeclaredConstructor().newInstance();
       } catch (ClassCastException | ReflectiveOperationException | SecurityException ex) {
         CheckstylePluginException.rethrow(ex);
       }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/AbstractASTResolution.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/AbstractASTResolution.java
@@ -64,8 +64,6 @@ import net.sf.eclipsecs.ui.Messages;
 /**
  * Abstract base class for marker resolutions using AST rewrite techniques.
  *
- * @author Lars Ködderitzsch
- * @author Philip Graf
  */
 public abstract class AbstractASTResolution extends WorkbenchMarkerResolution
         implements ICheckstyleMarkerResolution {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/CheckstyleMarkerResolutionGenerator.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/CheckstyleMarkerResolutionGenerator.java
@@ -50,7 +50,6 @@ public class CheckstyleMarkerResolutionGenerator implements IMarkerResolutionGen
   }
 
   /**
-   * @param marker
    * @return {@code true} if this is a checkstyle marker
    */
   private boolean isCheckstyleMarker(IMarker marker) {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/CheckstyleMarkerResolutionGenerator.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/CheckstyleMarkerResolutionGenerator.java
@@ -30,7 +30,6 @@ import net.sf.eclipsecs.core.builder.CheckstyleMarker;
 /**
  * Provides marker resolutions (quickfixes) for Checkstyle markers.
  *
- * @author Lars Ködderitzsch
  */
 public class CheckstyleMarkerResolutionGenerator implements IMarkerResolutionGenerator2 {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/CheckstyleQuickfixes.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/CheckstyleQuickfixes.java
@@ -38,7 +38,7 @@ import net.sf.eclipsecs.core.util.CheckstyleLog;
  * @implNote Cached over the runtime of the application. Will not react to plugins loaded
  *           dynamically.
  */
-public class CheckstyleQuickfixes {
+public final class CheckstyleQuickfixes {
 
   /**
    * ID of the quickfix extension point

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/FixCheckstyleMarkersAction.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/FixCheckstyleMarkersAction.java
@@ -33,7 +33,6 @@ import org.eclipse.ui.IWorkbenchPart;
  * This action tries to run all quickfixes for markers on a selected compilation
  * unit.
  *
- * @author Lars Ködderitzsch
  */
 public class FixCheckstyleMarkersAction implements IObjectActionDelegate {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/FixCheckstyleMarkersHandler.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/FixCheckstyleMarkersHandler.java
@@ -37,7 +37,6 @@ import org.eclipse.ui.texteditor.ITextEditor;
  * Command handler to enable key-binding support for the "Apply Checkstyle
  * fixes" action.
  *
- * @author Lars Ködderitzsch
  */
 public class FixCheckstyleMarkersHandler extends AbstractHandler {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/FixCheckstyleMarkersJob.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/FixCheckstyleMarkersJob.java
@@ -36,7 +36,6 @@ import net.sf.eclipsecs.ui.Messages;
 /**
  * Job implementation that tries to fix all Checkstyle markers in a file.
  *
- * @author Lars Ködderitzsch
  */
 public class FixCheckstyleMarkersJob extends UIJob {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/ICheckstyleMarkerResolution.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/ICheckstyleMarkerResolution.java
@@ -26,7 +26,6 @@ import org.eclipse.ui.IMarkerResolution2;
 /**
  * Interface for a quickfix implementation for checkstyle markers.
  *
- * @author Lars Ködderitzsch
  */
 public interface ICheckstyleMarkerResolution extends IMarkerResolution2 {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/MarkerHelpContextProvider.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/MarkerHelpContextProvider.java
@@ -137,9 +137,6 @@ public class MarkerHelpContextProvider extends AbstractContextProvider
   private static final class CheckstyleHelpContext implements IContext {
     private final String moduleName;
 
-    /**
-     * @param moduleName
-     */
     private CheckstyleHelpContext(String moduleName) {
       this.moduleName = moduleName;
     }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/Messages.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/Messages.java
@@ -23,7 +23,7 @@ package net.sf.eclipsecs.ui.quickfixes;
 //CHECKSTYLE:OFF
 import org.eclipse.osgi.util.NLS;
 
-public class Messages extends NLS {
+public final class Messages extends NLS {
   private static final String BUNDLE_NAME = "net.sf.eclipsecs.ui.quickfixes.messages"; //$NON-NLS-1$
 
   private Messages() {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/blocks/AvoidNestedBlocksQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/blocks/AvoidNestedBlocksQuickfix.java
@@ -36,7 +36,6 @@ import net.sf.eclipsecs.ui.quickfixes.Messages;
 /**
  * Quickfix implementation that removes nested blocks.
  *
- * @author Lars Ködderitzsch
  */
 public class AvoidNestedBlocksQuickfix extends AbstractASTResolution {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/blocks/NeedBracesQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/blocks/NeedBracesQuickfix.java
@@ -39,7 +39,6 @@ import net.sf.eclipsecs.ui.quickfixes.Messages;
 /**
  * Quickfix implementation that adds braces to if/for/while/do statements.
  *
- * @author Lars Ködderitzsch
  */
 public class NeedBracesQuickfix extends AbstractASTResolution {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/DefaultComesLastQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/DefaultComesLastQuickfix.java
@@ -38,7 +38,6 @@ import net.sf.eclipsecs.ui.quickfixes.Messages;
  * Quickfix implementation that moves the default case of a switch statement to
  * the last position.
  *
- * @author Lars Ködderitzsch
  */
 public class DefaultComesLastQuickfix extends AbstractASTResolution {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/EmptyStatementQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/EmptyStatementQuickfix.java
@@ -35,7 +35,6 @@ import net.sf.eclipsecs.ui.quickfixes.Messages;
  * Quickfix implementation that removes an empty statement (unneccessary
  * semicolon).
  *
- * @author Lars Ködderitzsch
  */
 public class EmptyStatementQuickfix extends AbstractASTResolution {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/ExplicitInitializationQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/ExplicitInitializationQuickfix.java
@@ -42,7 +42,6 @@ import net.sf.eclipsecs.ui.quickfixes.Messages;
  * Quickfix implementation which removes the explicit default initialization of
  * a class or object member.
  *
- * @author Philip Graf
  */
 public class ExplicitInitializationQuickfix extends AbstractASTResolution {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/FinalLocalVariableQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/FinalLocalVariableQuickfix.java
@@ -36,8 +36,6 @@ import net.sf.eclipsecs.ui.quickfixes.Messages;
  * Quickfix implementation which adds final modifiers to parameters in method
  * declarations.
  *
- * @author Levon Saldamli
- * @author Lars Ködderitzsch
  */
 public class FinalLocalVariableQuickfix extends AbstractASTResolution {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/MissingSwitchDefaultQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/MissingSwitchDefaultQuickfix.java
@@ -34,7 +34,6 @@ import net.sf.eclipsecs.ui.quickfixes.Messages;
  * Quickfix implementation that add a missing default statement to a switch
  * case.
  *
- * @author Levon Saldamli
  */
 public class MissingSwitchDefaultQuickfix extends AbstractASTResolution {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/RequireThisQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/RequireThisQuickfix.java
@@ -45,7 +45,6 @@ import net.sf.eclipsecs.ui.quickfixes.Messages;
  * Quickfix implementation which adds the <code>this</code> qualifier to a field
  * access or method invocation.
  *
- * @author Philip Graf
  */
 public class RequireThisQuickfix extends AbstractASTResolution {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnQuickfix.java
@@ -64,7 +64,6 @@ import net.sf.eclipsecs.ui.quickfixes.Messages;
  * return condition;
  * </pre>
  *
- * @author Philip Graf
  */
 public class SimplifyBooleanReturnQuickfix extends AbstractASTResolution {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnQuickfix.java
@@ -133,7 +133,7 @@ public class SimplifyBooleanReturnQuickfix extends AbstractASTResolution {
           // the return statement might be wrapped in a block statement
           @SuppressWarnings("unchecked")
           final List<Statement> statements = ((Block) node).statements();
-          if (statements.size() > 0) {
+          if (!statements.isEmpty()) {
             return isReturnStatementTrue(statements.get(0));
           }
         }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityQuickfix.java
@@ -43,7 +43,6 @@ import net.sf.eclipsecs.ui.quickfixes.Messages;
  * Quickfix implementation that replaces a string literal comparison using == or
  * != with a proper equals() comparison.
  *
- * @author Lars Ködderitzsch
  */
 public class StringLiteralEqualityQuickfix extends AbstractASTResolution {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/design/DesignForExtensionQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/design/DesignForExtensionQuickfix.java
@@ -38,8 +38,6 @@ import net.sf.eclipsecs.ui.quickfixes.modifier.ModifierOrderQuickfix;
 /**
  * Quickfix implementation which adds the final modifiers a method declaration.
  *
- * @author Levon Saldamli
- * @author Lars Ködderitzsch
  */
 public class DesignForExtensionQuickfix extends AbstractASTResolution {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/design/FinalClassQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/design/FinalClassQuickfix.java
@@ -37,8 +37,6 @@ import net.sf.eclipsecs.ui.quickfixes.modifier.ModifierOrderQuickfix;
 /**
  * Quickfix implementation which adds the final modifiers a method declaration.
  *
- * @author Levon Saldamli
- * @author Lars Ködderitzsch
  */
 public class FinalClassQuickfix extends AbstractASTResolution {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/ArrayTypeStyleQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/ArrayTypeStyleQuickfix.java
@@ -176,9 +176,7 @@ public class ArrayTypeStyleQuickfix extends AbstractASTResolution {
 
       private ArrayType createArrayType(Type componentType, int dimensions) {
         Type type = (Type) ASTNode.copySubtree(componentType.getAST(), componentType);
-        ArrayType arrayType = componentType.getAST().newArrayType(type, dimensions);
-
-        return arrayType;
+        return componentType.getAST().newArrayType(type, dimensions);
       }
     };
   }

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/ArrayTypeStyleQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/ArrayTypeStyleQuickfix.java
@@ -42,7 +42,6 @@ import net.sf.eclipsecs.ui.quickfixes.Messages;
  * Quickfix implementation which moves the array declaration (C-style to
  * Java-style and reverse).
  *
- * @author Lars Ködderitzsch
  */
 public class ArrayTypeStyleQuickfix extends AbstractASTResolution {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/FinalParametersQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/FinalParametersQuickfix.java
@@ -35,8 +35,6 @@ import net.sf.eclipsecs.ui.quickfixes.Messages;
  * Quickfix implementation which adds final modifiers to parameters in method
  * declarations.
  *
- * @author Levon Saldamli
- * @author Lars Ködderitzsch
  */
 public class FinalParametersQuickfix extends AbstractASTResolution {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/UncommentedMainQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/UncommentedMainQuickfix.java
@@ -33,7 +33,6 @@ import net.sf.eclipsecs.ui.quickfixes.Messages;
  * Quickfix implementation which removes uncommented main methods (debugging leftovers) from the
  * code.
  *
- * @author Lars Ködderitzsch
  */
 public class UncommentedMainQuickfix extends AbstractASTResolution {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/UpperEllQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/misc/UpperEllQuickfix.java
@@ -33,7 +33,6 @@ import net.sf.eclipsecs.ui.quickfixes.Messages;
  * Quickfix implementation which changes lowercase 'l' occurrances in long
  * literals into uppercase 'L' to enchance readability.
  *
- * @author Lars Ködderitzsch
  */
 public class UpperEllQuickfix extends AbstractASTResolution {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/modifier/Messages.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/modifier/Messages.java
@@ -23,7 +23,7 @@ package net.sf.eclipsecs.ui.quickfixes.modifier;
 //CHECKSTYLE:OFF
 import org.eclipse.osgi.util.NLS;
 
-public class Messages extends NLS {
+public final class Messages extends NLS {
   private static final String BUNDLE_NAME = "net.sf.eclipsecs.ui.quickfixes.modifier.messages"; //$NON-NLS-1$
 
   private Messages() {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/modifier/ModifierOrderQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/modifier/ModifierOrderQuickfix.java
@@ -47,7 +47,6 @@ import net.sf.eclipsecs.ui.quickfixes.Messages;
 /**
  * Quickfix implementation that orders modifiers into the suggested order by the JLS.
  *
- * @author Lars Ködderitzsch
  */
 public class ModifierOrderQuickfix extends AbstractASTResolution {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/modifier/RedundantModifierQuickfix.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/quickfixes/modifier/RedundantModifierQuickfix.java
@@ -44,7 +44,6 @@ import net.sf.eclipsecs.ui.quickfixes.Messages;
 /**
  * Quickfix implementation that removes redundant modifiers.
  *
- * @author Lars Ködderitzsch
  */
 public class RedundantModifierQuickfix extends AbstractASTResolution {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/Messages.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/Messages.java
@@ -25,7 +25,6 @@ import org.eclipse.osgi.util.NLS;
 /**
  * Class used for i18n.
  *
- * @author Fabrice BELLINGARD
  */
 public final class Messages extends NLS {
   // CHECKSTYLE:OFF

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/data/CreateStatsJob.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/data/CreateStatsJob.java
@@ -44,7 +44,6 @@ import net.sf.eclipsecs.ui.stats.views.internal.CheckstyleMarkerFilter;
 /**
  * Job implementation that builds the data objects for the statistic views.
  *
- * @author Lars Ködderitzsch
  */
 public class CreateStatsJob extends Job {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/data/MarkerStat.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/data/MarkerStat.java
@@ -29,7 +29,6 @@ import org.eclipse.ui.texteditor.MarkerUtilities;
 /**
  * Objet qui donne des statistiques sur les marqueurs.
  *
- * @author Fabrice BELLINGARD
  */
 public class MarkerStat implements Comparable<MarkerStat> {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/data/Stats.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/data/Stats.java
@@ -26,7 +26,6 @@ import java.util.Collection;
  * Classe qui véhicule les statistiques Checkstyle. Elle contient notamment la
  * liste des différentes erreurs avec leur comptage.
  *
- * @author Fabrice BELLINGARD
  */
 public class Stats {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/AbstractStatsView.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/AbstractStatsView.java
@@ -68,8 +68,6 @@ import net.sf.eclipsecs.ui.stats.views.internal.CheckstyleMarkerFilterDialog;
 /**
  * Abstract view that gathers common behaviour for the stats views.
  *
- * @author Fabrice BELLINGARD
- * @author Lars Ködderitzsch
  */
 public abstract class AbstractStatsView extends ViewPart {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilter.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilter.java
@@ -43,7 +43,6 @@ import net.sf.eclipsecs.core.builder.CheckstyleMarker;
 /**
  * Filter class for Checkstyle markers. This filter is used by the Checkstyle statistics views.
  *
- * @author Lars Ködderitzsch
  */
 public class CheckstyleMarkerFilter implements Cloneable {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilterDialog.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/CheckstyleMarkerFilterDialog.java
@@ -56,7 +56,6 @@ import net.sf.eclipsecs.ui.util.regex.RegexCompletionProposalFactory;
 /**
  * Dialog to edit the marker filter.
  *
- * @author Lars Ködderitzsch
  */
 public class CheckstyleMarkerFilterDialog extends TitleAreaDialog {
 
@@ -397,7 +396,6 @@ public class CheckstyleMarkerFilterDialog extends TitleAreaDialog {
   /**
    * The controller for this dialog.
    *
-   * @author Lars Ködderitzsch
    */
   private class PageController implements SelectionListener {
 
@@ -472,7 +470,6 @@ public class CheckstyleMarkerFilterDialog extends TitleAreaDialog {
   /**
    * Dialog to edit regular expressions to filter by.
    *
-   * @author Lars Ködderitzsch
    */
   private class RegexDialog extends TitleAreaDialog {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/FiltersAction.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/stats/views/internal/FiltersAction.java
@@ -29,7 +29,6 @@ import net.sf.eclipsecs.ui.stats.views.AbstractStatsView;
 /**
  * Action implementation for the filters action.
  *
- * @author Lars Ködderitzsch
  */
 public class FiltersAction extends Action {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/SWTUtil.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/SWTUtil.java
@@ -237,7 +237,7 @@ public final class SWTUtil {
     private String mDialogKey;
 
     /** flag that indicates if the dialog was already initally activated. */
-    private boolean mInitialyActivated = false;
+    private boolean mInitialyActivated;
 
     //
     // constructors

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/SWTUtil.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/SWTUtil.java
@@ -50,7 +50,6 @@ import org.eclipse.swt.widgets.Text;
 /**
  * Some widely used helper funktionality regarding SWT shortcomings.
  *
- * @author Lars Ködderitzsch
  */
 public final class SWTUtil {
 
@@ -106,7 +105,6 @@ public final class SWTUtil {
   /**
    * Listener that adds tooltip-on-press support.
    *
-   * @author Lars Ködderitzsch
    */
   private static final class TooltipOnPressListener extends MouseAdapter
           implements MouseTrackListener {
@@ -157,7 +155,6 @@ public final class SWTUtil {
   /**
    * Verifier that allows only digits to be input.
    *
-   * @author Lars Ködderitzsch
    */
   private static final class OnlyDigitsVerifyListener implements VerifyListener {
 
@@ -191,7 +188,6 @@ public final class SWTUtil {
   /**
    * Listener that adds resize support ((re)storing of size and location information).
    *
-   * @author Lars Ködderitzsch
    */
   private static final class ShellResizeSupportListener extends ShellAdapter
           implements ControlListener, DisposeListener {

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/table/EnhancedCheckBoxTableViewer.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/table/EnhancedCheckBoxTableViewer.java
@@ -490,7 +490,7 @@ public class EnhancedCheckBoxTableViewer extends EnhancedTableViewer implements 
 
     transient HashMapEntry[] elementData;
 
-    transient int firstSlot = 0;
+    transient int firstSlot;
 
     transient int lastSlot = -1;
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/table/EnhancedTableViewer.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/table/EnhancedTableViewer.java
@@ -204,7 +204,6 @@ public class EnhancedTableViewer extends TableViewer {
 
   /**
    * Set the sort column. By default the column 0 is used.
-   * @param sortedColumnIndex
    */
   public void setSortedColumnIndex(int sortedColumnIndex) {
     mSortedColumnIndex = sortedColumnIndex;

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/table/EnhancedTableViewer.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/table/EnhancedTableViewer.java
@@ -42,7 +42,6 @@ import net.sf.eclipsecs.ui.CheckstyleUIPlugin;
  * This subclass of <code>TableViewer</code> adds easier sorting support and
  * support for storing table settings (column width, sorter state).
  *
- * @author Lars Ködderitzsch
  */
 public class EnhancedTableViewer extends TableViewer {
   //
@@ -312,7 +311,6 @@ public class EnhancedTableViewer extends TableViewer {
   /**
    * Listener for header clicks and resize events.
    *
-   * @author Lars Ködderitzsch
    */
   private class TableListener implements SelectionListener, ControlListener {
 
@@ -360,7 +358,6 @@ public class EnhancedTableViewer extends TableViewer {
    * Sorter implementation that uses the values provided by the comparable
    * provider to sort the table.
    *
-   * @author Lars Ködderitzsch
    */
   private class TableSorter extends ViewerComparator {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/table/ITableComparableProvider.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/table/ITableComparableProvider.java
@@ -26,7 +26,6 @@ package net.sf.eclipsecs.ui.util.table;
  * ITableLabelProvider except that other comparable objects than Strings can be
  * returned.
  *
- * @author Lars Ködderitzsch
  */
 public interface ITableComparableProvider {
 

--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/table/ITableSettingsProvider.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/util/table/ITableSettingsProvider.java
@@ -26,7 +26,6 @@ import org.eclipse.jface.dialogs.IDialogSettings;
  * Interface for implementations that provide settings where the
  * <code>EnhancedTableViewer</code> can store its current state.
  *
- * @author Lars Ködderitzsch
  */
 public interface ITableSettingsProvider {
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/AvoidNestedBlocksTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/AvoidNestedBlocksTest.java
@@ -27,7 +27,7 @@ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 public class AvoidNestedBlocksTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void testAvoidNestedBlocks() throws Exception {
+  public void avoidNestedBlocks() throws Exception {
     testQuickfix("AvoidNestedBlocksInput.xml", new AvoidNestedBlocksQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/AvoidNestedBlocksTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/AvoidNestedBlocksTest.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.Test;
 
 import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 
-public class AvoidNestedBlocksTest extends AbstractQuickfixTestCase {
+class AvoidNestedBlocksTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void avoidNestedBlocks() throws Exception {
+  void avoidNestedBlocks() throws Exception {
     testQuickfix("AvoidNestedBlocksInput.xml", new AvoidNestedBlocksQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/NeedBracesTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/NeedBracesTest.java
@@ -27,32 +27,32 @@ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 public class NeedBracesTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void testNeedBracesIf() throws Exception {
+  public void needBracesIf() throws Exception {
     testQuickfix("NeedBracesInputIf.xml", new NeedBracesQuickfix());
   }
 
   @Test
-  public void testNeedBracesElse() throws Exception {
+  public void needBracesElse() throws Exception {
     testQuickfix("NeedBracesInputElse.xml", new NeedBracesQuickfix());
   }
 
   @Test
-  public void testNeedBracesElseIf() throws Exception {
+  public void needBracesElseIf() throws Exception {
     testQuickfix("NeedBracesInputElseIf.xml", new NeedBracesQuickfix());
   }
 
   @Test
-  public void testNeedBracesFor() throws Exception {
+  public void needBracesFor() throws Exception {
     testQuickfix("NeedBracesInputFor.xml", new NeedBracesQuickfix());
   }
 
   @Test
-  public void testNeedBracesWhile() throws Exception {
+  public void needBracesWhile() throws Exception {
     testQuickfix("NeedBracesInputWhile.xml", new NeedBracesQuickfix());
   }
 
   @Test
-  public void testNeedBracesDoWhile() throws Exception {
+  public void needBracesDoWhile() throws Exception {
     testQuickfix("NeedBracesInputDoWhile.xml", new NeedBracesQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/NeedBracesTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/blocks/NeedBracesTest.java
@@ -24,35 +24,35 @@ import org.junit.jupiter.api.Test;
 
 import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 
-public class NeedBracesTest extends AbstractQuickfixTestCase {
+class NeedBracesTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void needBracesIf() throws Exception {
+  void needBracesIf() throws Exception {
     testQuickfix("NeedBracesInputIf.xml", new NeedBracesQuickfix());
   }
 
   @Test
-  public void needBracesElse() throws Exception {
+  void needBracesElse() throws Exception {
     testQuickfix("NeedBracesInputElse.xml", new NeedBracesQuickfix());
   }
 
   @Test
-  public void needBracesElseIf() throws Exception {
+  void needBracesElseIf() throws Exception {
     testQuickfix("NeedBracesInputElseIf.xml", new NeedBracesQuickfix());
   }
 
   @Test
-  public void needBracesFor() throws Exception {
+  void needBracesFor() throws Exception {
     testQuickfix("NeedBracesInputFor.xml", new NeedBracesQuickfix());
   }
 
   @Test
-  public void needBracesWhile() throws Exception {
+  void needBracesWhile() throws Exception {
     testQuickfix("NeedBracesInputWhile.xml", new NeedBracesQuickfix());
   }
 
   @Test
-  public void needBracesDoWhile() throws Exception {
+  void needBracesDoWhile() throws Exception {
     testQuickfix("NeedBracesInputDoWhile.xml", new NeedBracesQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/DefaultComesLastTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/DefaultComesLastTest.java
@@ -27,12 +27,12 @@ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 public class DefaultComesLastTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void testDefaultComesLast() throws Exception {
+  public void defaultComesLast() throws Exception {
     testQuickfix("DefaultComesLastInput.xml", new DefaultComesLastQuickfix());
   }
 
   @Test
-  public void testDefaultComesLastInner() throws Exception {
+  public void defaultComesLastInner() throws Exception {
     testQuickfix("DefaultComesLastInputInner.xml", new DefaultComesLastQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/DefaultComesLastTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/DefaultComesLastTest.java
@@ -24,15 +24,15 @@ import org.junit.jupiter.api.Test;
 
 import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 
-public class DefaultComesLastTest extends AbstractQuickfixTestCase {
+class DefaultComesLastTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void defaultComesLast() throws Exception {
+  void defaultComesLast() throws Exception {
     testQuickfix("DefaultComesLastInput.xml", new DefaultComesLastQuickfix());
   }
 
   @Test
-  public void defaultComesLastInner() throws Exception {
+  void defaultComesLastInner() throws Exception {
     testQuickfix("DefaultComesLastInputInner.xml", new DefaultComesLastQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/EmptyStatementTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/EmptyStatementTest.java
@@ -24,15 +24,15 @@ import org.junit.jupiter.api.Test;
 
 import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 
-public class EmptyStatementTest extends AbstractQuickfixTestCase {
+class EmptyStatementTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void emptyStatement() throws Exception {
+  void emptyStatement() throws Exception {
     testQuickfix("EmptyStatementInput.xml", new EmptyStatementQuickfix());
   }
 
   @Test
-  public void emptyStatementNeg() throws Exception {
+  void emptyStatementNeg() throws Exception {
     testQuickfix("EmptyStatementInputNeg.xml", new EmptyStatementQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/EmptyStatementTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/EmptyStatementTest.java
@@ -27,12 +27,12 @@ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 public class EmptyStatementTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void testEmptyStatement() throws Exception {
+  public void emptyStatement() throws Exception {
     testQuickfix("EmptyStatementInput.xml", new EmptyStatementQuickfix());
   }
 
   @Test
-  public void testEmptyStatementNeg() throws Exception {
+  public void emptyStatementNeg() throws Exception {
     testQuickfix("EmptyStatementInputNeg.xml", new EmptyStatementQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/ExplicitInitializationTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/ExplicitInitializationTest.java
@@ -27,7 +27,7 @@ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 public class ExplicitInitializationTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void testExplicitInitialization() throws Exception {
+  public void explicitInitialization() throws Exception {
     testQuickfix("ExplicitInitialization.xml", new ExplicitInitializationQuickfix());
   }
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/ExplicitInitializationTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/ExplicitInitializationTest.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.Test;
 
 import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 
-public class ExplicitInitializationTest extends AbstractQuickfixTestCase {
+class ExplicitInitializationTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void explicitInitialization() throws Exception {
+  void explicitInitialization() throws Exception {
     testQuickfix("ExplicitInitialization.xml", new ExplicitInitializationQuickfix());
   }
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/FinalLocalVariableTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/FinalLocalVariableTest.java
@@ -27,7 +27,7 @@ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 public class FinalLocalVariableTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void testFinalLocalVariable() throws Exception {
+  public void finalLocalVariable() throws Exception {
     testQuickfix("FinalLocalVariableInput.xml", new FinalLocalVariableQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/FinalLocalVariableTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/FinalLocalVariableTest.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.Test;
 
 import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 
-public class FinalLocalVariableTest extends AbstractQuickfixTestCase {
+class FinalLocalVariableTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void finalLocalVariable() throws Exception {
+  void finalLocalVariable() throws Exception {
     testQuickfix("FinalLocalVariableInput.xml", new FinalLocalVariableQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/MissingSwitchDefaultTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/MissingSwitchDefaultTest.java
@@ -27,12 +27,12 @@ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 public class MissingSwitchDefaultTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void testMissingSwitchDefault() throws Exception {
+  public void missingSwitchDefault() throws Exception {
     testQuickfix("MissingSwitchDefaultInput.xml", new MissingSwitchDefaultQuickfix());
   }
 
   @Test
-  public void testMissingSwitchDefaultInner() throws Exception {
+  public void missingSwitchDefaultInner() throws Exception {
     testQuickfix("MissingSwitchDefaultInputInner.xml", new MissingSwitchDefaultQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/MissingSwitchDefaultTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/MissingSwitchDefaultTest.java
@@ -24,15 +24,15 @@ import org.junit.jupiter.api.Test;
 
 import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 
-public class MissingSwitchDefaultTest extends AbstractQuickfixTestCase {
+class MissingSwitchDefaultTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void missingSwitchDefault() throws Exception {
+  void missingSwitchDefault() throws Exception {
     testQuickfix("MissingSwitchDefaultInput.xml", new MissingSwitchDefaultQuickfix());
   }
 
   @Test
-  public void missingSwitchDefaultInner() throws Exception {
+  void missingSwitchDefaultInner() throws Exception {
     testQuickfix("MissingSwitchDefaultInputInner.xml", new MissingSwitchDefaultQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/RequireThisTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/RequireThisTest.java
@@ -27,47 +27,47 @@ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 public class RequireThisTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void testRequireThisFieldAccessAssignmentLHS() throws Exception {
+  public void requireThisFieldAccessAssignmentLHS() throws Exception {
     testQuickfix("RequireThisFieldAccessAssignmentLHS.xml", new RequireThisQuickfix());
   }
 
   @Test
-  public void testRequireThisFieldAccessAssignmentRHS() throws Exception {
+  public void requireThisFieldAccessAssignmentRHS() throws Exception {
     testQuickfix("RequireThisFieldAccessAssignmentRHS.xml", new RequireThisQuickfix());
   }
 
   @Test
-  public void testRequireThisFieldAccessArrayInitializer() throws Exception {
+  public void requireThisFieldAccessArrayInitializer() throws Exception {
     testQuickfix("RequireThisFieldAccessArrayInitializer.xml", new RequireThisQuickfix());
   }
 
   @Test
-  public void testRequireThisFieldAccessInnerClass() throws Exception {
+  public void requireThisFieldAccessInnerClass() throws Exception {
     testQuickfix("RequireThisFieldAccessInnerClass.xml", new RequireThisQuickfix());
   }
 
   @Test
-  public void testRequireThisMethodInvocation() throws Exception {
+  public void requireThisMethodInvocation() throws Exception {
     testQuickfix("RequireThisMethodInvocation.xml", new RequireThisQuickfix());
   }
 
   @Test
-  public void testRequireThisMethodInvocationWithParam() throws Exception {
+  public void requireThisMethodInvocationWithParam() throws Exception {
     testQuickfix("RequireThisMethodInvocationWithParam.xml", new RequireThisQuickfix());
   }
 
   @Test
-  public void testRequireThisMethodInvocationAssignmentRHS() throws Exception {
+  public void requireThisMethodInvocationAssignmentRHS() throws Exception {
     testQuickfix("RequireThisMethodInvocationAssignmentRHS.xml", new RequireThisQuickfix());
   }
 
   @Test
-  public void testRequireThisMethodInvocationArrayInitializer() throws Exception {
+  public void requireThisMethodInvocationArrayInitializer() throws Exception {
     testQuickfix("RequireThisMethodInvocationArrayInitializer.xml", new RequireThisQuickfix());
   }
 
   @Test
-  public void testRequireThisMethodInvocationInnerClass() throws Exception {
+  public void requireThisMethodInvocationInnerClass() throws Exception {
     testQuickfix("RequireThisMethodInvocationInnerClass.xml", new RequireThisQuickfix());
   }
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/RequireThisTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/RequireThisTest.java
@@ -24,50 +24,50 @@ import org.junit.jupiter.api.Test;
 
 import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 
-public class RequireThisTest extends AbstractQuickfixTestCase {
+class RequireThisTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void requireThisFieldAccessAssignmentLHS() throws Exception {
+  void requireThisFieldAccessAssignmentLHS() throws Exception {
     testQuickfix("RequireThisFieldAccessAssignmentLHS.xml", new RequireThisQuickfix());
   }
 
   @Test
-  public void requireThisFieldAccessAssignmentRHS() throws Exception {
+  void requireThisFieldAccessAssignmentRHS() throws Exception {
     testQuickfix("RequireThisFieldAccessAssignmentRHS.xml", new RequireThisQuickfix());
   }
 
   @Test
-  public void requireThisFieldAccessArrayInitializer() throws Exception {
+  void requireThisFieldAccessArrayInitializer() throws Exception {
     testQuickfix("RequireThisFieldAccessArrayInitializer.xml", new RequireThisQuickfix());
   }
 
   @Test
-  public void requireThisFieldAccessInnerClass() throws Exception {
+  void requireThisFieldAccessInnerClass() throws Exception {
     testQuickfix("RequireThisFieldAccessInnerClass.xml", new RequireThisQuickfix());
   }
 
   @Test
-  public void requireThisMethodInvocation() throws Exception {
+  void requireThisMethodInvocation() throws Exception {
     testQuickfix("RequireThisMethodInvocation.xml", new RequireThisQuickfix());
   }
 
   @Test
-  public void requireThisMethodInvocationWithParam() throws Exception {
+  void requireThisMethodInvocationWithParam() throws Exception {
     testQuickfix("RequireThisMethodInvocationWithParam.xml", new RequireThisQuickfix());
   }
 
   @Test
-  public void requireThisMethodInvocationAssignmentRHS() throws Exception {
+  void requireThisMethodInvocationAssignmentRHS() throws Exception {
     testQuickfix("RequireThisMethodInvocationAssignmentRHS.xml", new RequireThisQuickfix());
   }
 
   @Test
-  public void requireThisMethodInvocationArrayInitializer() throws Exception {
+  void requireThisMethodInvocationArrayInitializer() throws Exception {
     testQuickfix("RequireThisMethodInvocationArrayInitializer.xml", new RequireThisQuickfix());
   }
 
   @Test
-  public void requireThisMethodInvocationInnerClass() throws Exception {
+  void requireThisMethodInvocationInnerClass() throws Exception {
     testQuickfix("RequireThisMethodInvocationInnerClass.xml", new RequireThisQuickfix());
   }
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnTest.java
@@ -27,72 +27,72 @@ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 public class SimplifyBooleanReturnTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void testSimplifyBooleanReturnWithoutCurlyBraces() throws Exception {
+  public void simplifyBooleanReturnWithoutCurlyBraces() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithoutCurlyBraces.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void testSimplifyBooleanReturnWithCurlyBraces() throws Exception {
+  public void simplifyBooleanReturnWithCurlyBraces() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithCurlyBraces.xml", new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void testSimplifyBooleanReturnWithBooleanLiteralCondition() throws Exception {
+  public void simplifyBooleanReturnWithBooleanLiteralCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithBooleanLiteralCondition.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void testSimplifyBooleanReturnWithFieldAccessCondition() throws Exception {
+  public void simplifyBooleanReturnWithFieldAccessCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithFieldAccessCondition.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void testSimplifyBooleanReturnWithMethodInvocationCondition() throws Exception {
+  public void simplifyBooleanReturnWithMethodInvocationCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithMethodInvocationCondition.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void testSimplifyBooleanReturnWithQualifiedNameCondition() throws Exception {
+  public void simplifyBooleanReturnWithQualifiedNameCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithQualifiedNameCondition.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void testSimplifyBooleanReturnWithSimpleNameCondition() throws Exception {
+  public void simplifyBooleanReturnWithSimpleNameCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithSimpleNameCondition.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void testSimplifyBooleanReturnWithParanthesizedExpressionCondition() throws Exception {
+  public void simplifyBooleanReturnWithParanthesizedExpressionCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithParanthesizedExpressionCondition.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void testSimplifyBooleanReturnWithSuperFieldAccessCondition() throws Exception {
+  public void simplifyBooleanReturnWithSuperFieldAccessCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithSuperFieldAccessCondition.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void testSimplifyBooleanReturnWithSuperMethodInvocationCondition() throws Exception {
+  public void simplifyBooleanReturnWithSuperMethodInvocationCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithSuperMethodInvocationCondition.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void testSimplifyBooleanReturnWithThisExpressionCondition() throws Exception {
+  public void simplifyBooleanReturnWithThisExpressionCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithThisExpressionCondition.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void testSimplifyBooleanReturnWithNotCondition() throws Exception {
+  public void simplifyBooleanReturnWithNotCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithNotCondition.xml", new SimplifyBooleanReturnQuickfix());
   }
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/SimplifyBooleanReturnTest.java
@@ -24,75 +24,75 @@ import org.junit.jupiter.api.Test;
 
 import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 
-public class SimplifyBooleanReturnTest extends AbstractQuickfixTestCase {
+class SimplifyBooleanReturnTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void simplifyBooleanReturnWithoutCurlyBraces() throws Exception {
+  void simplifyBooleanReturnWithoutCurlyBraces() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithoutCurlyBraces.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void simplifyBooleanReturnWithCurlyBraces() throws Exception {
+  void simplifyBooleanReturnWithCurlyBraces() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithCurlyBraces.xml", new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void simplifyBooleanReturnWithBooleanLiteralCondition() throws Exception {
+  void simplifyBooleanReturnWithBooleanLiteralCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithBooleanLiteralCondition.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void simplifyBooleanReturnWithFieldAccessCondition() throws Exception {
+  void simplifyBooleanReturnWithFieldAccessCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithFieldAccessCondition.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void simplifyBooleanReturnWithMethodInvocationCondition() throws Exception {
+  void simplifyBooleanReturnWithMethodInvocationCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithMethodInvocationCondition.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void simplifyBooleanReturnWithQualifiedNameCondition() throws Exception {
+  void simplifyBooleanReturnWithQualifiedNameCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithQualifiedNameCondition.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void simplifyBooleanReturnWithSimpleNameCondition() throws Exception {
+  void simplifyBooleanReturnWithSimpleNameCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithSimpleNameCondition.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void simplifyBooleanReturnWithParanthesizedExpressionCondition() throws Exception {
+  void simplifyBooleanReturnWithParanthesizedExpressionCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithParanthesizedExpressionCondition.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void simplifyBooleanReturnWithSuperFieldAccessCondition() throws Exception {
+  void simplifyBooleanReturnWithSuperFieldAccessCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithSuperFieldAccessCondition.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void simplifyBooleanReturnWithSuperMethodInvocationCondition() throws Exception {
+  void simplifyBooleanReturnWithSuperMethodInvocationCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithSuperMethodInvocationCondition.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void simplifyBooleanReturnWithThisExpressionCondition() throws Exception {
+  void simplifyBooleanReturnWithThisExpressionCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithThisExpressionCondition.xml",
             new SimplifyBooleanReturnQuickfix());
   }
 
   @Test
-  public void simplifyBooleanReturnWithNotCondition() throws Exception {
+  void simplifyBooleanReturnWithNotCondition() throws Exception {
     testQuickfix("SimplifyBooleanReturnWithNotCondition.xml", new SimplifyBooleanReturnQuickfix());
   }
 

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityTest.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.Test;
 
 import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 
-public class StringLiteralEqualityTest extends AbstractQuickfixTestCase {
+class StringLiteralEqualityTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void stringLiteralEquality() throws Exception {
+  void stringLiteralEquality() throws Exception {
     testQuickfix("StringLiteralEqualityInput.xml", new StringLiteralEqualityQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/coding/StringLiteralEqualityTest.java
@@ -27,7 +27,7 @@ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 public class StringLiteralEqualityTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void testStringLiteralEquality() throws Exception {
+  public void stringLiteralEquality() throws Exception {
     testQuickfix("StringLiteralEqualityInput.xml", new StringLiteralEqualityQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/DesignForExtensionTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/DesignForExtensionTest.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.Test;
 
 import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 
-public class DesignForExtensionTest extends AbstractQuickfixTestCase {
+class DesignForExtensionTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void designForExtension() throws Exception {
+  void designForExtension() throws Exception {
     testQuickfix("DesignForExtensionInput.xml", new DesignForExtensionQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/DesignForExtensionTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/DesignForExtensionTest.java
@@ -27,7 +27,7 @@ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 public class DesignForExtensionTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void testDesignForExtension() throws Exception {
+  public void designForExtension() throws Exception {
     testQuickfix("DesignForExtensionInput.xml", new DesignForExtensionQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/FinalClassTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/FinalClassTest.java
@@ -27,7 +27,7 @@ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 public class FinalClassTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void testFinalClass() throws Exception {
+  public void finalClass() throws Exception {
     testQuickfix("FinalClassInput.xml", new FinalClassQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/FinalClassTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/design/FinalClassTest.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.Test;
 
 import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 
-public class FinalClassTest extends AbstractQuickfixTestCase {
+class FinalClassTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void finalClass() throws Exception {
+  void finalClass() throws Exception {
     testQuickfix("FinalClassInput.xml", new FinalClassQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/ArrayTypeStyleTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/ArrayTypeStyleTest.java
@@ -27,17 +27,17 @@ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 public class ArrayTypeStyleTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void testArrayTypeStyleField() throws Exception {
+  public void arrayTypeStyleField() throws Exception {
     testQuickfix("ArrayTypeStyleInputField.xml", new ArrayTypeStyleQuickfix());
   }
 
   @Test
-  public void testArrayTypeStyleMethodParam() throws Exception {
+  public void arrayTypeStyleMethodParam() throws Exception {
     testQuickfix("ArrayTypeStyleInputMethodParam.xml", new ArrayTypeStyleQuickfix());
   }
 
   @Test
-  public void testArrayTypeStyleVariable() throws Exception {
+  public void arrayTypeStyleVariable() throws Exception {
     testQuickfix("ArrayTypeStyleInputVariable.xml", new ArrayTypeStyleQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/ArrayTypeStyleTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/ArrayTypeStyleTest.java
@@ -24,20 +24,20 @@ import org.junit.jupiter.api.Test;
 
 import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 
-public class ArrayTypeStyleTest extends AbstractQuickfixTestCase {
+class ArrayTypeStyleTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void arrayTypeStyleField() throws Exception {
+  void arrayTypeStyleField() throws Exception {
     testQuickfix("ArrayTypeStyleInputField.xml", new ArrayTypeStyleQuickfix());
   }
 
   @Test
-  public void arrayTypeStyleMethodParam() throws Exception {
+  void arrayTypeStyleMethodParam() throws Exception {
     testQuickfix("ArrayTypeStyleInputMethodParam.xml", new ArrayTypeStyleQuickfix());
   }
 
   @Test
-  public void arrayTypeStyleVariable() throws Exception {
+  void arrayTypeStyleVariable() throws Exception {
     testQuickfix("ArrayTypeStyleInputVariable.xml", new ArrayTypeStyleQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/FinalParametersTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/FinalParametersTest.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.Test;
 
 import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 
-public class FinalParametersTest extends AbstractQuickfixTestCase {
+class FinalParametersTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void finalParameters() throws Exception {
+  void finalParameters() throws Exception {
     testQuickfix("FinalParametersInput.xml", new FinalParametersQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/FinalParametersTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/FinalParametersTest.java
@@ -27,7 +27,7 @@ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 public class FinalParametersTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void testFinalParameters() throws Exception {
+  public void finalParameters() throws Exception {
     testQuickfix("FinalParametersInput.xml", new FinalParametersQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UncommentedMainTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UncommentedMainTest.java
@@ -27,7 +27,7 @@ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 public class UncommentedMainTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void testUncommentedMain() throws Exception {
+  public void uncommentedMain() throws Exception {
     testQuickfix("UncommentedMainInput.xml", new UncommentedMainQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UncommentedMainTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UncommentedMainTest.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.Test;
 
 import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 
-public class UncommentedMainTest extends AbstractQuickfixTestCase {
+class UncommentedMainTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void uncommentedMain() throws Exception {
+  void uncommentedMain() throws Exception {
     testQuickfix("UncommentedMainInput.xml", new UncommentedMainQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UpperEllTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UpperEllTest.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.Test;
 
 import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 
-public class UpperEllTest extends AbstractQuickfixTestCase {
+class UpperEllTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void upperEll() throws Exception {
+  void upperEll() throws Exception {
     testQuickfix("UpperEllInput.xml", new UpperEllQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UpperEllTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/misc/UpperEllTest.java
@@ -27,7 +27,7 @@ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 public class UpperEllTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void testUpperEll() throws Exception {
+  public void upperEll() throws Exception {
     testQuickfix("UpperEllInput.xml", new UpperEllQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/ModifierOrderTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/ModifierOrderTest.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.Test;
 
 import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 
-public class ModifierOrderTest extends AbstractQuickfixTestCase {
+class ModifierOrderTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void modifierOrder() throws Exception {
+  void modifierOrder() throws Exception {
     testQuickfix("ModifierOrderInput.xml", new ModifierOrderQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/ModifierOrderTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/ModifierOrderTest.java
@@ -27,7 +27,7 @@ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 public class ModifierOrderTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void testModifierOrder() throws Exception {
+  public void modifierOrder() throws Exception {
     testQuickfix("ModifierOrderInput.xml", new ModifierOrderQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/RedundantModifierTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/RedundantModifierTest.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.Test;
 
 import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 
-public class RedundantModifierTest extends AbstractQuickfixTestCase {
+class RedundantModifierTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void redundantModifier() throws Exception {
+  void redundantModifier() throws Exception {
     testQuickfix("RedundantModifierInput.xml", new RedundantModifierQuickfix());
   }
 }

--- a/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/RedundantModifierTest.java
+++ b/net.sf.eclipsecs.ui/test/net/sf/eclipsecs/ui/quickfixes/modifier/RedundantModifierTest.java
@@ -27,7 +27,7 @@ import net.sf.eclipsecs.ui.quickfixes.AbstractQuickfixTestCase;
 public class RedundantModifierTest extends AbstractQuickfixTestCase {
 
   @Test
-  public void testRedundantModifier() throws Exception {
+  public void redundantModifier() throws Exception {
     testQuickfix("RedundantModifierInput.xml", new RedundantModifierQuickfix());
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -30,14 +30,12 @@
         <maven-antrun-plugin-version>3.1.0</maven-antrun-plugin-version>
         <maven-checkstyle-plugin-version>3.6.0</maven-checkstyle-plugin-version>
         <maven-clean-plugin-version>3.4.0</maven-clean-plugin-version>
-        <maven-compiler-plugin-version>3.13.0</maven-compiler-plugin-version>
         <maven-deploy-plugin-version>3.1.3</maven-deploy-plugin-version>
         <maven-enforcer-plugin-version>3.5.0</maven-enforcer-plugin-version>
         <maven-failsafe-plugin-version>3.5.2</maven-failsafe-plugin-version>
         <maven-install-plugin-version>3.1.3</maven-install-plugin-version>
         <maven-resources-plugin-version>3.3.1</maven-resources-plugin-version>
         <maven-site-plugin-version>3.21.0</maven-site-plugin-version>
-        <maven-surefire-plugin-version>3.5.2</maven-surefire-plugin-version>
         <maven-version>3.9.0</maven-version>
         <tycho-version>4.0.10</tycho-version>
         <versions-maven-plugin-version>2.18.0</versions-maven-plugin-version>
@@ -393,29 +391,12 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${maven-surefire-plugin-version}</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${maven-compiler-plugin-version}</version>
-                    <executions>
-                        <execution>
-                            <id>compiletests</id>
-                            <phase>test-compile</phase>
-                            <goals>
-                                <goal>testCompile</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>${maven-enforcer-plugin-version}</version>
                     <executions>
                         <execution>
-                            <id>enforce-maven</id>
+                            <id>enforce</id>
                             <goals>
                                 <goal>enforce</goal>
                             </goals>
@@ -537,7 +518,268 @@
                     <artifactId>versions-maven-plugin</artifactId>
                     <version>${versions-maven-plugin-version}</version>
                 </plugin>
+                <!-- automated mass refactorings -->
+                <plugin>
+                    <groupId>org.openrewrite.maven</groupId>
+                    <artifactId>rewrite-maven-plugin</artifactId>
+                    <version>6.0.4</version>
+                    <configuration>
+                        <activeRecipes>
+                            <recipe>net.sf.eclipsecs.recipe</recipe>
+                        </activeRecipes>
+                        <activeStyles>
+                            <style>net.sf.eclipsecs.style</style>
+                        </activeStyles>
+                        <configLocation>${maven.multiModuleProjectDirectory}/rewrite/rewrite.yml</configLocation>
+                        <exclusions>
+                            <exclusion>**/target/**</exclusion>
+                            <exclusion>**/bin/**</exclusion>
+                            <exclusion>**/*.groovy</exclusion>
+                            <exclusion>**/*.jar</exclusion>
+                            <exclusion>**/*.properties</exclusion>
+                            <exclusion>**/*.zip</exclusion>
+                        </exclusions>
+                        <failOnInvalidActiveRecipes>true</failOnInvalidActiveRecipes>
+                        <sizeThresholdMb>1</sizeThresholdMb>
+                    </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.openrewrite.recipe</groupId>
+                            <artifactId>rewrite-apache</artifactId>
+                            <version>2.0.0</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.openrewrite.recipe</groupId>
+                            <artifactId>rewrite-java-security</artifactId>
+                            <version>3.0.0</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.openrewrite.recipe</groupId>
+                            <artifactId>rewrite-migrate-java</artifactId>
+                            <version>3.0.1</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.openrewrite.recipe</groupId>
+                            <artifactId>rewrite-static-analysis</artifactId>
+                            <version>2.0.2</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.openrewrite.recipe</groupId>
+                            <artifactId>rewrite-testing-frameworks</artifactId>
+                            <version>3.0.0</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
+    <profiles>
+        <profile>
+            <!-- disable all other goals when running OpenRewrite, since that gives a tremendous speedup -->
+            <id>rewrite</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                               <id>create-sevntu-patch</id>
+                               <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>calculate-website-timestamp</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>checkstyle-check</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>sevntu-checkstyle-check</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+	                <plugin>
+	                    <groupId>org.apache.maven.plugins</groupId>
+	                    <artifactId>maven-enforcer-plugin</artifactId>
+	                    <version>${maven-enforcer-plugin-version}</version>
+	                    <executions>
+	                        <execution>
+	                            <id>enforce</id>
+	                            <phase>none</phase>
+	                        </execution>
+	                    </executions>
+	                </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-verify</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-resources</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>default-testResources</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>docs</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>website</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.eclipse.tycho</groupId>
+                        <artifactId>tycho-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>compiletests</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>default-compile</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>default-testCompile</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>default-validate-classpath</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.eclipse.tycho</groupId>
+                        <artifactId>tycho-packaging-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-build-qualifier</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>default-build-qualifier-aggregator</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>default-package-feature</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>default-package-plugin</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>default-update-consumer-pom</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>default-validate-id</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>default-validate-version</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.eclipse.tycho</groupId>
+                        <artifactId>target-platform-configuration</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-target-platform</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.eclipse.tycho</groupId>
+                        <artifactId>tycho-p2-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-p2-metadata</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>default-p2-metadata-default</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.eclipse.tycho</groupId>
+                        <artifactId>tycho-p2-repository-plugin</artifactId>
+                        <executions>
+                            <execution>
+                               <id>attach-p2-metadata</id>
+                               <phase>none</phase>
+                            </execution>
+                            <execution>
+                               <id>default-assemble-repository</id>
+                               <phase>none</phase>
+                            </execution>
+                            <execution>
+                               <id>default-archive-repository</id>
+                               <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.eclipse.tycho</groupId>
+                        <artifactId>tycho-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>feature-source</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>plugin-source</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.eclipse.tycho</groupId>
+                        <artifactId>tycho-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-integration-test</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/rewrite/OpenRewrite.launch
+++ b/rewrite/OpenRewrite.launch
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
+    <intAttribute key="M2_COLORS" value="0"/>
+    <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
+    <stringAttribute key="M2_GOALS" value="org.openrewrite.maven:rewrite-maven-plugin:run --projects !net.sf.eclipsecs:net.sf.eclipsecs,!net.sf.eclipsecs:net.sf.eclipsecs-updatesite"/>
+    <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
+    <booleanAttribute key="M2_OFFLINE" value="false"/>
+    <stringAttribute key="M2_PROFILES" value="rewrite"/>
+    <listAttribute key="M2_PROPERTIES"/>
+    <stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
+    <booleanAttribute key="M2_SKIP_TESTS" value="true"/>
+    <intAttribute key="M2_THREADS" value="1"/>
+    <booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
+    <stringAttribute key="M2_USER_SETTINGS" value=""/>
+    <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
+        <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
+    </listAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
+    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/eclipse-cs}"/>
+</launchConfiguration>

--- a/rewrite/rewrite.yml
+++ b/rewrite/rewrite.yml
@@ -1,0 +1,271 @@
+---
+type: specs.openrewrite.org/v1beta/style
+name: net.sf.eclipsecs.style
+styleConfigs:
+  - org.openrewrite.java.style.ImportLayoutStyle:
+      classCountToUseStarImport: 999
+      nameCountToUseStarImport: 999
+      layout:
+        - import java.*
+        - <blank line>
+        - import javax.*
+        - <blank line>
+        - import org.*
+        - <blank line>
+        - import com.*
+        - <blank line>
+        - import all other imports
+        - <blank line>
+        - import static all other imports
+  - org.openrewrite.java.style.TabsAndIndentsStyle:
+      useTabCharacter: false
+      tabSize: 2
+      indentSize: 2
+      continuationIndent: 2
+      indentsRelativeToExpressionStart: false
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: net.sf.eclipsecs.recipe
+recipeList:
+  - org.openrewrite.java.format.EmptyNewlineAtEndOfFile
+  - org.openrewrite.java.format.NormalizeTabsOrSpaces
+  - org.openrewrite.java.format.PadEmptyForLoopComponents
+  - org.openrewrite.java.format.RemoveTrailingWhitespace
+# - org.openrewrite.java.format.SingleLineComments, doesn't fit our copyright header comments
+  - org.openrewrite.java.format.TypecastParenPad
+  - org.openrewrite.apache.commons.codec.ApacheBase64ToJavaBase64
+  - org.openrewrite.apache.commons.io.ApacheCommonsFileUtilsRecipes
+  - org.openrewrite.apache.commons.io.ApacheFileUtilsToJavaFiles
+  - org.openrewrite.apache.commons.io.ApacheIOUtilsUseExplicitCharset
+  - org.openrewrite.apache.commons.io.RelocateApacheCommonsIo
+  - org.openrewrite.apache.commons.io.UseStandardCharsets
+  - org.openrewrite.apache.commons.io.UseSystemLineSeparator
+  - org.openrewrite.apache.commons.lang.ApacheCommonsStringUtilsRecipes
+  - org.openrewrite.java.migrate.concurrent.JavaConcurrentAPIs
+  - org.openrewrite.java.migrate.io.ReplaceFileInOrOutputStreamFinalizeWithClose
+  - org.openrewrite.java.migrate.Java8toJava11
+  - org.openrewrite.java.migrate.javax.AddInjectDependencies
+# - org.openrewrite.java.migrate.javax.AddJaxbDependencies, unwanted
+# - org.openrewrite.java.migrate.javax.AddJaxbRuntime, unwanted
+# - org.openrewrite.java.migrate.javax.AddJaxwsDependencies, unwanted
+# - org.openrewrite.java.migrate.javax.AddJaxwsRuntime, unwanted
+  - org.openrewrite.java.migrate.javax.AddScopeToInjectedClass
+  - org.openrewrite.java.migrate.javax.JavaxLangModelUtil
+  - org.openrewrite.java.migrate.javax.JavaxManagementMonitorAPIs
+  - org.openrewrite.java.migrate.javax.JavaxXmlStreamAPIs
+  - org.openrewrite.java.migrate.javax.MigrateAbstractAnnotationValueVisitor6To9
+  - org.openrewrite.java.migrate.javax.MigrateAbstractElementVisitor6To9
+  - org.openrewrite.java.migrate.javax.MigrateAbstractTypeVisitor6To9
+  - org.openrewrite.java.migrate.javax.MigrateCounterMonitorSetThresholdToSetInitThreshold
+  - org.openrewrite.java.migrate.javax.MigrateElementKindVisitor6To9
+  - org.openrewrite.java.migrate.javax.MigrateElementScanner6To9
+  - org.openrewrite.java.migrate.javax.MigrateSimpleAnnotationValueVisitor6To9
+  - org.openrewrite.java.migrate.javax.MigrateSimpleElementVisitor6To9
+  - org.openrewrite.java.migrate.javax.MigrateSimpleTypeVisitor6To9
+  - org.openrewrite.java.migrate.javax.MigrateTypeKindVisitor6To9
+  - org.openrewrite.java.migrate.javax.MigrateXMLEventFactoryNewInstanceToNewFactory
+  - org.openrewrite.java.migrate.javax.MigrateXMLInputFactoryNewInstanceToNewFactory
+  - org.openrewrite.java.migrate.javax.MigrateXMLOutputFactoryNewInstanceToNewFactory
+  - org.openrewrite.java.migrate.lang.JavaLangAPIs
+  - org.openrewrite.java.migrate.lang.MigrateCharacterIsJavaLetterOrDigitToIsJavaIdentifierPart
+  - org.openrewrite.java.migrate.lang.MigrateCharacterIsJavaLetterToIsJavaIdentifierStart
+  - org.openrewrite.java.migrate.lang.MigrateCharacterIsSpaceToIsWhitespace
+  - org.openrewrite.java.migrate.lang.MigrateClassLoaderDefineClass
+  - org.openrewrite.java.migrate.lang.MigrateClassNewInstanceToGetDeclaredConstructorNewInstance
+  - org.openrewrite.java.migrate.lang.MigrateRuntimeVersionMajorToFeature
+  - org.openrewrite.java.migrate.lang.MigrateRuntimeVersionMinorToInterim
+  - org.openrewrite.java.migrate.lang.MigrateRuntimeVersionSecurityToUpdate
+  - org.openrewrite.java.migrate.lang.MigrateSecurityManagerMulticast
+# - org.openrewrite.java.migrate.lang.StringFormatted, Java 17
+  - org.openrewrite.java.migrate.lang.StringRulesRecipes
+  - org.openrewrite.java.migrate.lang.UseStringIsEmptyRecipe
+  - org.openrewrite.java.migrate.net.JavaNetAPIs
+  - org.openrewrite.java.migrate.net.MigrateHttpURLConnectionHttpServerErrorToHttpInternalError
+  - org.openrewrite.java.migrate.net.MigrateMulticastSocketGetTTLToGetTimeToLive
+  - org.openrewrite.java.migrate.net.MigrateMulticastSocketSetTTLToSetTimeToLive
+  - org.openrewrite.java.migrate.net.MigrateURLDecoderDecode
+  - org.openrewrite.java.migrate.net.MigrateURLEncoderEncode
+  - org.openrewrite.java.migrate.UseJavaUtilBase64
+  - org.openrewrite.java.migrate.util.JavaUtilAPIs
+  - org.openrewrite.java.migrate.util.MigrateCollectionsSingletonList
+  - org.openrewrite.java.migrate.util.MigrateCollectionsSingletonMap
+  - org.openrewrite.java.migrate.util.MigrateCollectionsSingletonSet
+  - org.openrewrite.java.migrate.util.MigrateCollectionsUnmodifiableList
+  - org.openrewrite.java.migrate.util.MigrateCollectionsUnmodifiableSet
+  - org.openrewrite.java.migrate.util.OptionalNotEmptyToIsPresent
+  - org.openrewrite.java.migrate.util.OptionalNotPresentToIsEmpty
+  - org.openrewrite.java.migrate.util.RemoveFinalizerFromZip
+  - org.openrewrite.java.migrate.util.UseEnumSetOf
+  - org.openrewrite.java.migrate.util.UseLocaleOf
+  - org.openrewrite.java.migrate.util.UseMapOf
+  - org.openrewrite.java.security.FindTextDirectionChanges
+# - org.openrewrite.java.security.JavaSecurityBestPractices, contains XmlParserXXEVulnerability with bug
+# - org.openrewrite.java.security.OwaspTopTen, contains XmlParserXXEVulnerability with bug
+  - org.openrewrite.java.security.PartialPathTraversalVulnerability
+  - org.openrewrite.java.security.secrets.FindGitHubSecrets
+  - org.openrewrite.java.security.secrets.FindPasswordInUrlSecrets
+  - org.openrewrite.java.security.secrets.FindSshSecrets
+  - org.openrewrite.java.security.SecureTempFileCreation
+  - org.openrewrite.java.security.UseFilesCreateTempDirectory
+# - org.openrewrite.java.security.XmlParserXXEVulnerability, doesn't recognize that we use a factory for the same
+  - org.openrewrite.java.security.ZipSlip
+  - org.openrewrite.java.ShortenFullyQualifiedTypeReferences
+# - org.openrewrite.java.testing.assertj.Assertj, contains JUnitToAssertJ, which does unwanted changes
+  - org.openrewrite.java.testing.assertj.JUnitAssertArrayEqualsToAssertThat
+  - org.openrewrite.java.testing.assertj.JUnitAssertEqualsToAssertThat
+  - org.openrewrite.java.testing.assertj.JUnitAssertFalseToAssertThat
+  - org.openrewrite.java.testing.assertj.JUnitAssertNotEqualsToAssertThat
+  - org.openrewrite.java.testing.assertj.JUnitAssertNotNullToAssertThat
+  - org.openrewrite.java.testing.assertj.JUnitAssertNullToAssertThat
+  - org.openrewrite.java.testing.assertj.JUnitAssertSameToAssertThat
+  - org.openrewrite.java.testing.assertj.JUnitAssertThrowsToAssertExceptionType
+  - org.openrewrite.java.testing.assertj.JUnitAssertTrueToAssertThat
+  - org.openrewrite.java.testing.assertj.JUnitFailToAssertJFail
+# - org.openrewrite.java.testing.assertj.JUnitToAssertj, adds POM dependencies unconditionally
+  - org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertion
+  - org.openrewrite.java.testing.assertj.SimplifyChainedAssertJAssertions
+  - org.openrewrite.java.testing.assertj.StaticImports
+# - org.openrewrite.java.testing.cleanup.BestPractices, contains TestsShouldIncludeAssertions
+  - org.openrewrite.java.testing.cleanup.RemoveTestPrefix
+# - org.openrewrite.java.testing.cleanup.TestsShouldIncludeAssertions, unwanted as our assertion methods are not recognized
+  - org.openrewrite.java.testing.cleanup.TestsShouldNotBePublic
+  - org.openrewrite.java.testing.junit5.LifecycleNonPrivate
+  - org.openrewrite.java.testing.junit5.TempDirNonFinal
+  - org.openrewrite.maven.cleanup.DependencyManagementDependencyRequiresVersion
+  - org.openrewrite.maven.RemoveDuplicateDependencies
+  - org.openrewrite.maven.RemoveRedundantDependencyVersions
+  - org.openrewrite.staticanalysis.AddSerialVersionUidToSerializable
+  - org.openrewrite.staticanalysis.AtomicPrimitiveEqualsUsesGet
+  - org.openrewrite.staticanalysis.AvoidBoxedBooleanExpressions
+  - org.openrewrite.staticanalysis.BigDecimalRoundingConstantsToEnums
+  - org.openrewrite.staticanalysis.BooleanChecksNotInverted
+  - org.openrewrite.staticanalysis.CaseInsensitiveComparisonsDoNotChangeCase
+  - org.openrewrite.staticanalysis.CatchClauseOnlyRethrows
+  - org.openrewrite.staticanalysis.ChainStringBuilderAppendCalls
+# - org.openrewrite.staticanalysis.CodeCleanup, contains unwanted formatting recipe
+  - org.openrewrite.staticanalysis.CombineSemanticallyEqualCatchBlocks
+  - org.openrewrite.staticanalysis.CommonDeclarationSiteTypeVariances # needs manual cleanup
+# - org.openrewrite.staticanalysis.CommonStaticAnalysis, contains FinalizePrivateFields with bug
+  - org.openrewrite.staticanalysis.CompareEnumsWithEqualityOperator
+  - org.openrewrite.staticanalysis.ControlFlowIndentation
+  - org.openrewrite.staticanalysis.CovariantEquals
+  - org.openrewrite.staticanalysis.DefaultComesLast
+  - org.openrewrite.staticanalysis.EmptyBlock
+  - org.openrewrite.staticanalysis.EqualsAvoidsNull
+  - org.openrewrite.staticanalysis.EqualsToContentEquals
+  - org.openrewrite.staticanalysis.ExplicitCharsetOnStringGetBytes
+  - org.openrewrite.staticanalysis.ExplicitInitialization
+  - org.openrewrite.staticanalysis.ExplicitLambdaArgumentTypes
+  - org.openrewrite.staticanalysis.ExternalizableHasNoArgsConstructor
+  - org.openrewrite.staticanalysis.FallThrough
+  - org.openrewrite.staticanalysis.FinalClass
+# - org.openrewrite.staticanalysis.FinalizeLocalVariables, unwanted
+# - org.openrewrite.staticanalysis.FinalizeMethodArguments, unwanted
+# - org.openrewrite.staticanalysis.FinalizePrivateFields, TODO: needs naming changes
+  - org.openrewrite.staticanalysis.FixStringFormatExpressions
+  - org.openrewrite.staticanalysis.ForLoopControlVariablePostfixOperators
+  - org.openrewrite.staticanalysis.ForLoopIncrementInUpdate
+  - org.openrewrite.staticanalysis.HiddenField
+  - org.openrewrite.staticanalysis.HideUtilityClassConstructor
+  - org.openrewrite.staticanalysis.IndexOfChecksShouldUseAStartPosition
+  - org.openrewrite.staticanalysis.IndexOfReplaceableByContains
+  - org.openrewrite.staticanalysis.IndexOfShouldNotCompareGreaterThanZero
+  - org.openrewrite.staticanalysis.InlineVariable
+# - org.openrewrite.staticanalysis.InstanceOfPatternMatch, Java 17
+  - org.openrewrite.staticanalysis.IsEmptyCallOnCollections
+  - org.openrewrite.staticanalysis.JavaApiBestPractices
+  - org.openrewrite.staticanalysis.LambdaBlockToExpression
+  - org.openrewrite.staticanalysis.LowercasePackage
+  - org.openrewrite.staticanalysis.MethodNameCasing
+  - org.openrewrite.staticanalysis.MinimumSwitchCases
+# - org.openrewrite.staticanalysis.MissingOverrideAnnotation, https://github.com/openrewrite/rewrite-static-analysis/issues/178
+  - org.openrewrite.staticanalysis.ModifierOrder
+  - org.openrewrite.staticanalysis.MultipleVariableDeclarations
+  - org.openrewrite.staticanalysis.NeedBraces
+  - org.openrewrite.staticanalysis.NestedEnumsAreNotStatic
+  - org.openrewrite.staticanalysis.NewStringBuilderBufferWithCharArgument
+  - org.openrewrite.staticanalysis.NoDoubleBraceInitialization
+  - org.openrewrite.staticanalysis.NoEmptyCollectionWithRawType
+  - org.openrewrite.staticanalysis.NoEqualityInForCondition
+# - org.openrewrite.staticanalysis.NoFinalizedLocalVariables, unwanted
+  - org.openrewrite.staticanalysis.NoFinalizer
+  - org.openrewrite.staticanalysis.NoPrimitiveWrappersForToStringOrCompareTo
+  - org.openrewrite.staticanalysis.NoRedundantJumpStatements
+  - org.openrewrite.staticanalysis.NoToStringOnStringType
+  - org.openrewrite.staticanalysis.NoValueOfOnStringType
+  - org.openrewrite.staticanalysis.ObjectFinalizeCallsSuper
+  - org.openrewrite.staticanalysis.OperatorWrap
+  - org.openrewrite.staticanalysis.PrimitiveWrapperClassConstructorToValueOf
+  - org.openrewrite.staticanalysis.RedundantFileCreation
+# - org.openrewrite.staticanalysis.ReferentialEqualityToObjectEquals, unwanted
+  - org.openrewrite.staticanalysis.RemoveCallsToObjectFinalize
+  - org.openrewrite.staticanalysis.RemoveCallsToSystemGc
+  - org.openrewrite.staticanalysis.RemoveEmptyJavaDocParameters
+  - org.openrewrite.staticanalysis.RemoveExtraSemicolons
+  - org.openrewrite.staticanalysis.RemoveHashCodeCallsFromArrayInstances
+# - org.openrewrite.staticanalysis.RemoveInstanceOfPatternMatch, unwanted
+  - org.openrewrite.staticanalysis.RemoveJavaDocAuthorTag
+  - org.openrewrite.staticanalysis.RemoveRedundantTypeCast
+  - org.openrewrite.staticanalysis.RemoveSystemOutPrintln
+  - org.openrewrite.staticanalysis.RemoveToStringCallsFromArrayInstances
+  - org.openrewrite.staticanalysis.RemoveUnneededAssertion
+  - org.openrewrite.staticanalysis.RemoveUnneededBlock
+  - org.openrewrite.staticanalysis.RemoveUnusedLocalVariables
+  - org.openrewrite.staticanalysis.RemoveUnusedPrivateFields
+  - org.openrewrite.staticanalysis.RemoveUnusedPrivateMethods
+  - org.openrewrite.staticanalysis.RenameExceptionInEmptyCatch
+  - org.openrewrite.staticanalysis.RenameLocalVariablesToCamelCase
+  - org.openrewrite.staticanalysis.RenameMethodsNamedHashcodeEqualOrToString
+  - org.openrewrite.staticanalysis.RenamePrivateFieldsToCamelCase
+  - org.openrewrite.staticanalysis.ReplaceApacheCommonsLang3ValidateNotNullWithObjectsRequireNonNull
+  - org.openrewrite.staticanalysis.ReplaceDeprecatedRuntimeExecMethods
+  - org.openrewrite.staticanalysis.ReplaceDuplicateStringLiterals
+  - org.openrewrite.staticanalysis.ReplaceLambdaWithMethodReference
+  - org.openrewrite.staticanalysis.ReplaceOptionalIsPresentWithIfPresent
+  - org.openrewrite.staticanalysis.ReplaceRedundantFormatWithPrintf
+  - org.openrewrite.staticanalysis.ReplaceStackWithDeque
+  - org.openrewrite.staticanalysis.ReplaceStreamToListWithCollect
+  - org.openrewrite.staticanalysis.ReplaceStringBuilderWithString
+  - org.openrewrite.staticanalysis.ReplaceTextBlockWithString
+  - org.openrewrite.staticanalysis.ReplaceThreadRunWithThreadStart
+  - org.openrewrite.staticanalysis.ReplaceValidateNotNullHavingSingleArgWithObjectsRequireNonNull
+  - org.openrewrite.staticanalysis.ReplaceValidateNotNullHavingVarargsWithObjectsRequireNonNull
+  - org.openrewrite.staticanalysis.ReplaceWeekYearWithYear
+  - org.openrewrite.staticanalysis.SimplifyBooleanExpression
+  - org.openrewrite.staticanalysis.SimplifyBooleanReturn
+  - org.openrewrite.staticanalysis.SimplifyCompoundStatement
+  - org.openrewrite.staticanalysis.SimplifyConsecutiveAssignments
+  - org.openrewrite.staticanalysis.SimplifyConstantIfBranchExecution
+  - org.openrewrite.staticanalysis.SimplifyDurationCreationUnits
+  - org.openrewrite.staticanalysis.SortedSetStreamToLinkedHashSet
+  - org.openrewrite.staticanalysis.StaticMethodNotFinal
+  - org.openrewrite.staticanalysis.StringLiteralEquality
+  - org.openrewrite.staticanalysis.TernaryOperatorsShouldNotBeNested
+  - org.openrewrite.staticanalysis.TypecastParenPad
+# - org.openrewrite.staticanalysis.UnnecessaryCatch, bug
+  - org.openrewrite.staticanalysis.UnnecessaryCloseInTryWithResources
+  - org.openrewrite.staticanalysis.UnnecessaryExplicitTypeArguments
+  - org.openrewrite.staticanalysis.UnnecessaryParentheses
+  - org.openrewrite.staticanalysis.UnnecessaryPrimitiveAnnotations
+# - org.openrewrite.staticanalysis.UnnecessaryThrows, bug
+  - org.openrewrite.staticanalysis.UnwrapRepeatableAnnotations
+  - org.openrewrite.staticanalysis.UpperCaseLiteralSuffixes
+# - org.openrewrite.staticanalysis.UseAsBuilder, unwanted
+  - org.openrewrite.staticanalysis.UseCollectionInterfaces
+  - org.openrewrite.staticanalysis.UseDiamondOperator
+  - org.openrewrite.staticanalysis.UseForEachRemoveInsteadOfSetRemoveAll
+  - org.openrewrite.staticanalysis.UseJavaStyleArrayDeclarations
+  - org.openrewrite.staticanalysis.UseLambdaForFunctionalInterface
+  - org.openrewrite.staticanalysis.UseListSort
+  - org.openrewrite.staticanalysis.UseMapContainsKey
+  - org.openrewrite.staticanalysis.UseObjectNotifyAll
+  - org.openrewrite.staticanalysis.UseStandardCharset
+  - org.openrewrite.staticanalysis.UseStringReplace
+  - org.openrewrite.staticanalysis.UseSystemLineSeparator
+  - org.openrewrite.staticanalysis.WhileInsteadOfFor
+  - org.openrewrite.staticanalysis.WriteOctalValuesAsDecimal
+  - org.openrewrite.xml.RemoveTrailingWhitespace
+  - org.openrewrite.xml.security.AddOwaspDateBoundSuppressions
+  - org.openrewrite.xml.security.IsOwaspSuppressionsFile
+  - org.openrewrite.xml.security.RemoveOwaspSuppressions
+# - org.openrewrite.xml.security.UpdateOwaspSuppressionDate, unwanted


### PR DESCRIPTION
OpenRewrite is a mass refactoring engine to which I contribute since 2 years. This PR configures it and runs several refactorings. Every refactoring kind is in a separate commit for easier review. I intend to enable more of the recipes later and to submit more such changes until we reach a state where all enabled recipes can be run periodically and all changes can be submitted in one go.

@rnveach The main checkstyle project might profit from a similar configuration even more. Here in this project a lot of the recipes don't catch all occurrences, because the classes loaded by Tycho are not available to the type system inside OpenRewrite. In the main project everything is plain maven, therefore each recipe should apply everywhere. If you want me to configure something (like the "RemoveTestPrefix" recipe or similar) for a demo PR, then mention me, please.