### PR TITLE
Filter out provided dependencies when assembling p2 repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,6 +379,8 @@
                     <configuration>
                         <!-- make the update site self-contained by including all transitive dependencies -->
                         <includeAllDependencies>true</includeAllDependencies>
+                        <filterProvided>true</filterProvided>
+                        <addIUTargetRepositoryReferences>true</addIUTargetRepositoryReferences>
                     </configuration>
                 </plugin>
                 <!-- Disable default deployer. -->


### PR DESCRIPTION
This reduces the p2 repository down to 21MB, removing all the eclipse JARs, while retaining the Maven dependencies.

```
% ls -1 net.sf.eclipsecs-updatesite/target/repository/plugins
io.github.classgraph.classgraph_4.8.179.jar
net.sf.eclipsecs.branding_12.0.1.202511131557.jar
net.sf.eclipsecs.checkstyle_12.0.1.202511131557.jar
net.sf.eclipsecs.core_12.0.1.202511131557.jar
net.sf.eclipsecs.core.source_12.0.1.202511131557.jar
net.sf.eclipsecs.doc_12.0.1.202511131557.jar
net.sf.eclipsecs.ui_12.0.1.202511131557.jar
net.sf.eclipsecs.ui.source_12.0.1.202511131557.jar
org.apache.commons.lang3_3.17.0.jar
org.yaml.snakeyaml_2.3.0.jar
wrapped.org.dom4j.dom4j_2.1.4.jar
```