### PR TITLE
Issue #922: Improve refresh button positioning

### DIFF
--- a/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/preferences/CheckstylePreferencePageGeneralSettings.java
+++ b/net.sf.eclipsecs.ui/src/net/sf/eclipsecs/ui/preferences/CheckstylePreferencePageGeneralSettings.java
@@ -178,7 +178,7 @@ public final class CheckstylePreferencePageGeneralSettings extends Composite {
             CheckerFactory.cleanup();
             setRebuildAll.run();
         }));
-        GridDataFactory.swtDefaults().align(GridData.END, GridData.CENTER).grab(true, false)
+        GridDataFactory.swtDefaults().align(GridData.END, GridData.CENTER)
             .applyTo(mPurgeCacheButton);
 
         return mRebuildIfNeeded;


### PR DESCRIPTION
## Summary

- keep the Checkstyle configuration refresh button next to the rebuild preference
- prevent the button from consuming spare horizontal space and being pushed to the edge of the preferences page

## Root cause

The refresh button's grid data grabbed all excess horizontal space and aligned the button at the far end of that expanded cell. On laptop-sized displays, this could leave the button partially clipped and contribute to horizontal scrolling.

## User impact

The refresh action remains fully visible beside the rebuild dropdown at narrower resolutions, including the 1536 x 864 scenario reported in #922.

## Validation

- `git diff --check`
- attempted `./mvnw.cmd -pl net.sf.eclipsecs.ui -am verify`; dependency download completed, but Tycho stalled while resolving the Eclipse target platform in the sandbox

Fixes #922
