### PR TITLE
group rewrite updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
         # we need to update the main Checkstyle dependency manually
       - dependency-name: org.junit.jupiter:*
         # the supported range of JUnit depends on the version of Tycho used during the build
+    groups:
+      rewrite:
+        patterns:
+          - "*rewrite*"
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#prioritizing-meaningful-updates

to avoid the many PRs as of this weekend. rewrite publishes every some days, so we would often get multiple PRs every weekend