### PR TITLE
Issue #101: map LeftCurly LAMBDA to brace_position_for_lambda_body

### DIFF
--- a/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/LeftCurlyTransformer.java
+++ b/net.sf.eclipsecs.core/src/net/sf/eclipsecs/core/transformer/ctransformerclasses/LeftCurlyTransformer.java
@@ -35,7 +35,7 @@ public class LeftCurlyTransformer extends AbstractCTransformationClass {
     public FormatterConfiguration transformRule() {
         String tokens = getAttribute("tokens");
         if (tokens == null) {
-            tokens = "CLASS_DEF, CTOR_DEF, INTERFACE_DEF, METHOD_DEF, LITERAL_CATCH, LITERAL_DO, "
+            tokens = "CLASS_DEF, CTOR_DEF, INTERFACE_DEF, METHOD_DEF, LAMBDA, LITERAL_CATCH, LITERAL_DO, "
                 + "LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_SYNCHRONIZED, "
                 + "LITERAL_TRY, LITERAL_WHILE";
         }
@@ -61,6 +61,7 @@ public class LeftCurlyTransformer extends AbstractCTransformationClass {
                     "LITERAL_CATCH", "LITERAL_FINALLY", "LITERAL_TRY",
                     "LITERAL_SYNCHRONIZED" -> List.of("brace_position_for_block");
                 case "LITERAL_SWITCH" -> List.of("brace_position_for_switch");
+                case "LAMBDA" -> List.of("brace_position_for_lambda_body");
                 default -> Collections.emptyList();
             };
             settings.forEach(setting -> userFormatterSetting(setting, option));


### PR DESCRIPTION
LeftCurly ignored the LAMBDA token when converting a Checkstyle config to an Eclipse formatter profile, so lambda braces never got a brace_position setting.

I map LAMBDA to brace_position_for_lambda_body (and include it in the default token list, which Checkstyle already uses).

Fixes #101
