### PR TITLE
explicitly add OSGi annotations to target platform

### DIFF
--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.target
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Eclipse Checkstyle" sequenceNumber="1735410879">
+<target name="Eclipse Checkstyle" sequenceNumber="1741029769">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.jdt.feature.group" version="3.18.1300.v20220831-1800"/>
       <unit id="org.eclipse.sdk.ide" version="4.25.0.I20220831-1800"/>
+      <unit id="org.osgi.service.component.annotations" version="1.5.0.202109301733"/>
       <unit id="org.eclipse.e4.tools.emf.ui" version="4.7.300.v20220420-0901"/>
       <unit id="org.eclipse.e4.tools.services" version="4.9.0.v20210427-1802"/>
       <unit id="org.eclipse.e4.ui.progress" version="0.3.500.v20220717-1456"/>

--- a/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
+++ b/net.sf.eclipsecs.target/net.sf.eclipsecs.target.tpd
@@ -9,6 +9,7 @@ environment JavaSE-17
 location "https://download.eclipse.org/releases/2022-09/202209141001/" {
 	org.eclipse.jdt.feature.group
 	org.eclipse.sdk.ide
+	org.osgi.service.component.annotations
 
 	// the following are not actually needed by eclipse-cs itself, but required to avoid
 	// unresolved dependencies of platform bundles contained in the above features


### PR DESCRIPTION
@Calixte This might eventually fix your broken import, but it's really just a wild guess. If this doesn't change anything for you, then go ahead with the additional package import.